### PR TITLE
Fix #96, remove unused CF_EndOfHeaderPtr function

### DIFF
--- a/fsw/src/cf_cfdp_helpers.c
+++ b/fsw/src/cf_cfdp_helpers.c
@@ -187,8 +187,3 @@ int CF_HeaderSize(const pdu_header_t *ph)
     CF_Assert((eid_l > 0) && (tsn_l > 0));
     return sizeof(pdu_header_t) + (2 * eid_l) + tsn_l;
 }
-
-void *CF_EndOfHeaderPtr(const pdu_header_t *ph)
-{
-    return (void *)(((uint8 *)ph) + CF_HeaderSize(ph));
-}

--- a/fsw/src/cf_cfdp_pdu.h
+++ b/fsw/src/cf_cfdp_pdu.h
@@ -54,12 +54,11 @@ typedef struct
 #endif
 } CF_PACK pdu_header_t;
 
-extern int   CF_GetMemcpySize(const uint8 *num, int size);
-extern void  CF_MemcpyToBE(uint8 *dst, const uint8 *src, int src_size, int dst_size);
-extern int   CF_GetVariableHeader(void);
-extern void  CF_SetVariableHeader(cf_entity_id_t src_eid, cf_entity_id_t dst_eid, cf_transaction_seq_t tsn);
-extern void *CF_EndOfHeaderPtr(const pdu_header_t *ph);
-extern int   CF_HeaderSize(const pdu_header_t *ph);
+extern int  CF_GetMemcpySize(const uint8 *num, int size);
+extern void CF_MemcpyToBE(uint8 *dst, const uint8 *src, int src_size, int dst_size);
+extern int  CF_GetVariableHeader(void);
+extern void CF_SetVariableHeader(cf_entity_id_t src_eid, cf_entity_id_t dst_eid, cf_transaction_seq_t tsn);
+extern int  CF_HeaderSize(const pdu_header_t *ph);
 
 #define CF_MAX_HEADER_SIZE (sizeof(pdu_header_t) + (2 * sizeof(cf_entity_id_t)) + sizeof(cf_transaction_seq_t))
 #define STATIC_CAST(ph, t) ((t *)(((uint8 *)ph) + CF_HeaderSize(ph)))

--- a/unit-test/cf_cfdp_helpers_tests.c
+++ b/unit-test/cf_cfdp_helpers_tests.c
@@ -992,40 +992,6 @@ void Test_CF_HeaderSize_Return_sizeof_pdu_header_t_Plus_2_Times_eid_l_Plus_tsn_l
 
 /*******************************************************************************
 **
-**  CF_EndOfHeaderPtr tests (simple) - full coverage - [unstubbables: CF_HeaderSize]
-**
-*******************************************************************************/
-
-void Test_CF_EndOfHeaderPtr_Return_ph_PointerPlus_CF_HeaderSize_ph(void)
-{
-    /* Arrange */
-    pdu_header_t  dummy_ph;
-    pdu_header_t *arg_ph                      = &dummy_ph;
-    int32         forced_return_FGV_for_eid_l = Any_uint8_LessThan(
-                sizeof(cf_entity_id_t)); /*  Any_uint8_LessThan(sizeof(cf_entity_id_t)) used for reasonable size */
-    int32 forced_return_FGV_for_tsn_l = Any_uint8_LessThan(
-        sizeof(cf_transaction_seq_t)); /*  Any_uint8_LessThan(sizeof(cf_transaction_seq_t)) used for reasonable size */
-    void *expected_result = (uint8 *)arg_ph + sizeof(pdu_header_t) + (2 * (forced_return_FGV_for_eid_l + 1)) +
-                            (forced_return_FGV_for_tsn_l + 1); /* each +1 added by CUT */
-    void *local_result;
-
-    /* Arrange for CF_HeaderSize */
-    UT_SetDeferredRetcode(UT_KEY(FGV), 1, forced_return_FGV_for_eid_l);
-    UT_SetDeferredRetcode(UT_KEY(FGV), 1, forced_return_FGV_for_tsn_l);
-
-    /* Act */
-    local_result = CF_EndOfHeaderPtr(arg_ph);
-
-    /* Assert */
-    UtAssert_ADDRESS_EQ(local_result, expected_result);
-    /* Assert for CF_HeaderSize */
-    UtAssert_STUB_COUNT(FGV, 2);
-} /* end Test_CF_EndOfHeaderPtr_Return_ph_PointerPlus_CF_HeaderSize_ph */
-
-/* end CF_EndOfHeaderPtr tests */
-
-/*******************************************************************************
-**
 **  cf_cfdp_helpers_tests UtTest_Add groups
 **
 *******************************************************************************/
@@ -1172,12 +1138,6 @@ void add_CF_HeaderSize_tests(void)
                "Test_CF_HeaderSize_Return_sizeof_pdu_header_t_Plus_2_Times_eid_l_Plus_tsn_l");
 } /* end add_CF_HeaderSize_tests */
 
-void add_CF_EndOfHeaderPtr_tests(void)
-{
-    UtTest_Add(Test_CF_EndOfHeaderPtr_Return_ph_PointerPlus_CF_HeaderSize_ph, cf_cfdp_helpers_tests_Setup,
-               cf_cfdp_helpers_tests_Teardown, "Test_CF_EndOfHeaderPtr_Return_ph_PointerPlus_CF_HeaderSize_ph");
-} /* end add_CF_EndOfHeaderPtr_tests */
-
 /* end cf_cfdp_helpers_tests UtTest_Add groups */
 
 /*******************************************************************************
@@ -1205,8 +1165,6 @@ void UtTest_Setup(void)
     add_CF_SetVariableHeader_tests();
 
     add_CF_HeaderSize_tests();
-
-    add_CF_EndOfHeaderPtr_tests();
 
 } /* end UtTest_Setup for cf_cfdp_helpers_tests.c */
 

--- a/unit-test/stubs/cf_cfdp_helpers_stubs.c
+++ b/unit-test/stubs/cf_cfdp_helpers_stubs.c
@@ -31,22 +31,6 @@
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_EndOfHeaderPtr()
- * ----------------------------------------------------
- */
-void *CF_EndOfHeaderPtr(const pdu_header_t *ph)
-{
-    UT_GenStub_SetupReturnBuffer(CF_EndOfHeaderPtr, void *);
-
-    UT_GenStub_AddParam(CF_EndOfHeaderPtr, const pdu_header_t *, ph);
-
-    UT_GenStub_Execute(CF_EndOfHeaderPtr, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_EndOfHeaderPtr, void *);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_GetMemcpySize()
  * ----------------------------------------------------
  */


### PR DESCRIPTION
Unused functions/dead code should not be included in FSW

Fixes #96