### PR TITLE
Fix #67, remove use of bitfields in CF

### DIFF
--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -122,17 +122,18 @@ typedef struct
     uint16               num_ts; /* number of transactions -- 16 bit should be enough */
     uint8                priority;
     cf_entity_id_t       dest_id;
-    unsigned             busy : 1;
-    unsigned             diropen : 1;
-    unsigned             keep : 1;
-    unsigned             counted : 1;
+
+    bool busy;
+    bool diropen;
+    bool keep;
+    bool counted;
 } playback_t;
 
 typedef struct
 {
     playback_t pb;
     cf_timer_t interval_timer;
-    unsigned   timer_set : 1;
+    bool       timer_set;
 } poll_t;
 
 typedef union
@@ -176,47 +177,38 @@ typedef struct
 
 typedef struct
 {
-    unsigned q_index : 3; /* which Q is this in? */
-    unsigned ack_timer_armed : 1;
-    unsigned suspended : 1;
-    unsigned canceled : 1;
-    unsigned crc_calc : 1;
+    uint8 q_index; /* which Q is this in? */
+    bool  ack_timer_armed;
+    bool  suspended;
+    bool  canceled;
+    bool  crc_calc;
 } flags_all_t;
 
 typedef struct
 {
-    unsigned q_index : 3; /* which Q is this in? */
-    unsigned ack_timer_armed : 1;
-    unsigned suspended : 1;
-    unsigned canceled : 1;
-    unsigned crc_calc : 1;
+    flags_all_t com;
 
-    unsigned md_recv : 1; /* md received for r state */
-    unsigned eof_recv : 1;
-    unsigned send_nak : 1;
-    unsigned send_fin : 1;
-    unsigned send_ack : 1;
-    unsigned inactivity_fired : 1; /* used for r2 */
-    unsigned complete : 1;         /* r2 */
-    unsigned fd_nak_sent : 1;      /* latches that at least one nak has been sent for file data */
+    bool md_recv; /* md received for r state */
+    bool eof_recv;
+    bool send_nak;
+    bool send_fin;
+    bool send_ack;
+    bool inactivity_fired; /* used for r2 */
+    bool complete;         /* r2 */
+    bool fd_nak_sent;      /* latches that at least one nak has been sent for file data */
 } flags_rx_t;
 
 typedef struct
 {
-    unsigned q_index : 3; /* which Q is this in? */
-    unsigned ack_timer_armed : 1;
-    unsigned suspended : 1;
-    unsigned canceled : 1;
-    unsigned crc_calc : 1;
+    flags_all_t com;
 
-    unsigned md_need_send : 1;
-    unsigned cmd_tx : 1; /* indicates transaction is commanded (ground) tx */
+    bool md_need_send;
+    bool cmd_tx; /* indicates transaction is commanded (ground) tx */
 } flags_tx_t;
 
 typedef union
 {
-    uint16      flags;
-    flags_all_t all;
+    flags_all_t com;
     flags_rx_t  rx;
     flags_tx_t  tx;
 } state_flags_t;

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -89,7 +89,7 @@ static inline void CF_CFDP_R1_Reset(transaction_t *t)
 static void CF_CFDP_R2_Reset(transaction_t *t)
 {
     if ((t->state_data.r.sub_state == RECV_WAIT_FOR_FIN_ACK) || (t->state_data.r.r2.eof_cc != CC_NO_ERROR) ||
-        (t->history->cc != CC_NO_ERROR) || t->flags.rx.canceled)
+        (t->history->cc != CC_NO_ERROR) || t->flags.com.canceled)
     {
         CF_CFDP_R1_Reset(t); /* it's done */
     }
@@ -758,7 +758,7 @@ static int CF_CFDP_R2_CalcCrcChunk(transaction_t *t)
             CF_CFDP_R2_SetCc(t, CC_FILE_CHECKSUM_FAILURE);
         }
 
-        t->flags.rx.crc_calc = 1;
+        t->flags.com.crc_calc = 1;
 
         ret = 0;
     }
@@ -783,7 +783,7 @@ static int CF_CFDP_R2_SubstateSendFin(transaction_t *t)
     cfdp_send_ret_t sret;
     int             ret = -1;
 
-    if (t->history->cc == CC_NO_ERROR && !t->flags.rx.crc_calc)
+    if (t->history->cc == CC_NO_ERROR && !t->flags.com.crc_calc)
     {
         /* no error, and haven't checked crc -- so start checking it */
         if (CF_CFDP_R2_CalcCrcChunk(t))
@@ -1126,7 +1126,7 @@ void CF_CFDP_R_Tick(transaction_t *t, int *cont /* unused */)
             /* don't care about any other cases */
         }
 
-        if (t->flags.rx.ack_timer_armed)
+        if (t->flags.com.ack_timer_armed)
         {
             if (CF_Timer_Expired(&t->ack_timer))
             {

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -71,10 +71,10 @@ static inline void CF_CFDP_S_Reset(transaction_t *t)
 *************************************************************************/
 static cfdp_send_ret_t CF_CFDP_S_SendEof(transaction_t *t)
 {
-    if (!t->flags.tx.crc_calc)
+    if (!t->flags.com.crc_calc)
     {
         CF_CRC_Finalize(&t->crc);
-        t->flags.tx.crc_calc = 1;
+        t->flags.com.crc_calc = 1;
     }
     return CF_CFDP_SendEof(t);
 }
@@ -106,8 +106,8 @@ static void CF_CFDP_S1_SubstateSendEof(transaction_t *t)
 *************************************************************************/
 static void CF_CFDP_S2_SubstateSendEof(transaction_t *t)
 {
-    t->state_data.s.sub_state   = SEND_WAIT_FOR_EOF_ACK;
-    t->flags.tx.ack_timer_armed = 1; /* will cause tick to see ack_timer as expired, and act */
+    t->state_data.s.sub_state    = SEND_WAIT_FOR_EOF_ACK;
+    t->flags.com.ack_timer_armed = 1; /* will cause tick to see ack_timer as expired, and act */
 
     /* no longer need to send file data PDU except in the case of NAK response */
 
@@ -596,8 +596,8 @@ static void CF_CFDP_S2_WaitForEofAck(transaction_t *t, const pdu_header_t *ph)
         }
         else
         {
-            t->state_data.s.sub_state   = SEND_WAIT_FOR_FIN;
-            t->flags.tx.ack_timer_armed = 0; /* just wait for fin now, nothing to re-send */
+            t->state_data.s.sub_state    = SEND_WAIT_FOR_FIN;
+            t->flags.com.ack_timer_armed = 0; /* just wait for fin now, nothing to re-send */
         }
     }
     else
@@ -781,7 +781,7 @@ void CF_CFDP_S_Tick(transaction_t *t, int *cont /* unused */)
         {
             CF_Timer_Tick(&t->inactivity_timer);
 
-            if (t->flags.tx.ack_timer_armed)
+            if (t->flags.com.ack_timer_armed)
             {
                 if (CF_Timer_Expired(&t->ack_timer))
                 {

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -434,13 +434,13 @@ static int CF_TsnChanAction(cf_cmd_transaction_t *cmd, const char *cmdstr, CF_Ts
 static void CF_DoSuspRes_(transaction_t *t, susp_res_arg_t *context)
 {
     CF_Assert(t);
-    if (t->flags.all.suspended == context->action)
+    if (t->flags.com.suspended == context->action)
     {
         context->same = 1;
     }
     else
     {
-        t->flags.all.suspended = context->action;
+        t->flags.com.suspended = context->action;
     }
 }
 

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -248,7 +248,7 @@ void CF_InsertSortPrio(transaction_t *t, cf_queue_index_t q)
     {
         CF_CList_InsertBack_Ex(c, q, &t->cl_node);
     }
-    t->flags.all.q_index = q;
+    t->flags.com.q_index = q;
 }
 
 /************************************************************************/

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -42,20 +42,20 @@
 static inline void cf_dequeue_transaction(transaction_t *t)
 {
     CF_Assert(t && (t->chan_num < CF_NUM_CHANNELS));
-    CF_CList_Remove(&CF_AppData.engine.channels[t->chan_num].qs[t->flags.all.q_index], &t->cl_node);
-    CF_Assert(CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.all.q_index]); /* sanity check */
-    --CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.all.q_index];
+    CF_CList_Remove(&CF_AppData.engine.channels[t->chan_num].qs[t->flags.com.q_index], &t->cl_node);
+    CF_Assert(CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index]); /* sanity check */
+    --CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
 }
 
 static inline void cf_move_transaction(transaction_t *t, cf_queue_index_t q)
 {
     CF_Assert(t && (t->chan_num < CF_NUM_CHANNELS));
-    CF_CList_Remove(&CF_AppData.engine.channels[t->chan_num].qs[t->flags.all.q_index], &t->cl_node);
-    CF_Assert(CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.all.q_index]); /* sanity check */
-    --CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.all.q_index];
+    CF_CList_Remove(&CF_AppData.engine.channels[t->chan_num].qs[t->flags.com.q_index], &t->cl_node);
+    CF_Assert(CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index]); /* sanity check */
+    --CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
     CF_CList_InsertBack(&CF_AppData.engine.channels[t->chan_num].qs[q], &t->cl_node);
-    t->flags.all.q_index = q;
-    ++CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.all.q_index];
+    t->flags.com.q_index = q;
+    ++CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
 }
 
 static inline void CF_CList_Remove_Ex(channel_t *c, cf_queue_index_t index, clist_node node)

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -152,7 +152,7 @@ void Test_CFDP_R2_Reset_WhenTransactionSubStateIs_RECV_WAIT_FOR_FIN_ACK_Call_CF_
     arg_t.state_data.r.sub_state = RECV_WAIT_FOR_FIN_ACK;
     arg_t.state_data.r.r2.eof_cc = CC_NO_ERROR;
     arg_t.history->cc            = CC_NO_ERROR;
-    arg_t.flags.rx.canceled      = 0;
+    arg_t.flags.com.canceled     = 0;
     arg_t.flags.rx.send_fin      = 0;
 
     /* Act */
