### PR TITLE
Fix #88, consistent application target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,30 @@
-cmake_minimum_required(VERSION 2.6.4)
-project(CFS_CF_APP C)
+project(CFS_CF C)
 
 include_directories(fsw/src)
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 include_directories(${CFS_IO_LIB_MISSION_DIR}/fsw/public_inc)
 
-aux_source_directory(fsw/src APP_SRC_FILES)
+set(APP_SRC_FILES
+  fsw/src/cf_app.c
+  fsw/src/cf_assert.c
+  fsw/src/cf_cfdp.c
+  fsw/src/cf_cfdp_helpers.c
+  fsw/src/cf_cfdp_r.c
+  fsw/src/cf_cfdp_s.c
+  fsw/src/cf_chunk.c
+  fsw/src/cf_clist.c
+  fsw/src/cf_cmd.c
+  fsw/src/cf_crc.c
+  fsw/src/cf_timer.c
+  fsw/src/cf_utils.c
+)
 
 # Create the app module
-add_cfe_app(cf_app ${APP_SRC_FILES})
+add_cfe_app(cf ${APP_SRC_FILES})
 
-if (COMMAND add_cfe_tables)
-    aux_source_directory(fsw/tables APP_TBL_FILES)
-    add_cfe_tables(cf_app ${APP_TBL_FILES})
-endif(COMMAND add_cfe_tables)
+# configuration table
+add_cfe_tables(cf fsw/tables/cf_def_config.c)
 
 add_definitions("-D_DEFAULT_SOURCE")
 

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -9,20 +9,20 @@
 #
 # By convention this cmake file as written requires:
 #
-# 1. For each source file in an app there must be a 
-#    corresponding <src_filename>_test.c file in the 
-#    ${PROJECT_SOURCE_DIR}/unit-test directory 
+# 1. For each source file in an app there must be a
+#    corresponding <src_filename>_test.c file in the
+#    ${PROJECT_SOURCE_DIR}/unit-test directory
 #    (the same directory that this cmake file should exist in)
 #
 # 2. For each source file in an app there must be a
-#    corresponding <src_filename>_stub.c file in the 
-#    ${PROJECT_SOURCE_DIR}/unit-test/stubs directory 
+#    corresponding <src_filename>_stub.c file in the
+#    ${PROJECT_SOURCE_DIR}/unit-test/stubs directory
 #
 # Optionally you may have:
 #
-# 1. ${PROJECT_SOURCE_DIR}/unit-test/utilities directory that 
+# 1. ${PROJECT_SOURCE_DIR}/unit-test/utilities directory that
 #    contains any test specific utility files
-# 
+#
 # 2. ${PROJECT_SOURCE_DIR}/unit-test/inc directory that
 #    contains any test specific header files
 #
@@ -57,33 +57,33 @@ endforeach()
 # add both utility and stubs to the coverage stubs
 # TODO: currently adding both is considered a work-around
 # utilities should be added separately when a method for it is devised
-add_cfe_coverage_stubs("cf_app" ${app_stub_and_utility_filenames})
+add_cfe_coverage_stubs(cf ${app_stub_and_utility_filenames})
 
-# Generate a dedicated "testrunner" executable for each test file 
-# Accomplish this by cycling through all the app's source files, 
+# Generate a dedicated "testrunner" executable for each test file
+# Accomplish this by cycling through all the app's source files,
 # there must be a *_tests file for each
 set(source_files_under_test)
 aux_source_directory("${PROJECT_SOURCE_DIR}/fsw/src" source_files_under_test)
 foreach(SRCFILE ${source_files_under_test})
-   
-    # Get the base sourcefile name as a module name without path or the  
+
+    # Get the base sourcefile name as a module name without path or the
     # extension, this will be used as the base name of the unit test file.
     get_filename_component(MODULE_NAME "${SRCFILE}" NAME_WE)
-    
+
     # Use the module name to make the tests' name by adding _tests to the end
     set(TESTS_NAME "${MODULE_NAME}_tests")
-    
+
     # Get the tests' sourcefile name with unit test path and extension
     set(TESTS_SOURCE_FILE "${PROJECT_SOURCE_DIR}/unit-test/${TESTS_NAME}.c")
-    
+
     # build test, but CF includes the .c in the test's source therefore
     # the TESTCASE_SRC is left empty, while the UT_SRC is passed in as the
     # combined test and source (currently done to access 'static' functions)
     # without doing it like this the coverage reports will not be created
-    add_cfe_coverage_test("cf_app" "${TESTS_NAME}" "/" "${TESTS_SOURCE_FILE}")
+    add_cfe_coverage_test(cf "${TESTS_NAME}" "/" "${TESTS_SOURCE_FILE}")
 
-    # give the dependencies of cf_app to the test, this ensures 
+    # give the dependencies of cf_app to the test, this ensures
     # app_stub_and_utility_filenames are used when building (TODO: ? is this comment correct?)
-    add_cfe_coverage_dependency("cf_app" "${TESTS_NAME}" "cf_app")
-    
+    add_cfe_coverage_dependency(cf "${TESTS_NAME}" cf)
+
 endforeach()


### PR DESCRIPTION
The application target should not have an "app" suffix.  Note that none of the other CFS apps have a suffix either, so this
makes CF consistent with that.

Also - this removes use of "aux_source_directory" - preference is to list the source files.

Fixes #88 