### PR TITLE
Fix #51, do not assert when NDEBUG is set

### DIFF
--- a/fsw/src/cf_assert.h
+++ b/fsw/src/cf_assert.h
@@ -31,11 +31,23 @@
 
 extern void CF_HandleAssert(const char *file, int line);
 
+/*
+ * Note that in some cases, code in CF may compute or store a value for the
+ * sole purpose of checking it with a CF_Assert().  If CF_Assert is then entirely
+ * compiled out with NDEBUG, the compiler may see that as an unused value and
+ * trigger a warning.
+ *
+ * To avoid this, a no-op inline function is used, such that the value in the
+ * CF_Assert call is still evaluated, but the result is ignored.
+ */
+
 #ifdef NDEBUG
 /* this is release mode */
-#define CF_Assert(x)   \
-    if (unlikely((x))) \
-        CF_HandleAssert(__FILE__, __LINE__);
+static inline void CF_NoAssert(bool cond)
+{
+    /* no-op to avoid unused value warning */
+}
+#define CF_Assert(x) CF_NoAssert(x)
 #else /* NDEBUG */
 #include <assert.h>
 #define CF_Assert(x) assert(x)


### PR DESCRIPTION
This effectively ignores CF_Assert checks in the code when it is compiled with NDEBUG.  None of these checks should be needed after development.

In particular, this removes the use of the non-standard "unlikely" compiler extension that was used here.

Fixes #51