@@ -175,7 +175,7 @@ void Test_CFDP_R2_Reset_When_r_r2_eof_cc_IsErrorConditionCall_CF_CFDP_R1_Reset(v
     arg_t.state_data.r.sub_state = RECV_FILEDATA;            // TODO: Any_rx_sub_state_Except(RECV_WAIT_FOR_FIN_ACK);
     arg_t.state_data.r.r2.eof_cc = CC_POS_ACK_LIMIT_REACHED; // TODO: Any_condition_code_t_Except(CC_NO_ERROR);
     arg_t.history->cc            = CC_NO_ERROR;
-    arg_t.flags.rx.canceled      = 0;
+    arg_t.flags.com.canceled     = 0;
     arg_t.flags.rx.send_fin      = 0;
 
     /* Act */
@@ -198,7 +198,7 @@ void Test_CFDP_R2_Reset_When_t_history_cc_IsErrorConditionCall_CF_CFDP_R1_Reset(
     arg_t.state_data.r.sub_state = RECV_FILEDATA; // TODO: Any_rx_sub_state_Except(RECV_WAIT_FOR_FIN_ACK);
     arg_t.state_data.r.r2.eof_cc = CC_NO_ERROR;
     arg_t.history->cc            = CC_POS_ACK_LIMIT_REACHED; // TODO: Any_condition_code_t_Except(CC_NO_ERROR);;
-    arg_t.flags.rx.canceled      = 0;
+    arg_t.flags.com.canceled     = 0;
     arg_t.flags.rx.send_fin      = 0;
 
     /* Act */
@@ -221,7 +221,7 @@ void Test_CFDP_R2_Reset_When_t_flags_rx_cancelled_Is_1_Call_CF_CFDP_R1_Reset(voi
     arg_t.state_data.r.sub_state = RECV_FILEDATA; // TODO: Any_rx_sub_state_Except(RECV_WAIT_FOR_FIN_ACK);
     arg_t.state_data.r.r2.eof_cc = CC_NO_ERROR;
     arg_t.history->cc            = CC_NO_ERROR;
-    arg_t.flags.rx.canceled      = 1; // TODO Any but 0?
+    arg_t.flags.com.canceled     = 1; // TODO Any but 0?
     arg_t.flags.rx.send_fin      = 0;
 
     /* Act */
@@ -244,7 +244,7 @@ void Test_CFDP_R2_Reset_Set_flags_rx_send_fin_To_1(void)
     arg_t.state_data.r.sub_state = RECV_FILEDATA; // TODO: Any_rx_sub_state_Except(RECV_WAIT_FOR_FIN_ACK);
     arg_t.state_data.r.r2.eof_cc = CC_NO_ERROR;
     arg_t.history->cc            = CC_NO_ERROR;
-    arg_t.flags.rx.canceled      = 0;
+    arg_t.flags.com.canceled     = 0;
     arg_t.flags.rx.send_fin      = 0;
 
     /* Act */
@@ -2431,7 +2431,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk_Given_t_state_data_r_r2_rx_crc_calc_bytes_Is_N
 
     arg_t->fsize = arg_t->state_data.r.r2.rx_crc_calc_bytes;
 
-    arg_t->flags.rx.crc_calc = 0;
+    arg_t->flags.com.crc_calc = 0;
 
     /* Arrange for CF_CFDP_R_CheckCrc */
     history_t dummy_history;
@@ -2451,8 +2451,8 @@ void Test_CF_CFDP_R2_CalcCrcChunk_Given_t_state_data_r_r2_rx_crc_calc_bytes_Is_N
     /* Assert */
     UtAssert_True(local_result == 0, "CF_CFDP_R2_SubstateSendFin returned %d and should be 0", local_result);
     UtAssert_STUB_COUNT(CF_CRC_Start, 0);
-    UtAssert_True(arg_t->flags.rx.crc_calc == 1, "t->flags.rx.crc_calc is %u and should be 1",
-                  arg_t->flags.rx.crc_calc);
+    UtAssert_True(arg_t->flags.com.crc_calc == 1, "t->flags.com.crc_calc is %u and should be 1",
+                  arg_t->flags.com.crc_calc);
     /* Assert for CF_CFDP_R2_SetCc */
     UtAssert_True(arg_t->flags.rx.send_fin == 1, "t->flags.rx.send_fin is %u and should be 1",
                   arg_t->flags.rx.send_fin);
@@ -2481,7 +2481,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk_Given_t_state_data_r_r2_rx_crc_calc_bytes_Is_N
 
     arg_t->state_data.r.r2.dc = Any_uint8_Except(FIN_COMPLETE);
     arg_t->state_data.r.r2.fs = Any_uint8_Except(FIN_RETAINED);
-    arg_t->flags.rx.crc_calc  = 0;
+    arg_t->flags.com.crc_calc = 0;
 
     /* Arrange for CF_CFDP_R_CheckCrc */
     history_t dummy_history;
@@ -2505,8 +2505,8 @@ void Test_CF_CFDP_R2_CalcCrcChunk_Given_t_state_data_r_r2_rx_crc_calc_bytes_Is_N
     UtAssert_True(arg_t->state_data.r.r2.fs == FIN_RETAINED,
                   "t->state_data.r.r2.fs is %u and should be %u (FIN_RETAINED)", arg_t->state_data.r.r2.fs,
                   FIN_RETAINED);
-    UtAssert_True(arg_t->flags.rx.crc_calc == 1, "t->flags.rx.crc_calc is %u and should be 1",
-                  arg_t->flags.rx.crc_calc);
+    UtAssert_True(arg_t->flags.com.crc_calc == 1, "t->flags.com.crc_calc is %u and should be 1",
+                  arg_t->flags.com.crc_calc);
 } /* end
      Test_CF_CFDP_R2_CalcCrcChunk_Given_t_state_data_r_r2_rx_crc_calc_bytes_Is_Non0_And_IsEqTo_t_fsize_CallTo_CF_CFDP_R_CheckCrc_Return_0_Set_t_keep_To_1_And_t_state_data_r_r2_cc_To_FIN_COMPLETE_And_t_state_data_r_r2_fs_To_FIN_RETAINED_t_flags_rx_crc_calc_To_1_Return_0
    */
@@ -2552,7 +2552,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk_CAllTo_CF_WrappedLseek_ReturnsValueNotEqTo_RXC
                   "CFE_EVS_SendEvent receive event id %u and should receive %u (CF_EID_ERR_CFDP_R_SEEK_CRC)", EventID,
                   CF_EID_ERR_CFDP_R_SEEK_CRC);
     UtAssert_True(arg_t->history->cc == CC_FILE_SIZE_ERROR,
-                  "t->flags.rx.crc_calc is %u and should be %u (CC_FILE_SIZE_ERROR)", arg_t->history->cc,
+                  "t->flags.com.crc_calc is %u and should be %u (CC_FILE_SIZE_ERROR)", arg_t->history->cc,
                   CC_FILE_SIZE_ERROR);
     UtAssert_True(CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.file_seek == (uint16)(initial_file_seek + 1),
                   "fault.file_seek is %u and should be 1 more than %u (value before call)",
@@ -2604,7 +2604,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk_CAllTo_CF_WrappedLseek_ReturnsValueEqTo_RXC_cr
                   "CFE_EVS_SendEvent receive event id %u and should receive %u (CF_EID_ERR_CFDP_R_READ)", EventID,
                   CF_EID_ERR_CFDP_R_READ);
     UtAssert_True(arg_t->history->cc == CC_FILE_SIZE_ERROR,
-                  "t->flags.rx.crc_calc is %u and should be %u (CC_FILE_SIZE_ERROR)", arg_t->history->cc,
+                  "t->flags.com.crc_calc is %u and should be %u (CC_FILE_SIZE_ERROR)", arg_t->history->cc,
                   CC_FILE_SIZE_ERROR);
     UtAssert_True(CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.file_read == (uint16)(initial_file_read + 1),
                   "fault.file_seek is %u and should be 1 more than %u (value before call)",
@@ -2687,9 +2687,9 @@ void Test_CF_CFDP_R2_SubstateSendFin_Given_t_history_cc_IsEqTo_CC_NO_ERROR_And_t
     transaction_t *arg_t = &dummy_t;
     int            local_result;
 
-    arg_t->history           = &dummy_history;
-    arg_t->history->cc       = CC_NO_ERROR;
-    arg_t->flags.rx.crc_calc = 0;
+    arg_t->history            = &dummy_history;
+    arg_t->history->cc        = CC_NO_ERROR;
+    arg_t->flags.com.crc_calc = 0;
 
     /* Arrange for CF_CFDP_R2_CalcCrcChunk */
     cf_config_table_t dummy_config_table;
@@ -2723,7 +2723,7 @@ void Test_CF_CFDP_R2_SubstateSendFin_AssertsBecauseCallTo_CF_CFDP_SendFin_Return
 
     // arg_t->history = &dummy_history;
     // arg_t->history->cc = Any_uint8_Except(CC_NO_ERROR);
-    // arg_t->flags.rx.crc_calc = 0;
+    // arg_t->flags.com.crc_calc = 0;
 
     // UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_SendFin), CF_SEND_ERROR);
 
@@ -2744,9 +2744,9 @@ void Test_CF_CFDP_R2_SubstateSendFin_Given_t_history_cc_IsEqTo_CC_NO_ERROR_CallT
     uint8          exceptions[2] = {CF_SEND_ERROR, CF_SEND_SUCCESS};
     int            local_result;
 
-    arg_t->history           = &dummy_history;
-    arg_t->history->cc       = Any_uint8_Except(CC_NO_ERROR);
-    arg_t->flags.rx.crc_calc = 0;
+    arg_t->history            = &dummy_history;
+    arg_t->history->cc        = Any_uint8_Except(CC_NO_ERROR);
+    arg_t->flags.com.crc_calc = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_SendFin), Any_uint8_ExceptThese(exceptions, 2));
 
@@ -2774,9 +2774,9 @@ void Test_CF_CFDP_R2_SubstateSendFin_Given_t_flags_rx_crc_calc_Is_1_CallTo_CF_CF
     transaction_t *arg_t = &dummy_t;
     int            local_result;
 
-    arg_t->history           = &dummy_history;
-    arg_t->history->cc       = CC_NO_ERROR;
-    arg_t->flags.rx.crc_calc = 1;
+    arg_t->history            = &dummy_history;
+    arg_t->history->cc        = CC_NO_ERROR;
+    arg_t->flags.com.crc_calc = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_SendFin), CF_SEND_SUCCESS);
 
@@ -2804,9 +2804,9 @@ void Test_CF_CFDP_R2_SubstateSendFin_CallTo_CF_CFDP_R2_CalcCrcChunk_Returns_0_Gi
     transaction_t *arg_t = &dummy_t;
     int            local_result;
 
-    arg_t->history           = &dummy_history;
-    arg_t->history->cc       = CC_NO_ERROR;
-    arg_t->flags.rx.crc_calc = 0;
+    arg_t->history            = &dummy_history;
+    arg_t->history->cc        = CC_NO_ERROR;
+    arg_t->flags.com.crc_calc = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_SendFin), CF_SEND_SUCCESS);
 
@@ -2823,7 +2823,7 @@ void Test_CF_CFDP_R2_SubstateSendFin_CallTo_CF_CFDP_R2_CalcCrcChunk_Returns_0_Gi
 
     arg_t->fsize = arg_t->state_data.r.r2.rx_crc_calc_bytes;
 
-    arg_t->flags.rx.crc_calc = 0;
+    arg_t->flags.com.crc_calc = 0;
 
     /* Arrange for CF_CFDP_R_CheckCrc */
     arg_t->state_data.r.r2.eof_crc = Any_uint32();
@@ -2908,7 +2908,7 @@ void Test_CF_CFDP_R2_Recv_fin_ack_GetsValidFinAckFrom_CF_CFDP_RecvAck_Calls_CFDP
     arg_t->state_data.r.sub_state = Any_uint8_Except(RECV_WAIT_FOR_FIN_ACK);
     arg_t->state_data.r.r2.eof_cc = CC_NO_ERROR;
     arg_t->history->cc            = CC_NO_ERROR;
-    arg_t->flags.rx.canceled      = 0;
+    arg_t->flags.com.canceled     = 0;
 
     arg_t->flags.rx.send_fin = 0; /* set to see it turn to 1 in CF_CFDP_R2_Reset */
 
@@ -3871,7 +3871,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_But_inactivity_fired_Is_1_
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Act */
     CF_CFDP_R_Tick(arg_t, arg_cont);
@@ -3906,7 +3906,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_0_
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Act */
     CF_CFDP_R_Tick(arg_t, arg_cont);
@@ -3940,7 +3940,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_0_
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Arrange for CF_CFDP_R_SendInactivityEvent */
     UT_SetDataBuffer(UT_KEY(CFE_EVS_SendEvent), &EventID, sizeof(EventID), false);
@@ -3990,7 +3990,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_1_
 
     // arg_t->flags.rx.send_fin = 0;
 
-    // arg_t->flags.rx.ack_timer_armed = 0;
+    // arg_t->flags.com.ack_timer_armed = 0;
 
     // /* Arrange for CF_CFDP_R_SendInactivityEvent */
     // UT_SetDataBuffer(UT_KEY(CFE_EVS_SendEvent), &EventID,
