### PR TITLE
Fix #52, do not use system assert in tests

### DIFF
--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -115,8 +115,8 @@ file_directive_t Any_file_directive_t_Except(file_directive_t exception)
     {
         if (++num_tries > max_tries)
         {
-            UtPrintf("Unable to achieve different random value within %u tries.", max_tries);
-            assert(ERROR_RETRIEVING_ANY_VALUE);
+            UtAssert_Failed("Unable to achieve different random value within %u tries.", max_tries);
+            UtAssert_Abort(__func__);
         }
 
         rand_val = rand() % PDU_INVALID_MAX;

--- a/unit-test/utilities/cf_test_utils.c
+++ b/unit-test/utilities/cf_test_utils.c
@@ -410,7 +410,10 @@ uint32 Any_uint32_BetweenExcludeMax(uint32 min, uint32 max)
     uint32 difference = max - min;
 
     /* check that rand % 0 does not happen */
-    assert(difference != 0);
+    if (difference == 0)
+    {
+        UtAssert_Abort(__func__);
+    }
 
     return (uint32)((rand() % difference) + min);
 }
@@ -757,8 +760,7 @@ CFE_MSG_Size_t Any_CFE_MSG_Size_t_LessThan(size_t ceiling)
     switch (sizeof(CFE_MSG_Size_t))
     {
         case 8:
-            UtPrintf("Implementation of Any_uint64_LessThan pending");
-            assert(ERROR_RETRIEVING_ANY_VALUE); /* rand_val = (CFE_MSG_Size_t) Any_uint64_LessThan(ceiling); */
+            UtAssert_Abort("Implementation of Any_uint64_LessThan pending");
             break;
         case 4:
             rand_val = (CFE_MSG_Size_t)Any_uint32_LessThan(ceiling);
@@ -790,8 +792,8 @@ CFE_SB_MsgId_t Any_MsgId(void)
             return Any_uint16();
 
         default:
-            UtPrintf("Any_MsgId_ExceptThese unimplemented sizeof(CFE_SB_MsgId_t) = %lu", msg_id_size);
-            assert(ERROR_RETRIEVING_ANY_VALUE);
+            UtAssert_Failed("Any_MsgId_ExceptThese unimplemented sizeof(CFE_SB_MsgId_t) = %lu", msg_id_size);
+            UtAssert_Abort(__func__);
     }
 
     return (CFE_SB_MsgId_t)UT_UINT_16_DEFAULT; /* default for switch(msg_id_size) will always assert, this should not be
@@ -811,8 +813,8 @@ CFE_SB_MsgId_t Any_MsgId_ExceptThese(CFE_SB_MsgId_t exceptions[], uint8 num_exce
             return Any_uint16_ExceptThese((uint16 *)exceptions, num_exceptions);
 
         default:
-            UtPrintf("Any_MsgId_ExceptThese unimplemented sizeof(CFE_SB_MsgId_t) = %lu", msg_id_size);
-            assert(ERROR_RETRIEVING_ANY_VALUE);
+            UtAssert_Failed("Any_MsgId_ExceptThese unimplemented sizeof(CFE_SB_MsgId_t) = %lu", msg_id_size);
+            UtAssert_Abort(__func__);
     }
 
     return (CFE_SB_MsgId_t)UT_UINT_16_DEFAULT; /* default for switch(msg_id_size) will always assert, this should not be


### PR DESCRIPTION
Instead of using the system assert call, use UtAssert_Abort() to report critical conditions where continuation is not possible.

Note due to limitations of the UtAssert_Abort() function, this uses UtAssert_Failed() to report any runtime information, followed by
abort with a static/fixed message.

Fixes #52
