### PR TITLE
Fix #54, pass actual size of buffer

### DIFF
--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -1876,7 +1876,7 @@ void Test_CF_strnlen_When_end_IsNot_NULL_ReturnLengthOfGiven_s(void)
 {
     /* Arrange */
     const char arg_s[7]        = "NO NULL";
-    size_t     arg_maxlen      = 8; /* 256 is arbitrary and used for small size */
+    size_t     arg_maxlen      = 7; /* 256 is arbitrary and used for small size */
     size_t     expected_length = 7;
     size_t     local_result;
 


### PR DESCRIPTION
The test must not pass a buffer size larger than the actual buffer, or else it will read beyond the end.

Fixes #54