@@ -4033,7 +4033,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_1_
 
     arg_t->flags.rx.send_fin = Any_0_or_1();
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Act */
     CF_CFDP_R_Tick(arg_t, arg_cont);
@@ -4075,7 +4075,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_1_
 
     arg_t->flags.rx.send_fin = Any_0_or_1();
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Act */
     CF_CFDP_R_Tick(arg_t, arg_cont);
@@ -4111,7 +4111,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_1_
 
     arg_t->flags.rx.send_fin = Any_0_or_1();
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Arrange for CF_CFDP_R_SubstateSendNak */
     cf_config_table_t                    dummy_config_table;
@@ -4173,7 +4173,7 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_1_
 
     arg_t->flags.rx.send_fin = Any_0_or_1();
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Arrange for CF_CFDP_R_SubstateSendNak */
     history_t                            dummy_history;
@@ -4223,14 +4223,14 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_1_
 
     arg_t->flags.rx.send_fin = 1;
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Arrange for CF_CFDP_R2_SubstateSendFin*/
     history_t dummy_history;
 
-    arg_t->history           = &dummy_history;
-    arg_t->history->cc       = CC_NO_ERROR;
-    arg_t->flags.rx.crc_calc = 0;
+    arg_t->history            = &dummy_history;
+    arg_t->history->cc        = CC_NO_ERROR;
+    arg_t->flags.com.crc_calc = 0;
 
     /* Arrange for CF_CFDP_R2_CalcCrcChunk */
     cf_config_table_t dummy_config_table;
@@ -4278,14 +4278,14 @@ void Test_CF_CFDP_R_Tick_Given_t_state_IsEqTo_CFDP_R2_And_inactivity_fired_Is_1_
 
     arg_t->flags.rx.send_fin = 1;
 
-    arg_t->flags.rx.ack_timer_armed = 0;
+    arg_t->flags.com.ack_timer_armed = 0;
 
     /* Arrange for CF_CFDP_R2_SubstateSendFin*/
     history_t dummy_history;
 
-    arg_t->history           = &dummy_history;
-    arg_t->history->cc       = CC_NO_ERROR;
-    arg_t->flags.rx.crc_calc = 1;
+    arg_t->history            = &dummy_history;
+    arg_t->history->cc        = CC_NO_ERROR;
+    arg_t->flags.com.crc_calc = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_SendFin), CF_SEND_SUCCESS);
 
@@ -4328,7 +4328,7 @@ void Test_CF_CFDP_R_Tick_NothingElseSet_ack_timer_armed_Is_1_CAllTo_CF_Timer_Exp
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 1;
+    arg_t->flags.com.ack_timer_armed = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_Timer_Expired), 0);
 
@@ -4368,7 +4368,7 @@ void Test_CF_CFDP_R_Tick_NothingElseSet_ack_timer_armed_Is_1_CAllTo_CF_Timer_Exp
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 1;
+    arg_t->flags.com.ack_timer_armed = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_Timer_Expired), Any_int_Except(0));
 
@@ -4414,7 +4414,7 @@ void Test_CF_CFDP_R_Tick_NothingElseSet_ack_timer_armed_Is_1_CAllTo_CF_Timer_Exp
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 1;
+    arg_t->flags.com.ack_timer_armed = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_Timer_Expired), Any_int_Except(0));
 
@@ -4466,7 +4466,7 @@ void Test_CF_CFDP_R_Tick_NothingElseSet_ack_timer_armed_Is_1_CAllTo_CF_Timer_Exp
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 1;
+    arg_t->flags.com.ack_timer_armed = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_Timer_Expired), Any_int_Except(0));
 
@@ -4521,7 +4521,7 @@ void Test_CF_CFDP_R_Tick_NothingElseSet_ack_timer_armed_Is_1_CAllTo_CF_Timer_Exp
 
     arg_t->flags.rx.send_fin = 0;
 
-    arg_t->flags.rx.ack_timer_armed = 1;
+    arg_t->flags.com.ack_timer_armed = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_Timer_Expired), Any_int_Except(0));
 

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -163,7 +163,7 @@ void Test_CFDP_S_SendEof_When_flag_tx_crc_calc_Is_0_Call_CF_CRC_Finalize_AndSet_
     cfdp_send_ret_t           forced_return_CF_CFDP_SendEof = Any_cfdp_send_ret_t();
     CF_CFDP_SendEof_context_t context_CF_CFDP_SendEof;
 
-    arg_t->flags.tx.crc_calc = 0;
+    arg_t->flags.com.crc_calc = 0;
 
     UT_SetDataBuffer(UT_KEY(CF_CRC_Finalize), &context_CF_CRC_Finalize, sizeof(context_CF_CRC_Finalize), false);
 
@@ -179,8 +179,8 @@ void Test_CFDP_S_SendEof_When_flag_tx_crc_calc_Is_0_Call_CF_CRC_Finalize_AndSet_
                   forced_return_CF_CFDP_SendEof);
     UtAssert_STUB_COUNT(CF_CRC_Finalize, 1);
     UtAssert_ADDRESS_EQ(context_CF_CRC_Finalize, &arg_t->crc);
-    UtAssert_True(arg_t->flags.tx.crc_calc == 1, "t->flags.tx.crc_calc was changed to %d and should be 1",
-                  arg_t->flags.tx.crc_calc);
+    UtAssert_True(arg_t->flags.com.crc_calc == 1, "t->flags.com.crc_calc was changed to %d and should be 1",
+                  arg_t->flags.com.crc_calc);
     UtAssert_STUB_COUNT(CF_CFDP_SendEof, 1);
     UtAssert_ADDRESS_EQ(context_CF_CFDP_SendEof.t, arg_t);
 } /* end
@@ -196,7 +196,7 @@ void Test_CFDP_S_SendEof_When_crc_calc_Is_1_DoNotCall_CF_CRC_Finalize_ReturnValu
     cfdp_send_ret_t           forced_return_CF_CFDP_SendEof = Any_cfdp_send_ret_t();
     CF_CFDP_SendEof_context_t context_CF_CFDP_SendEof;
 
-    arg_t->flags.tx.crc_calc = 1;
+    arg_t->flags.com.crc_calc = 1;
 
     context_CF_CFDP_SendEof.forced_return = forced_return_CF_CFDP_SendEof;
     UT_SetDataBuffer(UT_KEY(CF_CFDP_SendEof), &context_CF_CFDP_SendEof, sizeof(context_CF_CFDP_SendEof), false);
@@ -209,8 +209,8 @@ void Test_CFDP_S_SendEof_When_crc_calc_Is_1_DoNotCall_CF_CRC_Finalize_ReturnValu
                   "CF_CFDP_S_SendEof returned %u and should be %u (value returned from CF_CFDP_SendEof)", local_result,
                   forced_return_CF_CFDP_SendEof);
     UtAssert_STUB_COUNT(CF_CRC_Finalize, 0);
-    UtAssert_True(arg_t->flags.tx.crc_calc == 1, "t->flags.tx.crc_calc is %d and should be 1 (unchanged)",
-                  arg_t->flags.tx.crc_calc);
+    UtAssert_True(arg_t->flags.com.crc_calc == 1, "t->flags.com.crc_calc is %d and should be 1 (unchanged)",
+                  arg_t->flags.com.crc_calc);
     UtAssert_STUB_COUNT(CF_CFDP_SendEof, 1);
     UtAssert_ADDRESS_EQ(context_CF_CFDP_SendEof.t, arg_t);
 } /* end Test_CFDP_S_SendEof_When_crc_calc_Is_1_DoNotCall_CF_CRC_Finalize_ReturnValueOfCallTo_CF_CFDP_SendEof */
@@ -233,7 +233,7 @@ void Test_CF_CFDP_S1_SubstateSendEof_When_S_SendEof_Is_CF_SEND_NO_MSG_DoNotCall_
     cfdp_send_ret_t           forced_return_CF_CFDP_SendEof = CF_SEND_NO_MSG;
     CF_CFDP_SendEof_context_t context_CF_CFDP_SendEof;
 
-    arg_t->flags.tx.crc_calc = 0;
+    arg_t->flags.com.crc_calc = 0;
 
     context_CF_CFDP_SendEof.forced_return = forced_return_CF_CFDP_SendEof;
     UT_SetDataBuffer(UT_KEY(CF_CFDP_SendEof), &context_CF_CFDP_SendEof, sizeof(context_CF_CFDP_SendEof), false);
@@ -259,7 +259,7 @@ void Test_CF_CFDP_S1_SubstateSendEof_Call_CF_CFDP_S_Reset_With_t_When_CFDP_S_Sen
     cfdp_send_ret_t           forced_return_CF_CFDP_SendEof = Any_cfdp_send_ret_t_Except(CF_SEND_NO_MSG);
     CF_CFDP_SendEof_context_t context_CF_CFDP_SendEof;
 
-    arg_t->flags.tx.crc_calc = 0;
+    arg_t->flags.com.crc_calc = 0;
 
     context_CF_CFDP_SendEof.forced_return = forced_return_CF_CFDP_SendEof;
     UT_SetDataBuffer(UT_KEY(CF_CFDP_SendEof), &context_CF_CFDP_SendEof, sizeof(context_CF_CFDP_SendEof), false);
@@ -290,8 +290,8 @@ void Test_CF_CFDP_S2_SubstateSendEof_TriggerTickProcessing(void)
     CF_InsertSortPrio_context_t context_CF_InsertSortPrio;
 
     /* setting sub_state and ack_timer_armed not required but assists in verification */
-    arg_t->state_data.s.sub_state   = Any_uint8_Except(SEND_WAIT_FOR_EOF_ACK);
-    arg_t->flags.tx.ack_timer_armed = 0;
+    arg_t->state_data.s.sub_state    = Any_uint8_Except(SEND_WAIT_FOR_EOF_ACK);
+    arg_t->flags.com.ack_timer_armed = 0;
 
     UT_SetDataBuffer(UT_KEY(CF_InsertSortPrio), &context_CF_InsertSortPrio, sizeof(context_CF_InsertSortPrio), false);
 
@@ -301,7 +301,7 @@ void Test_CF_CFDP_S2_SubstateSendEof_TriggerTickProcessing(void)
 
     arg_t->chan_num = Any_cf_chan_num();
 
-    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.all.q_index] = initial_q_size_q_index;
+    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] = initial_q_size_q_index;
 
     UT_SetDataBuffer(UT_KEY(CF_CList_Remove), &context_CF_CList_Remove, sizeof(context_CF_CList_Remove), false);
 
@@ -312,8 +312,8 @@ void Test_CF_CFDP_S2_SubstateSendEof_TriggerTickProcessing(void)
     UtAssert_True(arg_t->state_data.s.sub_state == SEND_WAIT_FOR_EOF_ACK,
                   "sub_state is %u and should be %u (SEND_WAIT_FOR_EOF_ACK)", arg_t->state_data.s.sub_state,
                   SEND_WAIT_FOR_EOF_ACK);
-    UtAssert_True(arg_t->flags.tx.ack_timer_armed == 1, "ack_timer_armed is %u and should be 1",
-                  arg_t->flags.tx.ack_timer_armed);
+    UtAssert_True(arg_t->flags.com.ack_timer_armed == 1, "ack_timer_armed is %u and should be 1",
+                  arg_t->flags.com.ack_timer_armed);
     UtAssert_STUB_COUNT(CF_InsertSortPrio, 1);
     UtAssert_ADDRESS_EQ(context_CF_InsertSortPrio.t, arg_t);
     UtAssert_True(context_CF_InsertSortPrio.q == CF_Q_TXW,
@@ -321,17 +321,17 @@ void Test_CF_CFDP_S2_SubstateSendEof_TriggerTickProcessing(void)
     /* Assert for cf_dequeue_transaction */
     UtAssert_STUB_COUNT(CF_CList_Remove, 1);
     UtAssert_ADDRESS_EQ(context_CF_CList_Remove.head,
-                        &CF_AppData.engine.channels[arg_t->chan_num].qs[arg_t->flags.all.q_index]);
+                        &CF_AppData.engine.channels[arg_t->chan_num].qs[arg_t->flags.com.q_index]);
     UtAssert_ADDRESS_EQ(context_CF_CList_Remove.node, &arg_t->cl_node);
