### PR TITLE
Fix #48, use proper CFE_SB_PipeID type

### DIFF
--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -8715,7 +8715,7 @@ void Test_CF_CFDP_DisableEngine_ClosesAllActiveFilesAndNoOpenPlaybackDirectories
     for (ci = 0; ci < CF_NUM_CHANNELS; ++ci)
     {
         dummy_channel[ci]       = CF_AppData.engine.channels + ci;
-        dummy_channel[ci]->pipe = Any_uint8();
+        dummy_channel[ci]->pipe = CFE_SB_PIPEID_C(CFE_ResourceId_FromInteger(1 + ci));
         for (qi = 0; qi < num_clist_node_ptrs; ++qi)
         {
             (CF_AppData.engine.channels + ci)->qs[qs_index[qi]] = malloc(sizeof(clist_node));
@@ -8805,7 +8805,7 @@ void Test_CF_CFDP_DisableEngine_ClosesAllActiveFilesAndAnyOpenPlaybackDirectorie
     for (ci = 0; ci < CF_NUM_CHANNELS; ++ci)
     {
         dummy_channel[ci]       = CF_AppData.engine.channels + ci;
-        dummy_channel[ci]->pipe = Any_uint8();
+        dummy_channel[ci]->pipe = CFE_SB_PIPEID_C(CFE_ResourceId_FromInteger(1 + ci));
         for (qi = 0; qi < num_clist_node_ptrs; ++qi)
         {
             (CF_AppData.engine.channels + ci)->qs[qs_index[qi]] = malloc(sizeof(clist_node));
@@ -8912,7 +8912,7 @@ void Test_CF_CFDP_DisableEngine_ClosesAllActiveFilesAndAllOpenPlaybackDirectorie
     for (ci = 0; ci < CF_NUM_CHANNELS; ++ci)
     {
         dummy_channel[ci]       = CF_AppData.engine.channels + ci;
-        dummy_channel[ci]->pipe = Any_uint8();
+        dummy_channel[ci]->pipe = CFE_SB_PIPEID_C(CFE_ResourceId_FromInteger(1 + ci));
         for (qi = 0; qi < num_clist_node_ptrs; ++qi)
         {
             (CF_AppData.engine.channels + ci)->qs[qs_index[qi]] = malloc(sizeof(clist_node));


### PR DESCRIPTION
Correct the pipe ID assignment in UT to use the resourceID type.

This also uses a fixed/consistent value here, rather than a random value.  There is no real need to use a random value.

Fixes #48 