-    UtAssert_True(CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.all.q_index] ==
+    UtAssert_True(CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] ==
                       initial_q_size_q_index - 1,
-                  "q_size[t->flags.all.q_index] is %u and should be 1 less than %u (value before call)",
-                  CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.all.q_index], initial_q_size_q_index);
+                  "q_size[t->flags.com.q_index] is %u and should be 1 less than %u (value before call)",
+                  CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index], initial_q_size_q_index);
     UtAssert_True(arg_t->state_data.s.sub_state == SEND_WAIT_FOR_EOF_ACK,
                   "t->state_data.s.sub_state is %d and should be %d (SEND_WAIT_FOR_EOF_ACK)",
                   arg_t->state_data.s.sub_state, SEND_WAIT_FOR_EOF_ACK);
-    UtAssert_True(arg_t->flags.tx.ack_timer_armed == 1, "t->flags.tx.ack_timer_armed is %d and should be 1",
-                  arg_t->flags.tx.ack_timer_armed);
+    UtAssert_True(arg_t->flags.com.ack_timer_armed == 1, "t->flags.com.ack_timer_armed is %d and should be 1",
+                  arg_t->flags.com.ack_timer_armed);
 } /* end Test_CF_CFDP_S2_SubstateSendEof_TriggerTickProcessing */
 
 /* end CF_CFDP_S2_SubstateSendEof tests */
@@ -2673,7 +2673,7 @@ void Test_CF_CFDP_S2_WaitForEofAck_CallTo_CF_CFDP_RecvAck_Returns_0_And_t_histor
 
     arg_t->state_data.s.sub_state =
         Any_uint8_Except(SEND_WAIT_FOR_FIN); /* setting sub_state not required, but helps verification */
-    arg_t->flags.tx.ack_timer_armed = 1;     /* setting ack_timer_armed not required, but helps verification */
+    arg_t->flags.com.ack_timer_armed = 1;    /* setting ack_timer_armed not required, but helps verification */
 
     /* Act */
     CF_CFDP_S2_WaitForEofAck(arg_t, arg_ph);
@@ -2682,8 +2682,8 @@ void Test_CF_CFDP_S2_WaitForEofAck_CallTo_CF_CFDP_RecvAck_Returns_0_And_t_histor
     UtAssert_True(arg_t->state_data.s.sub_state == SEND_WAIT_FOR_FIN,
                   "sub_state was set to %u and should be %u (SEND_WAIT_FOR_FIN)", arg_t->state_data.s.sub_state,
                   SEND_WAIT_FOR_FIN);
-    UtAssert_True(arg_t->flags.tx.ack_timer_armed == 0, "sub_state was set to %u and should be 0",
-                  arg_t->flags.tx.ack_timer_armed);
+    UtAssert_True(arg_t->flags.com.ack_timer_armed == 0, "sub_state was set to %u and should be 0",
+                  arg_t->flags.com.ack_timer_armed);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 } /* end
      Test_CF_CFDP_S2_WaitForEofAck_CallTo_CF_CFDP_RecvAck_Returns_0_And_t_history_cc_EqTo_CC_NO_ERROR_Set_sub_state_To_SEND_WAIT_FOR_FIN_And_ack_time_armed_To_0
@@ -3163,7 +3163,7 @@ void Test_CF_CFDP_S1_Tx_When_t_sub_state_Is_0_Call_CF_CFDP_S_SubstateSendMetadat
 //     // /* Arrange unstubbable: CF_CFDP_S_SendEof -  bypass finalize just return CF_CFDP_SendEof */
 //     // CF_CFDP_SendEof_context_t   context_CF_CFDP_SendEof;
 
-//     // arg_t->flags.tx.crc_calc = 1;
+//     // arg_t->flags.com.crc_calc = 1;
 
 //     // context_CF_CFDP_SendEof.forced_return = Any_uint8_Except(CF_SEND_NO_MSG);
 //     // UT_SetDataBuffer(UT_KEY(CF_CFDP_SendEof), &context_CF_CFDP_SendEof,
@@ -3262,7 +3262,7 @@ void Test_CF_CFDP_S2_Tx_When_t_sub_state_Is_0_Call_CF_CFDP_S_SubstateSendMetadat
 //     /* Arrange unstubbable: CF_CFDP_S_SendEof -  bypass finalize just return CF_CFDP_SendEof */
 //     CF_CFDP_SendEof_context_t   context_CF_CFDP_SendEof;
 
-//     arg_t->flags.tx.crc_calc = 1;
+//     arg_t->flags.com.crc_calc = 1;
 
 //     context_CF_CFDP_SendEof.forced_return = Any_uint8_Except(CF_SEND_NO_MSG);
 
@@ -3446,11 +3446,11 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpiredAnd_sub_state_EqTo_SEND_WAIT_FOR_EOF_A
     cf_timer_t       *context_CF_Timer_Tick;
     const char       *expected_Spec = "CF S2(%u:%u), ack limit reached, no eof-ack";
 
-    arg_t->history                  = &dummy_history;
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 1;
-    arg_t->state_data.s.sub_state   = SEND_WAIT_FOR_EOF_ACK;
+    arg_t->history                   = &dummy_history;
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 1;
+    arg_t->state_data.s.sub_state    = SEND_WAIT_FOR_EOF_ACK;
 
     arg_t->state_data.s.s2.counter.ack = dummy_ack_limit - 1;
 
@@ -3526,11 +3526,11 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpiredAnd_sub_state_EqTo_SEND_WAIT_FOR_EOF_A
     cf_timer_t       *context_CF_Timer_Expired[2];
     cf_timer_t       *context_CF_Timer_Tick;
 
-    arg_t->history                  = &dummy_history;
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 1;
-    arg_t->state_data.s.sub_state   = SEND_WAIT_FOR_EOF_ACK;
+    arg_t->history                   = &dummy_history;
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 1;
+    arg_t->state_data.s.sub_state    = SEND_WAIT_FOR_EOF_ACK;
 
     arg_t->state_data.s.s2.counter.ack = Any_uint8_Except(dummy_ack_limit - 1);
 
@@ -3548,7 +3548,7 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpiredAnd_sub_state_EqTo_SEND_WAIT_FOR_EOF_A
     /* Arrange unstubbable: CF_CFDP_S_SendEof */
     CF_CFDP_SendEof_context_t context_CF_CFDP_SendEof;
 
-    arg_t->flags.tx.crc_calc = 1;
+    arg_t->flags.com.crc_calc = 1;
 
     context_CF_CFDP_SendEof.forced_return = CF_SEND_NO_MSG;
 
@@ -3596,11 +3596,11 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpiredAnd_sub_state_EqTo_SEND_WAIT_FOR_EOF_A
     cf_timer_t       *context_CF_Timer_Expired[2];
     cf_timer_t       *context_CF_Timer_Tick;
 
-    arg_t->history                  = &dummy_history;
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 1;
-    arg_t->state_data.s.sub_state   = SEND_WAIT_FOR_EOF_ACK;
+    arg_t->history                   = &dummy_history;
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 1;
+    arg_t->state_data.s.sub_state    = SEND_WAIT_FOR_EOF_ACK;
 
     arg_t->state_data.s.s2.counter.ack = Any_uint8_Except(dummy_ack_limit - 1);
 
@@ -3618,7 +3618,7 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpiredAnd_sub_state_EqTo_SEND_WAIT_FOR_EOF_A
     /* Arrange unstubbable: CF_CFDP_S_SendEof */
     CF_CFDP_SendEof_context_t context_CF_CFDP_SendEof;
 
-    arg_t->flags.tx.crc_calc = 1;
+    arg_t->flags.com.crc_calc = 1;
 
     context_CF_CFDP_SendEof.forced_return = CF_SEND_ERROR;
 
@@ -3677,11 +3677,11 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpiredAnd_sub_state_EqTo_SEND_WAIT_FOR_EOF_A
     cf_timer_t       *context_CF_Timer_Tick;
     transaction_t    *context_CF_CFDP_ArmAckTimer;
 
-    arg_t->history                  = &dummy_history;
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 1;
-    arg_t->state_data.s.sub_state   = SEND_WAIT_FOR_EOF_ACK;
+    arg_t->history                   = &dummy_history;
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 1;
+    arg_t->state_data.s.sub_state    = SEND_WAIT_FOR_EOF_ACK;
 
     arg_t->state_data.s.s2.counter.ack = Any_uint8_Except(dummy_ack_limit - 1);
 
@@ -3703,7 +3703,7 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpiredAnd_sub_state_EqTo_SEND_WAIT_FOR_EOF_A
     cfdp_send_ret_t           exceptions[2] = {CF_SEND_NO_MSG, CF_SEND_ERROR};
     CF_CFDP_SendEof_context_t context_CF_CFDP_SendEof;
 
-    arg_t->flags.tx.crc_calc = 1;
+    arg_t->flags.com.crc_calc = 1;
 
     context_CF_CFDP_SendEof.forced_return = Any_cfdp_send_ret_t_ExceptThese(exceptions, 2);
 
@@ -3749,10 +3749,10 @@ void Test_CF_CFDP_S_Tick_ArmedTimerExpired_sub_state_NotEqTo_SEND_WAIT_FOR_EOF_A
     cf_timer_t    *context_CF_Timer_Expired[2];
     cf_timer_t    *context_CF_Timer_Tick;
 
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 1;
-    arg_t->state_data.s.sub_state   = Any_uint8_ExceptThese(exceptions, 2);
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 1;
+    arg_t->state_data.s.sub_state    = Any_uint8_ExceptThese(exceptions, 2);
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.inactivity_timer = initial_inactivity_timer;
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.ack_limit        = initial_fault_ack_limit;
@@ -3797,10 +3797,10 @@ void Test_CF_CFDP_S_Tick_ArmedTimerNotExpiredCall_CF_Timer_Tick(void)
     cf_timer_t    *context_CF_Timer_Expired[2];
     cf_timer_t    *context_CF_Timer_Tick[2];
 
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 1;
-    arg_t->state_data.s.sub_state   = SEND_WAIT_FOR_EOF_ACK;
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 1;
+    arg_t->state_data.s.sub_state    = SEND_WAIT_FOR_EOF_ACK;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.inactivity_timer = initial_inactivity_timer;
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.ack_limit        = initial_fault_ack_limit;
@@ -3846,10 +3846,10 @@ void Test_CF_CFDP_S_Tick_TimerNotArmedDoNotArmAckTimerOrDoTick(void)
     cf_timer_t    *context_CF_Timer_Expired;
     cf_timer_t    *context_CF_Timer_Tick;
 
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 0;
-    arg_t->state_data.s.sub_state   = Any_uint8_Except(SEND_SEND_FIN_ACK);
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 0;
+    arg_t->state_data.s.sub_state    = Any_uint8_Except(SEND_SEND_FIN_ACK);
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.inactivity_timer = initial_inactivity_timer;
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.ack_limit        = initial_fault_ack_limit;
@@ -3893,11 +3893,11 @@ void Test_CF_CFDP_S_Tick_When_sub_state_IsEqTo_SEND_SEND_FIN_ACK_Call_CF_CFDP_S_
     cf_timer_t    *context_CF_Timer_Expired;
     cf_timer_t    *context_CF_Timer_Tick;
 
-    arg_t->history                  = &dummy_history;
-    arg_t->chan_num                 = Any_cf_chan_num();
-    arg_t->state                    = CFDP_S2;
-    arg_t->flags.tx.ack_timer_armed = 0;
-    arg_t->state_data.s.sub_state   = SEND_SEND_FIN_ACK;
+    arg_t->history                   = &dummy_history;
+    arg_t->chan_num                  = Any_cf_chan_num();
+    arg_t->state                     = CFDP_S2;
+    arg_t->flags.com.ack_timer_armed = 0;
+    arg_t->state_data.s.sub_state    = SEND_SEND_FIN_ACK;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.inactivity_timer = initial_inactivity_timer;
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.ack_limit        = initial_fault_ack_limit;

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -180,7 +180,7 @@ void Handler_CF_CFDP_S1_Tx_notCF_Q_TXA_q_index(void *UserObj, UT_EntryKey_t Func
 
     if (UT_GetStubCount(FuncKey) > 1)
     {
-        t->flags.all.q_index = CF_Q_NUM;
+        t->flags.com.q_index = CF_Q_NUM;
     }
 }
 
@@ -346,7 +346,7 @@ void Test_CF_CFDP_ArmAckTimer_Call_CF_Timer_InitRelSec_WithCorrectParamsAndArmsT
     CF_AppData.config_table              = &dummy_config_table;
     CF_AppData.config_table->ack_timer_s = Any_uint32();
 
-    arg_t->flags.all.ack_timer_armed = 0; /* not required but helps show assert */
+    arg_t->flags.com.ack_timer_armed = 0; /* not required but helps show assert */
 
     UT_SetDataBuffer(UT_KEY(CF_Timer_InitRelSec), &context_CF_Timer_InitRelSec, sizeof(context_CF_Timer_InitRelSec),
                      false);
@@ -360,8 +360,8 @@ void Test_CF_CFDP_ArmAckTimer_Call_CF_Timer_InitRelSec_WithCorrectParamsAndArmsT
     UtAssert_True(context_CF_Timer_InitRelSec.rel_sec == CF_AppData.config_table->ack_timer_s,
                   "CF_Timer_InitRelSec received rel_sec %u and should be %u (CF_AppData.config_table->ack_timer_s)",
                   context_CF_Timer_InitRelSec.rel_sec, CF_AppData.config_table->ack_timer_s);
-    UtAssert_True(arg_t->flags.all.ack_timer_armed == 1,
-                  "CF_CFDP_ArmAckTimer set ack_timer_armed to %u and should be 1", arg_t->flags.all.ack_timer_armed);
+    UtAssert_True(arg_t->flags.com.ack_timer_armed == 1,
+                  "CF_CFDP_ArmAckTimer set ack_timer_armed to %u and should be 1", arg_t->flags.com.ack_timer_armed);
 } /* end Test_CF_CFDP_ArmAckTimer_Call_CF_Timer_InitRelSec_WithCorrectParamsAndArmsTimer */
 
 /* end CF_CFDP_ArmAckTimer tests */
@@ -378,7 +378,7 @@ void Test_CF_CFDP_GetClass_AssertsBecause_q_index_IsEqTo_CF_Q_FREE(void)
     // transaction_t   dummy_ti;
     // transaction_t*  arg_ti = &dummy_ti;
 
-    // arg_ti->flags.all.q_index = CF_Q_FREE;
+    // arg_ti->flags.com.q_index = CF_Q_FREE;
 
     // /* Act */
     // //CF_CFDP_GetClass(arg_ti);
@@ -396,7 +396,7 @@ void Test_CF_CFDP_GetClass_WhenNeitherStateIsSet_Return_CLASS_1(void)
     transaction_t *arg_ti = &dummy_ti;
     cfdp_class_t   local_result;
 
-    arg_ti->flags.all.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
+    arg_ti->flags.com.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
     arg_ti->state = Any_cfdp_state_t_ExceptThese(excepted_states, sizeof(excepted_states) / sizeof(excepted_states[0]));
 
     /* Act */
@@ -414,7 +414,7 @@ void Test_CF_CFDP_GetClass_WhenStateIs_CFDP_S2_Return_CLASS_1(void)
     transaction_t *arg_ti = &dummy_ti;
     cfdp_class_t   local_result;
 
-    arg_ti->flags.all.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
+    arg_ti->flags.com.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
     arg_ti->state             = CFDP_S2;
 
     /* Act */
@@ -432,7 +432,7 @@ void Test_CF_CFDP_GetClass_WhenStateIs_CFDP_R2_Return_CLASS_1(void)
     transaction_t *arg_ti = &dummy_ti;
     cfdp_class_t   local_result;
 
-    arg_ti->flags.all.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
+    arg_ti->flags.com.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
     arg_ti->state             = CFDP_R2;
 
     /* Act */
@@ -457,7 +457,7 @@ void Test_CF_CFDP_IsSender_AssertsBecause_q_index_IsEqTo_CF_Q_FREE(void)
     // transaction_t   dummy_ti;
     // transaction_t*  arg_ti = &dummy_ti;
 
-    // arg_ti->flags.all.q_index = CF_Q_FREE;
+    // arg_ti->flags.com.q_index = CF_Q_FREE;
 
     // /* Act */
     // CF_CFDP_IsSender(arg_ti);
@@ -474,7 +474,7 @@ void Test_CF_CFDP_IsSender_WhenNeitherStateIsSetReturn_0_MeaningReciever(void)
     transaction_t *arg_ti = &dummy_ti;
     int            local_result;
 
-    arg_ti->flags.all.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
+    arg_ti->flags.com.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
     arg_ti->state = Any_cfdp_state_t_ExceptThese(excepted_states, sizeof(excepted_states) / sizeof(excepted_states[0]));
 
     /* Act */
@@ -491,7 +491,7 @@ void Test_CF_CFDP_IsSender_WhenStateIs_CFDP_S1_Return_1_MeaningSender(void)
     transaction_t *arg_ti = &dummy_ti;
     int            local_result;
 
-    arg_ti->flags.all.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
+    arg_ti->flags.com.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
     arg_ti->state             = CFDP_S1;
 
     /* Act */
@@ -508,7 +508,7 @@ void Test_CF_CFDP_IsSender_WhenStateIs_CFDP_S2_Return_1_MeaningSender(void)
     transaction_t *arg_ti = &dummy_ti;
     int            local_result;
 
-    arg_ti->flags.all.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
+    arg_ti->flags.com.q_index = Any_cf_queue_index_t_Except(CF_Q_FREE);
     arg_ti->state             = CFDP_S2;
 
     /* Act */
@@ -1437,7 +1437,7 @@ void Test_CF_CFDP_MsgOutGet_When_outgoing_counter_DoesNotEq_max_outgoing_message
     initial_outgoing_counter = CF_AppData.engine.outgoing_counter;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 1;
+    arg_t->flags.com.suspended                       = 1;
 
     /* Act */
     local_result = CF_CFDP_MsgOutGet(arg_t, arg_silent);
@@ -1519,7 +1519,7 @@ void Test_CF_CFDP_MsgOutGet_When_sem_name_0_Is_non0_But_CallTo_OS_CountSemTimedW
     initial_outgoing_counter = CF_AppData.engine.outgoing_counter;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     CF_AppData.config_table->chan[arg_t->chan_num].sem_name[0] = Any_char_Except(0);
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), Any_int32_Except(OS_SUCCESS));
@@ -1570,7 +1570,7 @@ void Test_CF_CFDP_MsgOutGet_When_sem_name_0_Is_non0_But_CallTo_OS_CountSemTimedW
     initial_outgoing_counter = CF_AppData.engine.outgoing_counter;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     CF_AppData.config_table->chan[arg_t->chan_num].sem_name[0] = Any_char_Except(0);
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), Any_int32_Except(OS_SUCCESS));
@@ -1616,7 +1616,7 @@ void Test_CF_CFDP_MsgOutGet_When_sem_name_0_Is_non0_Then_CallTo_OS_CountSemTimed
     initial_outgoing_counter = CF_AppData.engine.outgoing_counter;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     CF_AppData.config_table->chan[arg_t->chan_num].sem_name[0] = Any_char_Except(0);
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), OS_SUCCESS);
@@ -1665,7 +1665,7 @@ void Test_CF_CFDP_MsgOutGet_When_sem_name_0_Is_0_Then_CallTo_OS_CountSemTimedWai
     initial_outgoing_counter = CF_AppData.engine.outgoing_counter;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     CF_AppData.config_table->chan[arg_t->chan_num].sem_name[0] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), OS_SUCCESS);
@@ -1817,7 +1817,7 @@ void Test_CF_CFDP_ConstructPduHeader_CallTo_CF_CFDP_MsgOutGet_Returns_NULL_DoNot
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), Any_uint32_Except(OS_SUCCESS));
 
@@ -1959,8 +1959,8 @@ void Test_CF_CFDP_SendMd_GetNull_pdu_header_Return_CF_SEND_NO_MSG(void)
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup =
         CF_AppData.engine.outgoing_counter;
 
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     local_result = CF_CFDP_SendMd(arg_t);
@@ -1991,11 +1991,11 @@ void Test_CF_CFDP_SendMd_AssertsBecause_state_NotEq_CFDP_S1_Or_CFDP_S2(void)
     // CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup =
     //   CF_AppData.engine.outgoing_counter + 1;
     // CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    // arg_t->flags.all.suspended = 0;
+    // arg_t->flags.com.suspended = 0;
     // CF_AppData.engine.out.msg = (CFE_SB_Buffer_t*)&dummy_msg_out;
 
-    // arg_t->flags.all.q_index = CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures
-    // ti->flags.all.q_index!=CF_Q_FREE is never false */
+    // arg_t->flags.com.q_index = CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures
+    // ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     // local_result = CF_CFDP_SendMd(arg_t);
@@ -2034,11 +2034,11 @@ void Test_CF_CFDP_SendMd_When_src_len_Eq_sizeof_src_filename_Return_CF_SEND_FAIL
     CF_AppData.engine.outgoing_counter = 0;
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 1;
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen                                = 0;
-    arg_t->flags.all.suspended                                                      = 0;
+    arg_t->flags.com.suspended                                                      = 0;
     CF_AppData.engine.out.msg                                                       = &dummy_msg_out.cfe_sb_buffer;
 
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     local_result = CF_CFDP_SendMd(arg_t);
@@ -2075,11 +2075,11 @@ void Test_CF_CFDP_SendMd_When_dst_len_Eq_sizeof_dst_filename_Return_CF_SEND_FAIL
     CF_AppData.engine.outgoing_counter = 0;
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 1;
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen                                = 0;
-    arg_t->flags.all.suspended                                                      = 0;
+    arg_t->flags.com.suspended                                                      = 0;
     CF_AppData.engine.out.msg                                                       = &dummy_msg_out.cfe_sb_buffer;
 
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     local_result = CF_CFDP_SendMd(arg_t);
@@ -2114,11 +2114,11 @@ void Test_CF_CFDP_SendMd_Returns_CF_SEND_ERROR_CF_CFDP_CopyDataToLv_Returns_neg1
     // CF_AppData.engine.outgoing_counter = 0;
     // CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 1;
     // CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    // arg_t->flags.all.suspended = 0;
+    // arg_t->flags.com.suspended = 0;
     // CF_AppData.engine.out.msg = (CFE_SB_Buffer_t*)&dummy_msg_out;
 
-    // arg_t->flags.all.q_index = CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures
-    // ti->flags.all.q_index!=CF_Q_FREE is never false */
+    // arg_t->flags.com.q_index = CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures
+    // ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     // /* Arrange unstubbable: CF_CFDP_CopyDataToLv */
     // /* no way to arrange it to fail */
@@ -2156,11 +2156,11 @@ void Test_CF_CFDP_SendMd_WhenCallTo_CF_CFDP_CopyDataToLv_Returns_neg1_OnThe_dst_
     // CF_AppData.engine.outgoing_counter = 0;
     // CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 1;
     // CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    // arg_t->flags.all.suspended = 0;
+    // arg_t->flags.com.suspended = 0;
     // CF_AppData.engine.out.msg = (CFE_SB_Buffer_t*)&dummy_msg_out;
 
-    // arg_t->flags.all.q_index = CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures
-    // ti->flags.all.q_index!=CF_Q_FREE is never false */
+    // arg_t->flags.com.q_index = CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures
+    // ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     // /* Arrange for CF_CFDP_CopyDataToLv */
     // /* no way to arrange it to fail */
@@ -2200,11 +2200,11 @@ void Test_CF_CFDP_SendMd_Return_CF_SEND_SUCCESS(void)
     CF_AppData.engine.outgoing_counter = 0;
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 1;
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen                                = 0;
-    arg_t->flags.all.suspended                                                      = 0;
+    arg_t->flags.com.suspended                                                      = 0;
     CF_AppData.engine.out.msg                                                       = &dummy_msg_out.cfe_sb_buffer;
 
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Arrange for CF_CFDP_CopyDataToLv */
     /* no way to arrange it to fail - which for success test is fine */
@@ -2332,7 +2332,7 @@ void Test_CF_CFDP_SendEof_Get_NULL_pdu_Return_CF_SEND_NO_MSG(void)
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), Any_uint32_Except(OS_SUCCESS));
 
@@ -2365,7 +2365,7 @@ void Test_CF_CFDP_SendEof_SuccessWithNoError(void)
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), Any_uint32_Except(OS_SUCCESS));
 
@@ -2398,7 +2398,7 @@ void Test_CF_CFDP_SendEof_SuccessWithError(void)
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), Any_uint32_Except(OS_SUCCESS));
 
@@ -2440,7 +2440,7 @@ void Test_CF_CFDP_SendAck_When_CF_CFDP_IsSender_Returns_false_Get_NULL_ph_Return
     arg_t->history          = &dummy_history;
 
     /* Arrange for CF_CFDP_IsSender */
-    arg_t->flags.all.q_index = Any_uint8_LessThan(CF_Q_FREE);
+    arg_t->flags.com.q_index = Any_uint8_LessThan(CF_Q_FREE);
     arg_t->state             = CFDP_DROP; /* ensures false from CF_CFDP_IsSender */
 
     /* Arrange for CF_CFDP_ConstructPduHeader */
@@ -2449,7 +2449,7 @@ void Test_CF_CFDP_SendAck_When_CF_CFDP_IsSender_Returns_false_Get_NULL_ph_Return
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     /* Act */
     local_result = CF_CFDP_SendAck(arg_t, arg_ts, arg_dir_code, arg_cc, arg_peer_eid, arg_tsn);
@@ -2479,7 +2479,7 @@ void Test_CF_CFDP_SendAck_AssertsBecauseGiven_dir_code_Is_Not_PDU_EOF_Or_PDU_FIN
     // arg_t->history = &dummy_history;
 
     // /* Arrange for CF_CFDP_IsSender */
-    // arg_t->flags.all.q_index = Any_uint8_LessThan(CF_Q_FREE);
+    // arg_t->flags.com.q_index = Any_uint8_LessThan(CF_Q_FREE);
     // arg_t->state = CFDP_S1; /* ensures true from CF_CFDP_IsSender */
 
     // /* Arrange for CF_CFDP_ConstructPduHeader */
@@ -2488,7 +2488,7 @@ void Test_CF_CFDP_SendAck_AssertsBecauseGiven_dir_code_Is_Not_PDU_EOF_Or_PDU_FIN
     // CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     // CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    // arg_t->flags.all.suspended = 0;
+    // arg_t->flags.com.suspended = 0;
 
     // /* Act */
     // local_result = CF_CFDP_SendAck(arg_t, arg_ts, arg_dir_code, arg_cc, arg_peer_eid, arg_tsn);
@@ -2522,7 +2522,7 @@ void Test_CF_CFDP_SendAck_WhenGiven_dir_code_Is_PDU_EOF_And_CF_CFDP_IsSender_Ret
     arg_t->history          = &dummy_history;
 
     /* Arrange for CF_CFDP_IsSender */
-    arg_t->flags.all.q_index = Any_uint8_LessThan(CF_Q_FREE);
+    arg_t->flags.com.q_index = Any_uint8_LessThan(CF_Q_FREE);
     arg_t->state             = CFDP_S1; /* ensures true from CF_CFDP_IsSender */
 
     /* Arrange for CF_CFDP_ConstructPduHeader */
@@ -2531,7 +2531,7 @@ void Test_CF_CFDP_SendAck_WhenGiven_dir_code_Is_PDU_EOF_And_CF_CFDP_IsSender_Ret
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     /* Act */
     local_result = CF_CFDP_SendAck(arg_t, arg_ts, arg_dir_code, arg_cc, arg_peer_eid, arg_tsn);
@@ -2565,7 +2565,7 @@ void Test_CF_CFDP_SendAck_WhenGiven_dir_code_Is_PDU_FIN_And_CF_CFDP_IsSender_Ret
     arg_t->history          = &dummy_history;
 
     /* Arrange for CF_CFDP_IsSender */
-    arg_t->flags.all.q_index = Any_uint8_LessThan(CF_Q_FREE);
+    arg_t->flags.com.q_index = Any_uint8_LessThan(CF_Q_FREE);
     arg_t->state             = CFDP_S1; /* ensures true from CF_CFDP_IsSender */
 
     /* Arrange for CF_CFDP_ConstructPduHeader */
@@ -2574,7 +2574,7 @@ void Test_CF_CFDP_SendAck_WhenGiven_dir_code_Is_PDU_FIN_And_CF_CFDP_IsSender_Ret
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     /* Act */
     local_result = CF_CFDP_SendAck(arg_t, arg_ts, arg_dir_code, arg_cc, arg_peer_eid, arg_tsn);
@@ -2617,7 +2617,7 @@ void Test_CF_CFDP_SendFin_Get_NULL_ph_Return_CF_SEND_NO_MSG(void)
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     /* Act */
     local_result = CF_CFDP_SendFin(arg_t, arg_dc, arg_fs, arg_cc);
@@ -2651,7 +2651,7 @@ void Test_CF_CFDP_SendFin_Given_cc_NotEqTo_CC_NO_ERROR_GetNull_ph_Return_CF_SEND
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     /* Act */
     local_result = CF_CFDP_SendFin(arg_t, arg_dc, arg_fs, arg_cc);
@@ -2687,7 +2687,7 @@ void Test_CF_CFDP_SendFin_Given_cc_EqTo_CC_NO_ERROR_GetNull_ph_Return_CF_SEND_SU
     CF_AppData.config_table->chan[arg_t->chan_num].max_outgoing_messages_per_wakeup = 0;
 
     CF_AppData.hk.channel_hk[arg_t->chan_num].frozen = 0;
-    arg_t->flags.all.suspended                       = 0;
+    arg_t->flags.com.suspended                       = 0;
 
     /* Act */
     local_result = CF_CFDP_SendFin(arg_t, arg_dc, arg_fs, arg_cc);
@@ -2738,7 +2738,7 @@ void Test_CF_CFDP_SendNak_AssertsBecause_CF_CFDP_GetClass_With_t_Eq_CLASS_2(void
     // CF_AppData.engine.out.msg = (CFE_SB_Buffer_t*)&dummy_nak;
 
     // /* Arrange for CF_CFDP_GetClass */
-    // arg_t->flags.all.q_index = Any_uint8_LessThan(CF_Q_FREE);
+    // arg_t->flags.com.q_index = Any_uint8_LessThan(CF_Q_FREE);
     // arg_t->state = CFDP_S1; /* ensures failre */
 
     // /* Act */
@@ -2774,7 +2774,7 @@ void Test_CF_CFDP_SendNak_Success_Return_CF_SEND_SUCCESS(void)
     arg_t->chan_num = dummy_chan_num;
 
     /* Arrange for CF_CFDP_GetClass */
-    arg_t->flags.all.q_index = CF_Q_PEND;
+    arg_t->flags.com.q_index = CF_Q_PEND;
     arg_t->state             = CFDP_S2; /* ensures pass */
 
     /* Act */
@@ -4124,8 +4124,8 @@ void Test_CF_CFDP_RecvIdle_CheckOf_PDU_HDR_FLAGS_TYPE_Is_true_And_PDU_HDR_FLAGS_
 
     /* Special arrange for CF_Timer_InitRelSec to change t->state value within call to CF_CFDP_DispatchRecv */
     UT_SetHandlerFunction(UT_KEY(CF_Timer_InitRelSec), Handler_CF_Timer_InitRelSec_Change_t_state_To_CFDP_IDLE, arg_t);
-    arg_t->flags.all.q_index                                                   = 0;
-    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.all.q_index] = 1;
+    arg_t->flags.com.q_index                                                   = 0;
+    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] = 1;
 
     arg_t->history->dir = CF_DIR_TX;
     arg_t->p            = NULL; /* arg_t->p = NULL bypasses an unnecessary branch */
@@ -5939,7 +5939,7 @@ void Test_CF_CFDP_CycleTx__Given_node_TransactionContainer_t_flags_all_suspended
     void                  *arg_context = (void *)&dummy_args;
     int                    local_result;
 
-    dummy_t.flags.all.suspended = true;
+    dummy_t.flags.com.suspended = true;
 
     /* Act */
     local_result = CF_CFDP_CycleTx_(arg_clist_node, arg_context);
@@ -5957,15 +5957,15 @@ void Test_CF_CFDP_CycleTx__AssertsBecauseGiven_node_TransactionContainer_t_flags
     // void*                   arg_context = (void*)&dummy_args;
     // int                     local_result;
 
-    // dummy_t.flags.all.suspended = false;
+    // dummy_t.flags.com.suspended = false;
 
-    // dummy_t.flags.all.q_index = Any_uint8_Except(CF_Q_TXA);
+    // dummy_t.flags.com.q_index = Any_uint8_Except(CF_Q_TXA);
 
     // /* Act */
     // local_result = CF_CFDP_CycleTx_(arg_clist_node, arg_context);
 
     // /* Assert */
-    UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert - t->flags.all.q_index==CF_Q_TXA");
+    UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert - t->flags.com.q_index==CF_Q_TXA");
 } /* end Test_CF_CFDP_CycleTx__AssertsBecauseGiven_node_TransactionContainer_t_flags_all_q_index_IsNotEqTo_CF_Q_TXA */
 
 void Test_CF_CFDP_CycleTx__Given_node_TransactionContainer_t_flags_all_q_index_IsEqTo_CF_Q_TXA_And_args_c_cur_Is_notNULL_Sets_args_ran_one_To_1_ThenReturn_1(
@@ -5980,9 +5980,9 @@ void Test_CF_CFDP_CycleTx__Given_node_TransactionContainer_t_flags_all_q_index_I
     void                  *arg_context = (void *)&dummy_args;
     int                    local_result;
 
-    dummy_t.flags.all.suspended = false;
+    dummy_t.flags.com.suspended = false;
 
-    dummy_t.flags.all.q_index = CF_Q_TXA;
+    dummy_t.flags.com.q_index = CF_Q_TXA;
 
     dummy_c.cur  = &dummy_cur;
     dummy_args.c = &dummy_c;
@@ -6012,9 +6012,9 @@ void Test_CF_CFDP_CycleTx__Given_node_TransactionContainer_t_flags_all_q_index_I
     void                  *arg_context = (void *)&dummy_args;
     int                    local_result;
 
-    dummy_t.flags.all.suspended = false;
+    dummy_t.flags.com.suspended = false;
 
-    dummy_t.flags.all.q_index = CF_Q_TXA;
+    dummy_t.flags.com.q_index = CF_Q_TXA;
 
     dummy_c.cur  = NULL;
     dummy_args.c = &dummy_c;
@@ -6052,9 +6052,9 @@ void Test_CF_CFDP_CycleTx__Given_node_TransactionContainer_t_flags_all_q_index_I
     void                  *arg_context = (void *)&dummy_args;
     int                    local_result;
 
-    dummy_t.flags.all.suspended = false;
+    dummy_t.flags.com.suspended = false;
 
-    dummy_t.flags.all.q_index = CF_Q_TXA;
+    dummy_t.flags.com.q_index = CF_Q_TXA;
 
     dummy_c.cur  = NULL;
     dummy_args.c = &dummy_c;
@@ -6094,9 +6094,9 @@ void Test_CF_CFDP_CycleTx_Given_node_TransactionContainer_t_flags_all_q_index_Is
     void                  *arg_context = (void *)&dummy_args;
     int                    local_result;
 
-    dummy_t.flags.all.suspended = false;
+    dummy_t.flags.com.suspended = false;
 
-    dummy_t.flags.all.q_index = CF_Q_TXA;
+    dummy_t.flags.com.q_index = CF_Q_TXA;
 
     dummy_c.cur  = NULL;
     dummy_args.c = &dummy_c;
@@ -6255,7 +6255,7 @@ void Test_CF_CFDP_CycleTx_EnterWhileLoopOnceAndCall_cf_move_transaction_SecondCa
     /* Arrange for cf_move_transaction */
     dummy_cur.chan_num = Any_cf_chan_num();
 
-    CF_AppData.hk.channel_hk[dummy_cur.chan_num].q_size[dummy_cur.flags.all.q_index] = 1; /* 1 for non zero */
+    CF_AppData.hk.channel_hk[dummy_cur.chan_num].q_size[dummy_cur.flags.com.q_index] = 1; /* 1 for non zero */
 
     /* Act */
     CF_CFDP_CycleTx(arg_c);
@@ -6314,7 +6314,7 @@ void Test_CF_CFDP_DoTick_Given_context_Determined_args_c_cur_IsNull_But_t_flags_
     dummy_args.c      = &dummy_c;
     dummy_args.c->cur = NULL;
 
-    dummy_t.flags.all.suspended = true;
+    dummy_t.flags.com.suspended = true;
 
     /* Act */
     local_result = CF_CFDP_DoTick(arg_node, arg_context);
@@ -6340,7 +6340,7 @@ void Test_CF_CFDP_DoTick_Given_context_Determined_args_c_cur_Is_t_But_t_flags_al
     dummy_args.c      = &dummy_c;
     dummy_args.c->cur = &dummy_t;
 
-    dummy_t.flags.all.suspended = true;
+    dummy_t.flags.com.suspended = true;
 
     /* Act */
     local_result = CF_CFDP_DoTick(arg_node, arg_context);
@@ -6367,7 +6367,7 @@ void Test_CF_CFDP_DoTick_Given_context_Determined_args_c_cur_Is_t_And_t_flags_al
     dummy_args.c      = &dummy_c;
     dummy_args.c->cur = &dummy_t;
 
-    dummy_t.flags.all.suspended = false;
+    dummy_t.flags.com.suspended = false;
 
     dummy_args.fn = (void (*)(transaction_t *, int *))Dummy_tick_args_t_fn;
 
@@ -6402,7 +6402,7 @@ void Test_CF_CFDP_DoTick_Given_context_Determined_args_c_cur_Is_t_And_t_flags_al
     dummy_args.c      = &dummy_c;
     dummy_args.c->cur = &dummy_t;
 
-    dummy_t.flags.all.suspended = false;
+    dummy_t.flags.com.suspended = false;
 
     dummy_args.fn = (void (*)(transaction_t *, int *))Dummy_tick_args_t_fn;
 
@@ -8057,8 +8057,8 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_true_Call_C
     arg_t->fd = Any_uint32_Except(0); /* Any_uint32_Except(0) causes OS_ObjectIdDefined (non 0 != 0) to return true */
 
     /* Arrange for CF_CFDP_GetClass */
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8106,7 +8106,7 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_true_Call_C
     arg_t->fd = Any_uint32_Except(0); /* Any_uint32_Except(0) causes OS_ObjectIdDefined (non 0 != 0) to return true */
 
     /* Arrange for CF_CFDP_IsSender */
-    arg_t->flags.all.q_index = CF_Q_RX; /* bypass CF_Assert */
+    arg_t->flags.com.q_index = CF_Q_RX; /* bypass CF_Assert */
 
     arg_t->state = CFDP_R1; /* arg_t->state = CFDP_R1 forces 0 return */
 
@@ -8159,7 +8159,7 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_true_Call_C
     arg_t->fd = Any_uint32_Except(0); /* Any_uint32_Except(0) causes OS_ObjectIdDefined (non 0 != 0) to return true */
 
     /* Arrange for CF_CFDP_IsSender */
-    arg_t->flags.all.q_index = CF_Q_RX; /* bypass CF_Assert */
+    arg_t->flags.com.q_index = CF_Q_RX; /* bypass CF_Assert */
 
     arg_t->state = CFDP_S1; /* arg_t->state = CFDP_S1 forces non 0 return */
 
@@ -8203,8 +8203,8 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_false_And_t
     arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     /* Arrange for CF_CFDP_GetClass */
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8243,8 +8243,8 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_false_And_t
     arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     /* Arrange for CF_CFDP_GetClass */
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8287,8 +8287,8 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_false_And_t
     arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     /* Arrange for CF_CFDP_GetClass */
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8332,8 +8332,8 @@ void Test_CF_CFDP_ResetTransaction_AssertsBecause_c_num_cmd_tx_Is_0(void)
     // arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     // /* Arrange for CF_CFDP_GetClass */
-    // arg_t->flags.all.q_index = CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures
-    // ti->flags.all.q_index!=CF_Q_FREE is never false */
+    // arg_t->flags.com.q_index = CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures
+    // ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     // /* Act */
     // CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8379,8 +8379,8 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_false_And_t
     arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     /* Arrange for CF_CFDP_GetClass */
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8426,8 +8426,8 @@ void Test_CF_CFDP_ResetTransaction_AssertsBecause_t_p_num_ts_Is_0(void)
     // arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     // /* Arrange for CF_CFDP_GetClass */
-    // arg_t->flags.all.q_index = CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures
-    // ti->flags.all.q_index!=CF_Q_FREE is never false */
+    // arg_t->flags.com.q_index = CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures
+    // ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     // /* Act */
     // CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8475,8 +8475,8 @@ void Test_CF_CFDP_ResetTransaction_CallTo_OS_ObjectIdDefined_Returns_false_And_t
     arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     /* Arrange for CF_CFDP_GetClass */
-    arg_t->flags.all.q_index =
-        CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures ti->flags.all.q_index!=CF_Q_FREE is never false */
+    arg_t->flags.com.q_index =
+        CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     /* Act */
     CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8518,8 +8518,8 @@ void Test_CF_CFDP_ResetTransaction_AssertsBecause_t_history_dir_IsNeither_CF_DIR
     // arg_t->fd = 0; /* arg_t->fd = 0 causes OS_ObjectIdDefined (0 != 0) to return false */
 
     // /* Arrange for CF_CFDP_GetClass */
-    // arg_t->flags.all.q_index = CF_Q_PEND; /* arg_t->flags.all.q_index = CF_Q_PEND ensures
-    // ti->flags.all.q_index!=CF_Q_FREE is never false */
+    // arg_t->flags.com.q_index = CF_Q_PEND; /* arg_t->flags.com.q_index = CF_Q_PEND ensures
+    // ti->flags.com.q_index!=CF_Q_FREE is never false */
 
     // /* Act */
     // CF_CFDP_ResetTransaction(arg_t, arg_keep_history);
@@ -8685,7 +8685,7 @@ void Test_CF_CFDP_CancelTransaction_DoesNothingBecause_flags_all_cancelled_IsAlr
     transaction_t *context_CF_CFDP_R_Cancel;
     transaction_t *context_CF_CFDP_S_Cancel;
 
-    arg_t->flags.all.canceled = 1; /* 1 = true */
+    arg_t->flags.com.canceled = 1; /* 1 = true */
 
     UT_SetDataBuffer(UT_KEY(CF_CFDP_R_Cancel), &context_CF_CFDP_R_Cancel, sizeof(context_CF_CFDP_R_Cancel), false);
     UT_SetDataBuffer(UT_KEY(CF_CFDP_S_Cancel), &context_CF_CFDP_S_Cancel, sizeof(context_CF_CFDP_S_Cancel), false);
@@ -8696,8 +8696,8 @@ void Test_CF_CFDP_CancelTransaction_DoesNothingBecause_flags_all_cancelled_IsAlr
     /* Assert */
     UtAssert_STUB_COUNT(CF_CFDP_R_Cancel, 0);
     UtAssert_STUB_COUNT(CF_CFDP_S_Cancel, 0);
-    UtAssert_True(arg_t->flags.all.canceled == 1, "t->flags.all.canceled is %d and should not have changed from 1",
-                  arg_t->flags.all.canceled);
+    UtAssert_True(arg_t->flags.com.canceled == 1, "t->flags.com.canceled is %d and should not have changed from 1",
+                  arg_t->flags.com.canceled);
 
 } /* end Test_CF_CFDP_CancelTransaction_DoesNothingBecause_flags_all_cancelled_IsAlreadyTrue */
 
@@ -8709,7 +8709,7 @@ void Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesT
     transaction_t *arg_t = &dummy_t;
     transaction_t *context_CF_CFDP_S_Cancel;
 
-    arg_t->flags.all.canceled = 0; /* 0 = false */
+    arg_t->flags.com.canceled = 0; /* 0 = false */
     arg_t->history            = &dummy_history;
 
     UT_SetDataBuffer(UT_KEY(CF_CFDP_S_Cancel), &context_CF_CFDP_S_Cancel, sizeof(context_CF_CFDP_S_Cancel), false);
@@ -8717,7 +8717,7 @@ void Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesT
     /* Arrange unstubbable: CF_CFDP_IsSender */
     uint8 send_states[2] = {CFDP_S1, CFDP_S2};
 
-    arg_t->flags.all.q_index = Any_uint8_LessThan(CF_Q_FREE); /* removes CF_Q_NUM by design */
+    arg_t->flags.com.q_index = Any_uint8_LessThan(CF_Q_FREE); /* removes CF_Q_NUM by design */
     arg_t->state             = Any_uint8_FromThese(send_states, sizeof(send_states));
 
     /* Act */
@@ -8727,8 +8727,8 @@ void Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesT
     UtAssert_STUB_COUNT(CF_CFDP_R_Cancel, 0);
     UtAssert_STUB_COUNT(CF_CFDP_S_Cancel, 1);
     UtAssert_ADDRESS_EQ(context_CF_CFDP_S_Cancel, arg_t);
-    UtAssert_True(arg_t->flags.all.canceled == 1, "t->flags.all.canceled is %d and should not have changed from 1",
-                  arg_t->flags.all.canceled);
+    UtAssert_True(arg_t->flags.com.canceled == 1, "t->flags.com.canceled is %d and should not have changed from 1",
+                  arg_t->flags.com.canceled);
 
 } /* end Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesTransaction_t_When_t_IsSender */
 
@@ -8740,7 +8740,7 @@ void Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesT
     transaction_t *arg_t = &dummy_t;
     transaction_t *context_CF_CFDP_R_Cancel;
 
-    arg_t->flags.all.canceled = 0; /* 0 = false */
+    arg_t->flags.com.canceled = 0; /* 0 = false */
     arg_t->history            = &dummy_history;
 
     UT_SetDataBuffer(UT_KEY(CF_CFDP_R_Cancel), &context_CF_CFDP_R_Cancel, sizeof(context_CF_CFDP_R_Cancel), false);
@@ -8748,7 +8748,7 @@ void Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesT
     /* Arrange unstubbable: CF_CFDP_IsSender */
     uint8 non_send_states[2] = {CFDP_S1, CFDP_S2};
 
-    arg_t->flags.all.q_index = Any_uint8_LessThan(CF_Q_FREE); /* removes CF_Q_NUM by design */
+    arg_t->flags.com.q_index = Any_uint8_LessThan(CF_Q_FREE); /* removes CF_Q_NUM by design */
     arg_t->state             = Any_uint8_ExceptThese(non_send_states, sizeof(non_send_states));
 
     /* Act */
@@ -8758,8 +8758,8 @@ void Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesT
     UtAssert_STUB_COUNT(CF_CFDP_R_Cancel, 1);
     UtAssert_ADDRESS_EQ(context_CF_CFDP_R_Cancel, arg_t);
     UtAssert_STUB_COUNT(CF_CFDP_S_Cancel, 0);
-    UtAssert_True(arg_t->flags.all.canceled == 1, "t->flags.all.canceled is %d and should not have changed from 1",
-                  arg_t->flags.all.canceled);
+    UtAssert_True(arg_t->flags.com.canceled == 1, "t->flags.com.canceled is %d and should not have changed from 1",
+                  arg_t->flags.com.canceled);
 
 } /* end Test_CF_CFDP_CancelTransaction_Because_flags_all_canceled_IsFalse_CancelesTransaction_t_When_t_IsNotSender */
 

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -1605,7 +1605,7 @@ void Test_CF_DoSuspRes__Set_context_same_To_1_suspended_Eq_action(void)
     arg_context->same   = 0;
     arg_context->action = AnyCoinFlip();
 
-    arg_t->flags.all.suspended = arg_context->action;
+    arg_t->flags.com.suspended = arg_context->action;
 
     /* Act */
     CF_DoSuspRes_(arg_t, arg_context);
@@ -1628,15 +1628,15 @@ void Test_CF_DoSuspRes__When_suspended_NotEqTo_action_Set_suspended_To_action(vo
     arg_context->same   = 0;
     arg_context->action = AnyCoinFlip();
 
-    arg_t->flags.all.suspended = !arg_context->action;
+    arg_t->flags.com.suspended = !arg_context->action;
 
     /* Act */
     CF_DoSuspRes_(arg_t, arg_context);
 
     /* Assert */
-    UtAssert_True(arg_t->flags.all.suspended == arg_context->action,
-                  "CF_DoSuspRes_ set arg_t->flags.all.suspended to %d and should be %d (context->action)",
-                  arg_t->flags.all.suspended, arg_context->action);
+    UtAssert_True(arg_t->flags.com.suspended == arg_context->action,
+                  "CF_DoSuspRes_ set arg_t->flags.com.suspended to %d and should be %d (context->action)",
+                  arg_t->flags.com.suspended, arg_context->action);
 } /* end Test_CF_DoSuspRes__When_suspended_NotEqTo_action_Set_suspended_To_action */
 
 /*******************************************************************************
@@ -1668,7 +1668,7 @@ void Test_CF_DoSuspRes_CallTo_CF_TsnChanAction_Returns_0_And_args_same_WasChange
                      sizeof(context_CF_CFDP_FindTransactionBySequenceNumber), false);
 
     /* Arrange unstubbable: CF_DoSuspRes_ */
-    dummy_t->flags.all.suspended = arg_action;
+    dummy_t->flags.com.suspended = arg_action;
 
     /* Arrange unstubbable: CF_CmdRej */
     uint16 initial_hk_err_counter = Any_uint16();
@@ -1809,7 +1809,7 @@ void Test_CF_DoSuspRes_CallTo_CF_TsnChanAction_Returns_0_And_args_same_WasNotCha
                      sizeof(context_CF_TraverseAllTransactions_All_Channels), false);
 
     /* Arrange unstubbable: CF_DoSuspRes_ */
-    dummy_t->flags.all.suspended = arg_action;
+    dummy_t->flags.com.suspended = arg_action;
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -92,7 +92,7 @@ void Test_cf_dequeue_transaction_AssertsBecause_t_chan_num_LessThan_CF_NUM_CHANN
     // /* Arrange */
     // transaction_t   arg_t;
     // clist_node      *expected_qs =
-    //   &CF_AppData.engine.channels[arg_t.chan_num].qs[arg_t.flags.all.q_index];
+    //   &CF_AppData.engine.channels[arg_t.chan_num].qs[arg_t.flags.com.q_index];
     // uint8           dummy_chan_num =
     //   Any_uint8_GreaterThan_or_EqualTo(CF_NUM_CHANNELS);
 
@@ -116,7 +116,7 @@ void Test_cf_dequeue_transaction_AssertsBecause_q_size_Eq0(void)
 
     // /* Assert */
     // UtAssert_STUB_COUNT(CF_HandleAssert, 1);
-    UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert - CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.all.q_index]");
+    UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert - CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index]");
 } /* end Test_cf_dequeue_transaction_AssertsBecause_q_size_Eq0 */
 
 void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
@@ -132,15 +132,15 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
     UT_SetDataBuffer(UT_KEY(CF_CList_Remove), &context_clist_remove, sizeof(context_clist_remove), false);
 
     arg_t.chan_num   = dummy_chan_num;
-    expected_head    = &CF_AppData.engine.channels[arg_t.chan_num].qs[arg_t.flags.all.q_index];
+    expected_head    = &CF_AppData.engine.channels[arg_t.chan_num].qs[arg_t.flags.com.q_index];
     expected_cl_node = &arg_t.cl_node;
 
-    CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.all.q_index] = initial_q_size;
+    CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index] = initial_q_size;
 
     /* Act */
     cf_dequeue_transaction(&arg_t);
 
-    uint16 updated_q_size = CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.all.q_index];
+    uint16 updated_q_size = CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_HandleAssert, 0);
@@ -182,7 +182,7 @@ void Test_cf_move_transaction_AssertsBecause_channel_hk_Has_q_size_Eq0(void)
     // /* Act */
 
     // /* Assert */
-    UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert - CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.all.q_index]");
+    UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert - CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index]");
 } /* end Test_cf_move_transaction_AssertsBecause_channel_hk_Has_q_size_Eq0 */
 
 void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(void)
@@ -202,7 +202,7 @@ void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(
     CF_Clist_Remove_context_t context_clist_remove;
     UT_SetDataBuffer(UT_KEY(CF_CList_Remove), &context_clist_remove, sizeof(context_clist_remove), false);
 
-    expected_remove_head = &CF_AppData.engine.channels[arg_t->chan_num].qs[arg_t->flags.all.q_index];
+    expected_remove_head = &CF_AppData.engine.channels[arg_t->chan_num].qs[arg_t->flags.com.q_index];
     expected_remove_node = &arg_t->cl_node;
 
     CF_CList_InsertBack_context_t context_clist_insert_back;
@@ -212,7 +212,7 @@ void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(
     expected_insert_back_node = &arg_t->cl_node;
 
     /* after here must have chan_num set */
-    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.all.q_index] =
+    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] =
         Any_uint8_LessThanCeilingExcept(CF_Q_NUM + 1, 0);
 
     /* Act */
@@ -226,8 +226,8 @@ void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(
     UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);
     UtAssert_ADDRESS_EQ(context_clist_insert_back.head, expected_insert_back_head);
     UtAssert_ADDRESS_EQ(context_clist_insert_back.node, expected_insert_back_node);
-    UtAssert_True(arg_t->flags.all.q_index == arg_q,
-                  "t->flags.all.q_index set to %u and should equal passed in q value %u", arg_t->flags.all.q_index,
+    UtAssert_True(arg_t->flags.com.q_index == arg_q,
+                  "t->flags.com.q_index set to %u and should equal passed in q value %u", arg_t->flags.com.q_index,
                   arg_q);
 } /* end Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q */
 
@@ -825,8 +825,8 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_ind
     UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);
     UtAssert_ADDRESS_EQ(context_clist_insert_back.head, expected_insert_back_head);
     UtAssert_ADDRESS_EQ(context_clist_insert_back.node, expected_insert_back_node);
-    UtAssert_True(arg_t->flags.all.q_index == arg_q,
-                  "arg_t->flags.all.q_index set to %d and should be %d (cf_queue_index_t q)", arg_t->flags.all.q_index,
+    UtAssert_True(arg_t->flags.com.q_index == arg_q,
+                  "arg_t->flags.com.q_index set to %d and should be %d (cf_queue_index_t q)", arg_t->flags.com.q_index,
                   arg_q);
 } /* end Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_index_To_q */
 
@@ -884,8 +884,8 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(voi
     UtAssert_ADDRESS_EQ(context_CF_CList_InsertAfter.head, (clist_node *)expected_insert_after_head);
     UtAssert_ADDRESS_EQ(context_CF_CList_InsertAfter.start, (clist_node)expected_insert_after_start);
     UtAssert_ADDRESS_EQ(context_CF_CList_InsertAfter.after, (clist_node)expected_insert_after_after);
-    UtAssert_True(arg_t->flags.all.q_index == arg_q, "t->flags.all.q_index is %u and should be %u (q)",
-                  arg_t->flags.all.q_index, arg_q);
+    UtAssert_True(arg_t->flags.com.q_index == arg_q, "t->flags.com.q_index is %u and should be %u (q)",
+                  arg_t->flags.com.q_index, arg_q);
 
 } /* end Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q */
 
@@ -939,8 +939,8 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);
     UtAssert_ADDRESS_EQ(context_clist_insert_back.head, expected_insert_back_head);
     UtAssert_ADDRESS_EQ(context_clist_insert_back.node, expected_insert_back_node);
-    UtAssert_True(arg_t->flags.all.q_index == arg_q, "t->flags.all.q_index is %u and should be %u (q)",
-                  arg_t->flags.all.q_index, arg_q);
+    UtAssert_True(arg_t->flags.com.q_index == arg_q, "t->flags.com.q_index is %u and should be %u (q)",
+                  arg_t->flags.com.q_index, arg_q);
 
 } /* end Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex */
 


### PR DESCRIPTION
Bit field behavior is platform-specific, bits are not specified to be in any particular order. Furthermore, unions of bitfields are likely undefined behavior. 

This removes the bitfields and replaces with normal fields.

Fixes #67

NOTE: The cost of doing this is slightly larger data size.  I checked the size of the structure before and after to quantify this - the "flags" structure grew by 16 bytes on my dev system (x86-64, gcc 11.2).

The net result is that the memory footprint of the CF global grows by 1600 bytes (due to 100 transactions in default config).  However, this is partially mitigated by a slight reduction in code size, of approximately 300 bytes.  It probably runs faster too (although I did not quantify that - not as easy to test) but the 300 bytes of extra code were obviously being executed every time these flags were read/written, that adds up.