### PR TITLE
Fix #111, make dispatch tables and functions consistent

### DIFF
--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -335,6 +335,67 @@ typedef struct CF_Engine
     uint8  enabled;
 } CF_Engine_t;
 
+/**
+ * @brief A function for dispatching actions to a handler, without existing PDU data
+ *
+ * This allows quick delegation to handler functions using dispatch tables.  This version is
+ * used on the transmit side, where a PDU will likely be generated/sent by the handler being
+ * invoked.
+ *
+ * @param[inout] t  The transaction object
+ */
+typedef void (*CF_CFDP_StateSendFunc_t)(CF_Transaction_t *t);
+
+/**
+ * @brief A function for dispatching actions to a handler, with existing PDU data
+ *
+ * This allows quick delegation of PDUs to handler functions using dispatch tables.  This version is
+ * used on the receive side where a PDU buffer is associated with the activity, which is then
+ * interpreted by the handler being invoked.
+ *
+ * @param[inout] t  The transaction object
+ * @param[inout] ph The PDU buffer currently being received/processed
+ */
+typedef void (*CF_CFDP_StateRecvFunc_t)(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+
+/**
+ * @brief A table of receive handler functions based on file directive code
+ *
+ * For PDUs identified as a "file directive" type - generally anything other
+ * than file data - this provides a table to branch to a different handler
+ * function depending on the value of the file directive code.
+ */
+typedef struct
+{
+    /* a separate recv handler for each possible file directive PDU in this state */
+    CF_CFDP_StateRecvFunc_t fdirective[CF_CFDP_FileDirective_INVALID_MAX];
+} CF_CFDP_FileDirectiveDispatchTable_t;
+
+/**
+ * @brief A table of transmit handler functions based on transaction state
+ *
+ * This reflects the main dispatch table for the transmit side of a transaction.
+ * Each possible state has a corresponding function pointer in the table to implement
+ * the PDU transmit action(s) associated with that state.
+ */
+typedef struct
+{
+    CF_CFDP_StateSendFunc_t tx[CF_TxnState_INVALID];
+} CF_CFDP_TxnSendDispatchTable_t;
+
+/**
+ * @brief A table of receive handler functions based on transaction state
+ *
+ * This reflects the main dispatch table for the receive side of a transaction.
+ * Each possible state has a corresponding function pointer in the table to implement
+ * the PDU receive action(s) associated with that state.
+ */
+typedef struct
+{
+    /* a separate recv handler for each possible file directive PDU in this state */
+    CF_CFDP_StateRecvFunc_t rx[CF_TxnState_INVALID];
+} CF_CFDP_TxnRecvDispatchTable_t;
+
 /* NOTE: functions grouped together on contiguous lines are in groups that are described by
  * a simple comment at the top. Other comments below that apply to the whole group. */
 /* reset functions */
@@ -360,9 +421,8 @@ extern CF_CFDP_PduHeader_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *t
                                                        CF_EntityId_t src_eid, CF_EntityId_t dst_eid,
                                                        uint8 towards_sender, CF_TransactionSeq_t tsn, int silent);
 extern CF_SendRet_t         CF_CFDP_SendMd(CF_Transaction_t *t);
-extern CF_SendRet_t         CF_CFDP_SendFd(CF_Transaction_t *t, uint32 offset, int len);
-
-extern CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t);
+extern CF_SendRet_t         CF_CFDP_SendFd(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph, uint32 offset, int len);
+extern CF_SendRet_t         CF_CFDP_SendEof(CF_Transaction_t *t);
 /* NOTE: CF_CFDP_SendAck() takes a CF_TransactionSeq_t instead of getting it from transaction history because
  * of the special case where a FIN-ACK must be sent for an unknown transaction. It's better for
  * long term maintenance to not build an incomplete CF_History_t for it.
@@ -371,22 +431,22 @@ extern CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t 
                                     CF_CFDP_ConditionCode_t cc, CF_EntityId_t peer_eid, CF_TransactionSeq_t tsn);
 extern CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, CF_CFDP_FinFileStatus_t fs,
                                     CF_CFDP_ConditionCode_t cc);
-extern CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, int num_segment_requests);
+extern CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph, int num_segment_requests);
 
 /* PDU receive functions */
 /* returns 0 on success */
-extern int CF_CFDP_RecvMd(CF_Transaction_t *t);
-extern int CF_CFDP_RecvFd(CF_Transaction_t *t);
-extern int CF_CFDP_RecvEof(void);
-extern int CF_CFDP_RecvAck(void);
-extern int CF_CFDP_RecvFin(void);
-extern int CF_CFDP_RecvNak(int *num_segment_requests);
+extern int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph, int *num_segment_requests);
 
 /* Engine functional dispatch. These are all implemented in cf_cfdp_r.c or cf_cfdp_s.c */
-extern void CF_CFDP_S1_Recv(CF_Transaction_t *t);
-extern void CF_CFDP_R1_Recv(CF_Transaction_t *t);
-extern void CF_CFDP_S2_Recv(CF_Transaction_t *t);
-extern void CF_CFDP_R2_Recv(CF_Transaction_t *t);
+extern void CF_CFDP_S1_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern void CF_CFDP_R1_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern void CF_CFDP_S2_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
+extern void CF_CFDP_R2_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph);
 extern void CF_CFDP_S1_Tx(CF_Transaction_t *t);
 extern void CF_CFDP_S2_Tx(CF_Transaction_t *t);
 extern void CF_CFDP_R_Tick(CF_Transaction_t *t, int *cont);

--- a/fsw/src/cf_cfdp_helpers.c
+++ b/fsw/src/cf_cfdp_helpers.c
@@ -134,13 +134,12 @@ static int CF_GetEIDSize(const CF_CFDP_PduHeader_t *ph)
 
 /* get the variable length header items out of the PDU header and store as incoming data */
 /* in.msg must be valid PDU message */
-int CF_GetVariableHeader(void)
+int CF_GetVariableHeader(CF_CFDP_PduHeader_t *ph)
 {
-    CF_CFDP_PduHeader_t *ph    = &((CF_PduRecvMsg_t *)CF_AppData.engine.in.msg)->ph;
-    const int            eid_l = CF_GetEIDSize(ph);
-    const int            tsn_l = CF_GetTSNSize(ph);
-    int                  offs  = sizeof(*ph);
-    int                  ret   = -1;
+    const int eid_l = CF_GetEIDSize(ph);
+    const int tsn_l = CF_GetTSNSize(ph);
+    int       offs  = sizeof(*ph);
+    int       ret   = -1;
 
     if ((eid_l > 0) && (tsn_l > 0))
     {
@@ -155,14 +154,14 @@ int CF_GetVariableHeader(void)
     return ret;
 }
 
-void CF_SetVariableHeader(CF_EntityId_t src_eid, CF_EntityId_t dst_eid, CF_TransactionSeq_t tsn)
+void CF_SetVariableHeader(CF_CFDP_PduHeader_t *ph, CF_EntityId_t src_eid, CF_EntityId_t dst_eid,
+                          CF_TransactionSeq_t tsn)
 {
-    CF_CFDP_PduHeader_t *ph      = &((CF_PduSendMsg_t *)CF_AppData.engine.out.msg)->ph;
-    int                  offs    = sizeof(*ph);
-    const int            eid_s_l = CF_GetMemcpySize((uint8 *)&src_eid, sizeof(src_eid));
-    const int            eid_d_l = CF_GetMemcpySize((uint8 *)&dst_eid, sizeof(dst_eid));
-    const int            tsn_l   = CF_GetMemcpySize((uint8 *)&tsn, sizeof(tsn));
-    const int            csize   = ((eid_s_l > eid_d_l) ? eid_s_l : eid_d_l);
+    int       offs    = sizeof(*ph);
+    const int eid_s_l = CF_GetMemcpySize((uint8 *)&src_eid, sizeof(src_eid));
+    const int eid_d_l = CF_GetMemcpySize((uint8 *)&dst_eid, sizeof(dst_eid));
+    const int tsn_l   = CF_GetMemcpySize((uint8 *)&tsn, sizeof(tsn));
+    const int csize   = ((eid_s_l > eid_d_l) ? eid_s_l : eid_d_l);
 
     CF_MemcpyToBE(((uint8 *)ph) + offs, (uint8 *)&src_eid, sizeof(src_eid), csize);
     offs += csize;

--- a/fsw/src/cf_cfdp_pdu.h
+++ b/fsw/src/cf_cfdp_pdu.h
@@ -106,8 +106,9 @@ DECLARE_FIELD(CF_CFDP_PduHeader_LENGTHS_TRANSACTION_SEQUENCE, 3, 0)
 
 extern int  CF_GetMemcpySize(const uint8 *num, int size);
 extern void CF_MemcpyToBE(uint8 *dst, const uint8 *src, int src_size, int dst_size);
-extern int  CF_GetVariableHeader(void);
-extern void CF_SetVariableHeader(CF_EntityId_t src_eid, CF_EntityId_t dst_eid, CF_TransactionSeq_t tsn);
+extern int  CF_GetVariableHeader(CF_CFDP_PduHeader_t *ph);
+extern void CF_SetVariableHeader(CF_CFDP_PduHeader_t *ph, CF_EntityId_t src_eid, CF_EntityId_t dst_eid,
+                                 CF_TransactionSeq_t tsn);
 extern int  CF_HeaderSize(const CF_CFDP_PduHeader_t *ph);
 
 #define CF_MAX_HEADER_SIZE (sizeof(CF_CFDP_PduHeader_t) + (2 * sizeof(CF_EntityId_t)) + sizeof(CF_TransactionSeq_t))

--- a/unit-test/cf_cfdp_helpers_tests.c
+++ b/unit-test/cf_cfdp_helpers_tests.c
@@ -780,8 +780,6 @@ void Test_CF_GetVariableHeader_When_eid_l_AND_tsn_l_AreNotGreaterThan_0_DoesNotC
 
     memset(&dummy_ph, 0, sizeof(dummy_ph));
 
-    CF_AppData.engine.in.msg = &dummy_ph.cfe_sb_buffer;
-
     /* Arrange for CF_GetEIDSize */
     uint32 forced_return_FGV_from_EID = sizeof(CF_EntityId_t); /* unstubbable code adds +1 to this value */
 
@@ -795,7 +793,7 @@ void Test_CF_GetVariableHeader_When_eid_l_AND_tsn_l_AreNotGreaterThan_0_DoesNotC
                           forced_return_FGV_from_TSN); /* FGV + 1 > sizeof(CF_TransactionSeq_t) causes ret to be -1 */
 
     /* Act */
-    local_result = CF_GetVariableHeader();
+    local_result = CF_GetVariableHeader(&dummy_ph.pdu_r_msg.ph);
 
     /* Assert */
     UtAssert_True(local_result == -1, "CF_GetVariableHeader returned %d and should be -1 (fail)", local_result);
@@ -811,8 +809,6 @@ void Test_CF_GetVariableHeader_WhenOnly_eid_l_IsGreaterThan_0_DoesNotCallAnyMemC
 
     memset(&dummy_ph, 0, sizeof(dummy_ph));
 
-    CF_AppData.engine.in.msg = &dummy_ph.cfe_sb_buffer;
-
     /* Arrange for CF_GetEIDSize */
     uint32 forced_return_FGV_from_EID = sizeof(CF_EntityId_t) - 1; /* unstubbable code adds +1 to this value */
 
@@ -827,7 +823,7 @@ void Test_CF_GetVariableHeader_WhenOnly_eid_l_IsGreaterThan_0_DoesNotCallAnyMemC
                           forced_return_FGV_from_TSN); /* FGV + 1 > sizeof(CF_TransactionSeq_t) causes ret to be -1  */
 
     /* Act */
-    local_result = CF_GetVariableHeader();
+    local_result = CF_GetVariableHeader(&dummy_ph.pdu_r_msg.ph);
 
     /* Assert */
     UtAssert_True(local_result == -1, "CF_GetVariableHeader returned %d and should be -1 (fail)", local_result);
@@ -842,8 +838,6 @@ void Test_CF_GetVariableHeader_WhenOnly_tsn_l_IsGreaterThan_0_DoesNotCallAnyMemC
     int                  local_result;
 
     memset(&dummy_ph, 0, sizeof(dummy_ph));
-
-    CF_AppData.engine.in.msg = &dummy_ph.cfe_sb_buffer;
 
     /* Arrange for CF_GetEIDSize */
     uint32 forced_return_FGV_from_EID = sizeof(CF_EntityId_t); /* unstubbable code adds +1 to this value */
@@ -860,7 +854,7 @@ void Test_CF_GetVariableHeader_WhenOnly_tsn_l_IsGreaterThan_0_DoesNotCallAnyMemC
                                         sizeof(CF_TransactionSeq_t) causes ret to be sizeof(CF_TransactionSeq_t) */
 
     /* Act */
-    local_result = CF_GetVariableHeader();
+    local_result = CF_GetVariableHeader(&dummy_ph.pdu_r_msg.ph);
 
     /* Assert */
     UtAssert_True(local_result == -1, "CF_GetVariableHeader returned %d and should be -1 (fail)", local_result);
@@ -876,8 +870,6 @@ void Test_CF_GetVariableHeader_GetsAllThreeVariableLengthItemsOutOfHeaderAndRetu
 
     memset(&dummy_ph, 0, sizeof(dummy_ph));
 
-    CF_AppData.engine.in.msg = &dummy_ph.cfe_sb_buffer;
-
     /* Arrange for CF_GetEIDSize */
     uint32 forced_return_FGV_from_EID =
         Any_uint32_LessThan(sizeof(CF_EntityId_t)); /* unstubbable code adds +1 to this value */
@@ -891,7 +883,7 @@ void Test_CF_GetVariableHeader_GetsAllThreeVariableLengthItemsOutOfHeaderAndRetu
     UT_SetDeferredRetcode(UT_KEY(FGV), 1, forced_return_FGV_from_TSN); /* FGV + 1 <= sizeof(CF_TransactionSeq_t) */
 
     /* Act */
-    local_result = CF_GetVariableHeader();
+    local_result = CF_GetVariableHeader(&dummy_ph.pdu_r_msg.ph);
 
     /* Assert */
     UtAssert_True(local_result == 0, "CF_GetVariableHeader returned %d and should be 0 (success)", local_result);
@@ -917,10 +909,8 @@ void Test_CF_SetVariableHeader_Call_FSV_Twice(void)
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.out.msg = &dummy_msg.cfe_sb_buffer;
-
     /* Act */
-    CF_SetVariableHeader(arg_src_eid, arg_dst_eid, arg_tsn);
+    CF_SetVariableHeader(&dummy_msg.pdu_s_msg.ph, arg_src_eid, arg_dst_eid, arg_tsn);
 
     /* Assert */
     UtAssert_STUB_COUNT(FSV, 2);

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -21,7 +21,7 @@ uint8 Stub_FGV(uint8 source, CF_FIELD_FIELD name);
 **
 *******************************************************************************/
 
-static void Dummy_fd_fn(CF_Transaction_t *t, const CF_CFDP_PduHeader_t *pdu)
+static void Dummy_fd_fn(CF_Transaction_t *t, CF_CFDP_PduHeader_t *pdu)
 {
     UT_Stub_CopyFromLocal(UT_KEY(Dummy_fd_fn), &t, sizeof(t));
     UT_Stub_CopyFromLocal(UT_KEY(Dummy_fd_fn), &pdu, sizeof(pdu));
@@ -29,7 +29,7 @@ static void Dummy_fd_fn(CF_Transaction_t *t, const CF_CFDP_PduHeader_t *pdu)
     UT_DEFAULT_IMPL(Dummy_fd_fn);
 }
 
-static void Dummy_fns(CF_Transaction_t *t, const CF_CFDP_PduHeader_t *pdu)
+static void Dummy_fns(CF_Transaction_t *t, CF_CFDP_PduHeader_t *pdu)
 {
     UT_Stub_CopyFromLocal(UT_KEY(Dummy_fns), &t, sizeof(t));
     UT_Stub_CopyFromLocal(UT_KEY(Dummy_fns), &pdu, sizeof(pdu));
@@ -639,7 +639,6 @@ void Test_CF_CFDP_R_ProcessFd_NoCrcWhen_bytes_received_IsLessThan_size_of_pdu_fi
 
     memset(&dummy_ph, 0, sizeof(dummy_ph));
 
-    CF_AppData.engine.in.msg            = &dummy_ph.cfe_sb_buffer;
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), 0);
@@ -648,7 +647,7 @@ void Test_CF_CFDP_R_ProcessFd_NoCrcWhen_bytes_received_IsLessThan_size_of_pdu_fi
     arg_t->chan_num = Any_cf_chan_num();
 
     /* Act */
-    local_result = CF_CFDP_R_ProcessFd(arg_t, arg_bytes_received);
+    local_result = CF_CFDP_R_ProcessFd(arg_t, &dummy_ph.pdu_r_msg.ph, arg_bytes_received);
 
     /* Assert */
     UtAssert_True(local_result == -1, "CF_CFDP_R_ProcessFd returned %d and should be -1", local_result);
@@ -672,8 +671,6 @@ void Test_CF_CFDP_R_ProcessFd_HasCrcBut_bytes_received_Minus_4_IsLessThan_size_o
 
     memset(&dummy_ph, 0, sizeof(dummy_ph));
 
-    CF_AppData.engine.in.msg = &dummy_ph.cfe_sb_buffer;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), 0);
     UT_SetDefaultReturnValue(UT_KEY(FGV), 1);
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
@@ -681,7 +678,7 @@ void Test_CF_CFDP_R_ProcessFd_HasCrcBut_bytes_received_Minus_4_IsLessThan_size_o
     arg_t->chan_num = Any_cf_chan_num();
 
     /* Act */
-    local_result = CF_CFDP_R_ProcessFd(arg_t, arg_bytes_received);
+    local_result = CF_CFDP_R_ProcessFd(arg_t, &dummy_ph.pdu_r_msg.ph, arg_bytes_received);
 
     /* Assert */
     UtAssert_True(local_result == -1, "CF_CFDP_R_ProcessFd returned %d and should be -1", local_result);
@@ -709,7 +706,6 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_cached_pos_NotEqTo_offset_And_fret_NotEqTo_o
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg            = &dummy_msg.cfe_sb_buffer;
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), sizeof(CF_CFDP_PduHeader_t));
@@ -725,7 +721,7 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_cached_pos_NotEqTo_offset_And_fret_NotEqTo_o
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.file_seek = initial_fault_file_seek;
 
     /* Act */
-    local_result = CF_CFDP_R_ProcessFd(arg_t, arg_bytes_received);
+    local_result = CF_CFDP_R_ProcessFd(arg_t, &dummy_msg.pdu_r_msg.ph, arg_bytes_received);
 
     /* Assert */
     UtAssert_True(local_result == -1, "CF_CFDP_R_ProcessFd returned %d and should be -1", local_result);
@@ -759,7 +755,6 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_fret_NotEqTo_bytes_received_Value_SendEventS
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg            = &dummy_msg.cfe_sb_buffer;
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), sizeof(CF_CFDP_PduHeader_t));
@@ -775,7 +770,7 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_fret_NotEqTo_bytes_received_Value_SendEventS
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.fault.file_write = initial_fault_file_write;
 
     /* Act */
-    local_result = CF_CFDP_R_ProcessFd(arg_t, arg_bytes_received);
+    local_result = CF_CFDP_R_ProcessFd(arg_t, &dummy_msg.pdu_r_msg.ph, arg_bytes_received);
 
     /* Assert */
     UtAssert_True(local_result == -1, "CF_CFDP_R_ProcessFd returned %d and should be -1", local_result);
@@ -813,7 +808,6 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_cached_pos_Gets_bytes_received_Plus_offset_A
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg            = &dummy_msg.cfe_sb_buffer;
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), sizeof(CF_CFDP_PduHeader_t));
@@ -829,7 +823,7 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_cached_pos_Gets_bytes_received_Plus_offset_A
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.recv.file_data_bytes = initial_file_data_bytes;
 
     /* Act */
-    local_result = CF_CFDP_R_ProcessFd(arg_t, arg_bytes_received);
+    local_result = CF_CFDP_R_ProcessFd(arg_t, &dummy_msg.pdu_r_msg.ph, arg_bytes_received);
 
     /* Assert */
     UtAssert_True(local_result == 0, "CF_CFDP_R_ProcessFd returned %d and should be 0", local_result);
@@ -872,7 +866,6 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_cached_pos_NotEqTo_offset_But_fret_IsEqTo_of
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg            = &dummy_msg.cfe_sb_buffer;
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), sizeof(CF_CFDP_PduHeader_t));
@@ -890,7 +883,7 @@ void Test_CF_CFDP_R_ProcessFd_NoCrc_cached_pos_NotEqTo_offset_But_fret_IsEqTo_of
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.recv.file_data_bytes = initial_file_data_bytes;
 
     /* Act */
-    local_result = CF_CFDP_R_ProcessFd(arg_t, arg_bytes_received);
+    local_result = CF_CFDP_R_ProcessFd(arg_t, &dummy_msg.pdu_r_msg.ph, arg_bytes_received);
 
     /* Assert */
     UtAssert_True(local_result == 0, "CF_CFDP_R_ProcessFd returned %d and should be 0", local_result);
@@ -1388,13 +1381,17 @@ void Test_CF_CFDP_R1_SubstateRecvFileData_CallTo_CF_CFDP_RecvFd_Returns_0_CallTo
     void)
 {
     /* Arrange */
-    CF_Transaction_t    *arg_t                        = NULL;
-    CF_CFDP_PduHeader_t *arg_ph                       = NULL;
+    CF_UT_inmsg_buffer_t dummy_msg;
+    CF_Transaction_t    *arg_t = NULL;
+    CF_CFDP_PduHeader_t *arg_ph;
     int                  forced_return_CF_CFDP_RecvFd = 0;
 
     UT_SetHandlerFunction(UT_KEY(CF_CFDP_RecvFd), Handler_int_ForcedReturnOnly, &forced_return_CF_CFDP_RecvFd);
 
     /* Arrange for CF_CFDP_R_ProcessFd */
+    memset(&dummy_msg, 0, sizeof(dummy_msg));
+
+    arg_ph                              = &dummy_msg.pdu_r_msg.ph;
     CF_AppData.engine.in.bytes_received = 0; /* 0 = recv dropped */
 
     /* Arrange for CF_CFDP_R2_Reset */
@@ -1420,8 +1417,8 @@ void Test_CF_CFDP_R1_SubstateRecvFileData_CallTo_CF_CFDP_RecvFd_Returns_0_CallTo
     void)
 {
     /* Arrange */
-    CF_Transaction_t    *arg_t                        = NULL;
-    CF_CFDP_PduHeader_t *arg_ph                       = NULL;
+    CF_Transaction_t    *arg_t = NULL;
+    CF_CFDP_PduHeader_t *arg_ph;
     int                  forced_return_CF_CFDP_RecvFd = 0;
 
     UT_SetHandlerFunction(UT_KEY(CF_CFDP_RecvFd), Handler_int_ForcedReturnOnly, &forced_return_CF_CFDP_RecvFd);
@@ -1442,7 +1439,7 @@ void Test_CF_CFDP_R1_SubstateRecvFileData_CallTo_CF_CFDP_RecvFd_Returns_0_CallTo
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
+    arg_ph = &dummy_msg.pdu_r_msg.ph;
 
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
@@ -1486,17 +1483,22 @@ void Test_CF_CFDP_R1_SubstateRecvFileData_CallTo_CF_CFDP_RecvFd_Returns_0_CallTo
 void Test_CF_CFDP_R2_SubstateRecvFileData_CallTo_CF_CFDP_RecvFd_Returns_non0_Call_CF_CFDP_R2_Reset(void)
 {
     /* Arrange */
-    CF_Transaction_t    *arg_t                        = NULL;
-    CF_CFDP_PduHeader_t *arg_ph                       = NULL;
+    CF_Transaction_t    *arg_t = NULL;
+    CF_CFDP_PduHeader_t *arg_ph;
+    CF_UT_inmsg_buffer_t dummy_msg;
     int                  forced_return_CF_CFDP_RecvFd = Any_int_Except(0);
 
     UT_SetHandlerFunction(UT_KEY(CF_CFDP_RecvFd), Handler_int_ForcedReturnOnly, &forced_return_CF_CFDP_RecvFd);
+
+    memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     /* Arrange for CF_CFDP_R2_Reset */
     CF_Transaction_t dummy_t;
 
     arg_t                         = &dummy_t;
     arg_t->state_data.r.sub_state = Any_uint8_Except(CF_RxSubState_WAIT_FOR_FIN_ACK);
+
+    arg_ph = &dummy_msg.pdu_r_msg.ph;
 
     /* Act */
     CF_CFDP_R2_SubstateRecvFileData(arg_t, arg_ph);
@@ -1514,13 +1516,17 @@ void Test_CF_CFDP_R2_SubstateRecvFileData_CallTo_CF_CFDP_RecvFd_Returns_0_CallTo
     void)
 {
     /* Arrange */
-    CF_Transaction_t    *arg_t                        = NULL;
-    CF_CFDP_PduHeader_t *arg_ph                       = NULL;
+    CF_Transaction_t    *arg_t  = NULL;
+    CF_CFDP_PduHeader_t *arg_ph = NULL;
+    CF_UT_inmsg_buffer_t dummy_msg;
     int                  forced_return_CF_CFDP_RecvFd = 0;
 
     UT_SetHandlerFunction(UT_KEY(CF_CFDP_RecvFd), Handler_int_ForcedReturnOnly, &forced_return_CF_CFDP_RecvFd);
 
+    memset(&dummy_msg, 0, sizeof(dummy_msg));
+
     /* Arrange for CF_CFDP_R_ProcessFd */
+    arg_ph                              = &dummy_msg.pdu_r_msg.ph;
     CF_AppData.engine.in.bytes_received = 0; /* 0 = recv dropped */
 
     /* Arrange for CF_CFDP_R2_Reset */
@@ -1549,8 +1555,7 @@ void Test_CF_CFDP_R2_SubstateRecvFileData_t_flags_rx_fd_nak_sent_Is_0_And_t_flag
     /* Arrange */
     CF_Transaction_t     dummy_t;
     CF_Transaction_t    *arg_t = &dummy_t;
-    CF_CFDP_PduHeader_t  dummy_arg_ph;
-    CF_CFDP_PduHeader_t *arg_ph                       = &dummy_arg_ph;
+    CF_CFDP_PduHeader_t *arg_ph;
     int                  forced_return_CF_CFDP_RecvFd = 0;
 
     UT_SetHandlerFunction(UT_KEY(CF_CFDP_RecvFd), Handler_int_ForcedReturnOnly, &forced_return_CF_CFDP_RecvFd);
@@ -1576,7 +1581,7 @@ void Test_CF_CFDP_R2_SubstateRecvFileData_t_flags_rx_fd_nak_sent_Is_0_And_t_flag
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
+    arg_ph = &dummy_msg.pdu_r_msg.ph;
 
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
@@ -1614,8 +1619,7 @@ void Test_CF_CFDP_R2_SubstateRecvFileData_t_flags_rx_fd_nak_sent_Is_1_Call_CF_CF
     /* Arrange */
     CF_Transaction_t     dummy_t;
     CF_Transaction_t    *arg_t = &dummy_t;
-    CF_CFDP_PduHeader_t  dummy_arg_ph;
-    CF_CFDP_PduHeader_t *arg_ph                       = &dummy_arg_ph;
+    CF_CFDP_PduHeader_t *arg_ph;
     int                  forced_return_CF_CFDP_RecvFd = 0;
 
     UT_SetHandlerFunction(UT_KEY(CF_CFDP_RecvFd), Handler_int_ForcedReturnOnly, &forced_return_CF_CFDP_RecvFd);
@@ -1641,7 +1645,7 @@ void Test_CF_CFDP_R2_SubstateRecvFileData_t_flags_rx_fd_nak_sent_Is_1_Call_CF_CF
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
+    arg_ph = &dummy_msg.pdu_r_msg.ph;
 
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
@@ -1682,8 +1686,7 @@ void Test_CF_CFDP_R2_SubstateRecvFileData_t_flags_rx_fd_nak_sent_Is_0_And_t_flag
     /* Arrange */
     CF_Transaction_t     dummy_t;
     CF_Transaction_t    *arg_t = &dummy_t;
-    CF_CFDP_PduHeader_t  dummy_arg_ph;
-    CF_CFDP_PduHeader_t *arg_ph                       = &dummy_arg_ph;
+    CF_CFDP_PduHeader_t *arg_ph;
     int                  forced_return_CF_CFDP_RecvFd = 0;
 
     UT_SetHandlerFunction(UT_KEY(CF_CFDP_RecvFd), Handler_int_ForcedReturnOnly, &forced_return_CF_CFDP_RecvFd);
@@ -1709,7 +1712,7 @@ void Test_CF_CFDP_R2_SubstateRecvFileData_t_flags_rx_fd_nak_sent_Is_0_And_t_flag
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
+    arg_ph = &dummy_msg.pdu_r_msg.ph;
 
     CF_AppData.engine.in.bytes_received = initial_bytes_received;
 
@@ -2877,11 +2880,11 @@ void Test_CF_CFDP_R2_SubstateSendFin_CallTo_CF_CFDP_R2_CalcCrcChunk_Returns_0_Gi
 void Test_CF_CFDP_R2_Recv_fin_ack_GetsInvalidFinAckFrom_CF_CFDP_RecvAck_SendEventAndIncrement_recv_error(void)
 {
     /* Arrange */
-    CF_History_t               dummy_history;
-    CF_Transaction_t           dummy_t;
-    CF_Transaction_t          *arg_t              = &dummy_t;
-    const CF_CFDP_PduHeader_t *arg_pdu            = NULL;
-    uint32                     initial_recv_error = Any_uint32();
+    CF_History_t         dummy_history;
+    CF_Transaction_t     dummy_t;
+    CF_Transaction_t    *arg_t              = &dummy_t;
+    CF_CFDP_PduHeader_t *arg_pdu            = NULL;
+    uint32               initial_recv_error = Any_uint32();
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_RecvAck), -1); /* -1 indicates error from CF_CFDP_RecvAck */
 
@@ -2907,11 +2910,11 @@ void Test_CF_CFDP_R2_Recv_fin_ack_GetsInvalidFinAckFrom_CF_CFDP_RecvAck_SendEven
 void Test_CF_CFDP_R2_Recv_fin_ack_GetsValidFinAckFrom_CF_CFDP_RecvAck_Calls_CFDP_R2_Reset(void)
 {
     /* Arrange */
-    CF_History_t               dummy_history;
-    CF_Transaction_t           dummy_t;
-    CF_Transaction_t          *arg_t              = &dummy_t;
-    const CF_CFDP_PduHeader_t *arg_pdu            = NULL;
-    uint32                     initial_recv_error = Any_uint32();
+    CF_History_t         dummy_history;
+    CF_Transaction_t     dummy_t;
+    CF_Transaction_t    *arg_t              = &dummy_t;
+    CF_CFDP_PduHeader_t *arg_pdu            = NULL;
+    uint32               initial_recv_error = Any_uint32();
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_RecvAck), 0); /* 0 indicates success from CF_CFDP_RecvAck */
 
@@ -3271,19 +3274,17 @@ void Test_CFDP_R_DispatchRecv_AssertsBecause_msg_in_Is_NULL(void)
 void Test_CFDP_R_DispatchRecv_FlagsAreSetTo_PDU_HDR_FLAGS_TYPE_And_cc_DoesNotEq_CC_NO_ERROR_Increment_dropped(void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_History_t         dummy_history;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t = &dummy_t;
-    static void (*const arg_fns[CF_RxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(
-        CF_Transaction_t * t, const CF_CFDP_PduHeader_t *)                   = {{NULL}};
-    void (*const arg_fd_fn)(CF_Transaction_t *, const CF_CFDP_PduHeader_t *) = {NULL};
-    uint16 initial_dropped                                                   = Any_uint16();
+    CF_UT_inmsg_buffer_t                     dummy_msg;
+    CF_History_t                             dummy_history;
+    CF_Transaction_t                         dummy_t;
+    CF_Transaction_t                        *arg_t           = &dummy_t;
+    static CF_CFDP_R_SubstateDispatchTable_t arg_fns         = {{NULL}};
+    CF_CFDP_StateRecvFunc_t                  arg_fd_fn       = {NULL};
+    uint16                                   initial_dropped = Any_uint16();
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
-    CF_AppData.engine.in.msg      = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 1);
 
@@ -3294,7 +3295,7 @@ void Test_CFDP_R_DispatchRecv_FlagsAreSetTo_PDU_HDR_FLAGS_TYPE_And_cc_DoesNotEq_
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.recv.dropped = initial_dropped;
 
     /* Act */
-    CF_CFDP_R_DispatchRecv(arg_t, arg_fns, arg_fd_fn);
+    CF_CFDP_R_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns, arg_fd_fn);
 
     /* Assert */
     UtAssert_STUB_COUNT(FGV, 1);
@@ -3307,20 +3308,18 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreSetTo_PDU_HDR_FLAGS_TYPE_And_cc
     void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_CFDP_PduHeader_t *dummy_ph = &dummy_msg.pdu_r_msg.ph;
-    CF_History_t         dummy_history;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t = &dummy_t;
-    static void (*const arg_fns[CF_RxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(
-        CF_Transaction_t * t, const CF_CFDP_PduHeader_t *)                   = {{NULL}};
-    void (*const arg_fd_fn)(CF_Transaction_t *, const CF_CFDP_PduHeader_t *) = Dummy_fd_fn;
-    Dummy_fd_fn_context_t context_Dummy_fd_fn;
+    CF_UT_inmsg_buffer_t                     dummy_msg;
+    CF_CFDP_PduHeader_t                     *dummy_ph = &dummy_msg.pdu_r_msg.ph;
+    CF_History_t                             dummy_history;
+    CF_Transaction_t                         dummy_t;
+    CF_Transaction_t                        *arg_t     = &dummy_t;
+    static CF_CFDP_R_SubstateDispatchTable_t arg_fns   = {{NULL}};
+    CF_CFDP_StateRecvFunc_t                  arg_fd_fn = Dummy_fd_fn;
+    Dummy_fd_fn_context_t                    context_Dummy_fd_fn;
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
-    CF_AppData.engine.in.msg      = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 1);
 
@@ -3330,7 +3329,7 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreSetTo_PDU_HDR_FLAGS_TYPE_And_cc
     UT_SetDataBuffer(UT_KEY(Dummy_fd_fn), &context_Dummy_fd_fn, sizeof(context_Dummy_fd_fn), false);
 
     /* Act */
-    CF_CFDP_R_DispatchRecv(arg_t, arg_fns, arg_fd_fn);
+    CF_CFDP_R_DispatchRecv(arg_t, dummy_ph, &arg_fns, arg_fd_fn);
 
     /* Assert */
     UtAssert_STUB_COUNT(FGV, 1);
@@ -3345,19 +3344,17 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreNotSetAnd_directive_code_IsEqTo
     void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_History_t         dummy_history;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t = &dummy_t;
-    static void (*const arg_fns[CF_RxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(
-        CF_Transaction_t * t, const CF_CFDP_PduHeader_t *)                   = {{NULL}};
-    void (*const arg_fd_fn)(CF_Transaction_t *, const CF_CFDP_PduHeader_t *) = Dummy_fd_fn;
-    uint16 initial_spurious                                                  = Any_uint16();
+    CF_UT_inmsg_buffer_t                     dummy_msg;
+    CF_History_t                             dummy_history;
+    CF_Transaction_t                         dummy_t;
+    CF_Transaction_t                        *arg_t            = &dummy_t;
+    static CF_CFDP_R_SubstateDispatchTable_t arg_fns          = {{NULL}};
+    CF_CFDP_StateRecvFunc_t                  arg_fd_fn        = Dummy_fd_fn;
+    uint16                                   initial_spurious = Any_uint16();
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
-    CF_AppData.engine.in.msg      = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
@@ -3370,7 +3367,7 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreNotSetAnd_directive_code_IsEqTo
     arg_t->history = &dummy_history;
 
     /* Act */
-    CF_CFDP_R_DispatchRecv(arg_t, arg_fns, arg_fd_fn);
+    CF_CFDP_R_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns, arg_fd_fn);
 
     /* Assert */
     UtAssert_True(CF_AppData.hk.channel_hk[arg_t->chan_num].counters.recv.spurious == (uint16)(initial_spurious + 1),
@@ -3388,19 +3385,17 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreNotSetAnd_directive_code_IsGrea
     void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_History_t         dummy_history;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t = &dummy_t;
-    static void (*const arg_fns[CF_RxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(
-        CF_Transaction_t * t, const CF_CFDP_PduHeader_t *)                   = {{NULL}};
-    void (*const arg_fd_fn)(CF_Transaction_t *, const CF_CFDP_PduHeader_t *) = Dummy_fd_fn;
-    uint16 initial_spurious                                                  = Any_uint16();
+    CF_UT_inmsg_buffer_t                     dummy_msg;
+    CF_History_t                             dummy_history;
+    CF_Transaction_t                         dummy_t;
+    CF_Transaction_t                        *arg_t            = &dummy_t;
+    static CF_CFDP_R_SubstateDispatchTable_t arg_fns          = {{NULL}};
+    CF_CFDP_StateRecvFunc_t                  arg_fd_fn        = Dummy_fd_fn;
+    uint16                                   initial_spurious = Any_uint16();
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
-    CF_AppData.engine.in.msg      = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
@@ -3414,7 +3409,7 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreNotSetAnd_directive_code_IsGrea
     arg_t->history = &dummy_history;
 
     /* Act */
-    CF_CFDP_R_DispatchRecv(arg_t, arg_fns, arg_fd_fn);
+    CF_CFDP_R_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns, arg_fd_fn);
 
     /* Assert */
     UtAssert_True(CF_AppData.hk.channel_hk[arg_t->chan_num].counters.recv.spurious == (uint16)(initial_spurious + 1),
@@ -3432,19 +3427,17 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreNotSetAnd_directive_code_IsLess
     void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t = &dummy_t;
-    static void (*const arg_fns[CF_RxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(
-        CF_Transaction_t * t, const CF_CFDP_PduHeader_t *)                   = {{NULL}};
-    void (*const arg_fd_fn)(CF_Transaction_t *, const CF_CFDP_PduHeader_t *) = Dummy_fd_fn;
-    uint16 initial_dropped                                                   = Any_uint16();
-    uint16 initial_spurious                                                  = Any_uint16();
+    CF_UT_inmsg_buffer_t                     dummy_msg;
+    CF_Transaction_t                         dummy_t;
+    CF_Transaction_t                        *arg_t            = &dummy_t;
+    static CF_CFDP_R_SubstateDispatchTable_t arg_fns          = {{NULL}};
+    CF_CFDP_StateRecvFunc_t                  arg_fd_fn        = Dummy_fd_fn;
+    uint16                                   initial_dropped  = Any_uint16();
+    uint16                                   initial_spurious = Any_uint16();
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
-    CF_AppData.engine.in.msg      = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), sizeof(CF_CFDP_PduHeader_t));
@@ -3456,7 +3449,7 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreNotSetAnd_directive_code_IsLess
     CF_AppData.hk.channel_hk[arg_t->chan_num].counters.recv.spurious = initial_spurious;
 
     /* Act */
-    CF_CFDP_R_DispatchRecv(arg_t, arg_fns, arg_fd_fn);
+    CF_CFDP_R_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns, arg_fd_fn);
 
     /* Assert */
     UtAssert_True(CF_AppData.hk.channel_hk[arg_t->chan_num].counters.recv.dropped == initial_dropped,
@@ -3474,34 +3467,34 @@ void Test_CFDP_RTest_CFDP_R_DispatchRecv_FlagsAreNotSetAnd_directive_code_IsLess
     void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t = &dummy_t;
-    void (*const arg_fns[CF_RxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(CF_Transaction_t * t,
-                                                                                       const CF_CFDP_PduHeader_t *);
-    void (*const arg_fd_fn)(CF_Transaction_t *, const CF_CFDP_PduHeader_t *) = Dummy_fd_fn;
-    CF_RxSubState_t dummy_state          = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
-    uint8           dummy_directive_code = Any_uint8_LessThan(CF_CFDP_FileDirective_INVALID_MAX);
-    void (*const fns_pointer)(CF_Transaction_t * t, const CF_CFDP_PduHeader_t *pdu) = Dummy_fns;
-    Dummy_fns_context_t context_Dummy_fns;
+    CF_UT_inmsg_buffer_t                 dummy_msg;
+    CF_Transaction_t                     dummy_t;
+    CF_Transaction_t                    *arg_t                = &dummy_t;
+    CF_CFDP_R_SubstateDispatchTable_t    arg_fns              = {{NULL}};
+    CF_CFDP_FileDirectiveDispatchTable_t fd_fns               = {NULL};
+    CF_CFDP_StateRecvFunc_t              arg_fd_fn            = Dummy_fd_fn;
+    CF_RxSubState_t                      dummy_state          = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
+    uint8                                dummy_directive_code = Any_uint8_LessThan(CF_CFDP_FileDirective_INVALID_MAX);
+    CF_CFDP_StateRecvFunc_t              fns_pointer          = Dummy_fns;
+    Dummy_fns_context_t                  context_Dummy_fns;
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(CF_RxSubState_NUM_STATES);
-    CF_AppData.engine.in.msg      = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
     UT_SetDefaultReturnValue(UT_KEY(CF_HeaderSize), sizeof(CF_CFDP_PduHeader_t));
     dummy_msg.content.cfdp.secondary.fdirh.directive_code = dummy_directive_code;
 
-    arg_t->state_data.r.sub_state = dummy_state;
-    memcpy((void *)&arg_fns[dummy_state][dummy_directive_code], &fns_pointer, sizeof(void *));
+    arg_t->state_data.r.sub_state           = dummy_state;
+    arg_fns.state[dummy_state]              = &fd_fns;
+    fd_fns.fdirective[dummy_directive_code] = fns_pointer;
 
     UT_SetDataBuffer(UT_KEY(Dummy_fns), &context_Dummy_fns, sizeof(context_Dummy_fns), false);
 
     /* Act */
-    CF_CFDP_R_DispatchRecv(arg_t, arg_fns, arg_fd_fn);
+    CF_CFDP_R_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns, arg_fd_fn);
 
     /* Assert */
     UtAssert_STUB_COUNT(Dummy_fns, 1);
@@ -3537,7 +3530,6 @@ void Test_CF_CFDP_R1_Recv_Runs(void)
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(
         CF_RxSubState_NUM_STATES); /* Any_uint8_LessThan used because small size of CF_RxSubState_NUM_STATES*/
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
 
     arg_t->history = &dummy_history;
     arg_t->history->cc =
@@ -3550,7 +3542,7 @@ void Test_CF_CFDP_R1_Recv_Runs(void)
     UT_SetDefaultReturnValue(UT_KEY(FGV), 1); /* 1 force else */
 
     /* Act */
-    CF_CFDP_R1_Recv(arg_t);
+    CF_CFDP_R1_Recv(arg_t, &dummy_msg.pdu_r_msg.ph);
 
     /* Assert */
     /* Assert for CF_CFDP_R_DispatchRecv */
@@ -3586,7 +3578,6 @@ void Test_CF_CFDP_R2_Recv_Runs(void)
 
     arg_t->state_data.r.sub_state = Any_uint8_LessThan(
         CF_RxSubState_NUM_STATES); /* Any_uint8_LessThan used because small size of CF_RxSubState_NUM_STATES*/
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
 
     arg_t->history = &dummy_history;
     arg_t->history->cc =
@@ -3599,7 +3590,7 @@ void Test_CF_CFDP_R2_Recv_Runs(void)
     UT_SetDefaultReturnValue(UT_KEY(FGV), 1); /* 1 force else */
 
     /* Act */
-    CF_CFDP_R2_Recv(arg_t);
+    CF_CFDP_R2_Recv(arg_t, &dummy_msg.pdu_r_msg.ph);
 
     /* Assert */
     /* Assert for CF_CFDP_R_DispatchRecv */

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -70,7 +70,7 @@ void Dummy_fns_CF_CFDP_S_DispatchRecv(CF_Transaction_t* t, const CF_CFDP_PduHead
     UT_GenStub_Execute(Stub_FGV, Basic, NULL);
 } */
 
-void Dummy_fns_CF_CFDP_S_DispatchRecv(CF_Transaction_t *t, const CF_CFDP_PduHeader_t *pdu)
+void Dummy_fns_CF_CFDP_S_DispatchRecv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *pdu)
 {
     UT_Stub_CopyFromLocal(UT_KEY(Dummy_fns_CF_CFDP_S_DispatchRecv), &t, sizeof(t));
     UT_Stub_CopyFromLocal(UT_KEY(Dummy_fns_CF_CFDP_S_DispatchRecv), &pdu, sizeof(pdu));
@@ -2067,8 +2067,8 @@ void Test_CF_CFDP_S2_EarlyFin_SendEventAndCallReset(void)
     CF_History_t                dummy_history;
     CF_Transaction_t            dummy_t;
     CF_Transaction_t           *arg_t = &dummy_t;
-    const CF_CFDP_PduHeader_t   dummy_ph;
-    const CF_CFDP_PduHeader_t  *arg_ph        = &dummy_ph;
+    CF_CFDP_PduHeader_t         dummy_ph;
+    CF_CFDP_PduHeader_t        *arg_ph        = &dummy_ph;
     const char                 *expected_Spec = "CF S%d(%u:%u): got early fin -- cancelling";
     CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
 
@@ -2115,12 +2115,12 @@ void Test_CF_CFDP_S2_EarlyFin_SendEventAndCallReset(void)
 void Test_CF_CFDP_S2_Fin_When_CF_CFDP_RecvFin_Returns_0_Set_fin_cc_And_sub_state(void)
 {
     /* Arrange */
-    CF_Transaction_t           dummy_t;
-    CF_Transaction_t          *arg_t       = &dummy_t;
-    uint8                      dummy_flags = Any_uint8();
-    const CF_CFDP_PduHeader_t  dummy_ph;
-    const CF_CFDP_PduHeader_t *arg_ph;
-    uint8                      expected_fin_cc = FGV(dummy_flags, CF_CFDP_PduFin_FLAGS_CC);
+    CF_Transaction_t     dummy_t;
+    CF_Transaction_t    *arg_t       = &dummy_t;
+    uint8                dummy_flags = Any_uint8();
+    CF_CFDP_PduHeader_t  dummy_ph;
+    CF_CFDP_PduHeader_t *arg_ph;
+    uint8                expected_fin_cc = FGV(dummy_flags, CF_CFDP_PduFin_FLAGS_CC);
 
     memcpy((void *)&dummy_ph.flags, &dummy_flags, 1);
     arg_ph = &dummy_ph;
@@ -2148,8 +2148,8 @@ void Test_CF_CFDP_S2_Fin_When_CF_CFDP_RecvFin_DoesNotReturn_0_SendEventAndCountR
     CF_History_t                dummy_history;
     CF_Transaction_t            dummy_t;
     CF_Transaction_t           *arg_t = &dummy_t;
-    const CF_CFDP_PduHeader_t   dummy_ph;
-    const CF_CFDP_PduHeader_t  *arg_ph             = &dummy_ph;
+    CF_CFDP_PduHeader_t         dummy_ph;
+    CF_CFDP_PduHeader_t        *arg_ph             = &dummy_ph;
     uint32                      initial_recv_error = Any_uint32();
     const char                 *expected_Spec      = "CF S%d(%u:%u): received invalid fin pdu";
     CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
@@ -2198,12 +2198,14 @@ void Test_CF_CFDP_S2_Nak_CallTo_CF_CFDP_RecvNak_Returns_neg1_SendEventAndIncreme
     CF_History_t                dummy_history;
     CF_Transaction_t            dummy_t;
     CF_Transaction_t           *arg_t = &dummy_t;
-    CF_CFDP_PduNak_t            dummy_ph;
-    CF_CFDP_PduHeader_t        *arg_ph             = (CF_CFDP_PduHeader_t *)&dummy_ph;
+    CF_UT_inmsg_buffer_t        dummy_msg;
+    CF_CFDP_PduHeader_t        *arg_ph             = &dummy_msg.pdu_r_msg.ph;
     uint32                      initial_recv_error = Any_uint32();
     const char                 *expected_Spec      = "CF S%d(%u:%u): received invalid nak pdu";
     CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
     int                         context_CF_CFDP_RecvNak_forced_num_sr = Any_int();
+
+    memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->history  = &dummy_history;
     arg_t->chan_num = Any_cf_chan_num();
@@ -2242,12 +2244,14 @@ void Test_CF_CFDP_S2_Nak_CallTo_CF_CFDP_RecvNak_Returns_0_Set_num_sr_to_0_SendEv
     CF_History_t                dummy_history;
     CF_Transaction_t            dummy_t;
     CF_Transaction_t           *arg_t = &dummy_t;
-    CF_CFDP_PduNak_t            dummy_ph;
-    CF_CFDP_PduHeader_t        *arg_ph             = (CF_CFDP_PduHeader_t *)&dummy_ph;
+    CF_UT_inmsg_buffer_t        dummy_msg;
+    CF_CFDP_PduHeader_t        *arg_ph             = &dummy_msg.pdu_r_msg.ph;
     uint32                      initial_recv_error = Any_uint32();
     const char                 *expected_Spec      = "CF S%d(%u:%u): received invalid nak pdu";
     CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
     int                         context_CF_CFDP_RecvNak_forced_num_sr = 0;
+
+    memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->history  = &dummy_history;
     arg_t->chan_num = Any_cf_chan_num();
@@ -2583,8 +2587,8 @@ void Test_CF_CFDP_S2_Nak_Arm_Call_CF_CFDP_ArmAckTimer_And_CF_CFDP_S2_Nak(void)
     CF_History_t                dummy_history;
     CF_Transaction_t            dummy_t;
     CF_Transaction_t           *arg_t = &dummy_t;
-    const CF_CFDP_PduHeader_t   dummy_ph;
-    const CF_CFDP_PduHeader_t  *arg_ph                                = &dummy_ph;
+    CF_CFDP_PduHeader_t         dummy_ph;
+    CF_CFDP_PduHeader_t        *arg_ph                                = &dummy_ph;
     uint32                      initial_recv_error                    = Any_uint32();
     int                         context_CF_CFDP_RecvNak_forced_num_sr = Any_int();
     CF_Transaction_t           *context_CF_CFDP_ArmAckTimer;
@@ -2636,8 +2640,8 @@ void Test_CF_CFDP_S2_WaitForEofAck_CallTo_CF_CFDP_RecvAck_Returns_neg1_SendEvent
     CF_History_t                dummy_history;
     CF_Transaction_t            dummy_t;
     CF_Transaction_t           *arg_t = &dummy_t;
-    const CF_CFDP_PduHeader_t   dummy_ph;
-    const CF_CFDP_PduHeader_t  *arg_ph             = &dummy_ph;
+    CF_CFDP_PduHeader_t         dummy_ph;
+    CF_CFDP_PduHeader_t        *arg_ph             = &dummy_ph;
     uint32                      initial_recv_error = Any_uint32();
     const char                 *expected_Spec      = "CF S%d(%u:%u): received invalid eof pdu";
     CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
@@ -2674,11 +2678,11 @@ void Test_CF_CFDP_S2_WaitForEofAck_CallTo_CF_CFDP_RecvAck_Returns_0_And_t_histor
     void)
 {
     /* Arrange */
-    CF_History_t               dummy_history;
-    CF_Transaction_t           dummy_t;
-    CF_Transaction_t          *arg_t = &dummy_t;
-    const CF_CFDP_PduHeader_t  dummy_ph;
-    const CF_CFDP_PduHeader_t *arg_ph = &dummy_ph;
+    CF_History_t         dummy_history;
+    CF_Transaction_t     dummy_t;
+    CF_Transaction_t    *arg_t = &dummy_t;
+    CF_CFDP_PduHeader_t  dummy_ph;
+    CF_CFDP_PduHeader_t *arg_ph = &dummy_ph;
 
     arg_t->history     = &dummy_history;
     arg_t->history->cc = CF_CFDP_ConditionCode_NO_ERROR;
@@ -2707,11 +2711,11 @@ void Test_CF_CFDP_S2_WaitForEofAck_CallTo_CF_CFDP_RecvAck_Returns_0_And_t_histor
     void)
 {
     /* Arrange */
-    CF_History_t               dummy_history;
-    CF_Transaction_t           dummy_t;
-    CF_Transaction_t          *arg_t = &dummy_t;
-    const CF_CFDP_PduHeader_t  dummy_ph;
-    const CF_CFDP_PduHeader_t *arg_ph = &dummy_ph;
+    CF_History_t         dummy_history;
+    CF_Transaction_t     dummy_t;
+    CF_Transaction_t    *arg_t = &dummy_t;
+    CF_CFDP_PduHeader_t  dummy_ph;
+    CF_CFDP_PduHeader_t *arg_ph = &dummy_ph;
 
     arg_t->history     = &dummy_history;
     arg_t->history->cc = Any_uint8_Except(CF_CFDP_ConditionCode_NO_ERROR);
@@ -2765,19 +2769,18 @@ void Test_CF_CFDP_S_DispatchRecv_Asserts_msg_in_Is_NULL(void)
 void Test_CF_CFDP_S_DispatchRecv_AlreadyHas_pdu_ph_flags_SetSoSendEvent(void)
 {
     /* Arrange */
-    CF_History_t                dummy_history;
-    CF_UT_inmsg_buffer_t        dummy_msg;
-    CF_Transaction_t            dummy_t;
-    CF_Transaction_t           *arg_t         = &dummy_t;
-    const char                 *expected_Spec = "CF S%d(%u:%u): received non-file directive pdu";
-    void                       *arg_fns       = NULL;
-    CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
+    CF_History_t                          dummy_history;
+    CF_UT_inmsg_buffer_t                  dummy_msg;
+    CF_Transaction_t                      dummy_t;
+    CF_Transaction_t                     *arg_t         = &dummy_t;
+    const char                           *expected_Spec = "CF S%d(%u:%u): received non-file directive pdu";
+    CF_CFDP_S_SubstateRecvDispatchTable_t arg_fns       = {{NULL}};
+    CFE_EVS_SendEvent_context_t           context_CFE_EVS_SendEvent;
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
+    dummy_msg.pdu_r_msg.ph.flags  = 0x10; /* pdu_type bit */
     arg_t->state_data.s.sub_state = Any_uint8_LessThan(CF_TxSubState_NUM_STATES);
-
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 1);
 
@@ -2785,7 +2788,7 @@ void Test_CF_CFDP_S_DispatchRecv_AlreadyHas_pdu_ph_flags_SetSoSendEvent(void)
     arg_t->history = &dummy_history;
 
     /* Act */
-    CF_CFDP_S_DispatchRecv(arg_t, arg_fns);
+    CF_CFDP_S_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns);
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -2812,14 +2815,12 @@ void Test_CF_CFDP_S_DispatchRecv_DidNotHaveFlagsSetBut_fdh_directive_code_IsEqTo
     uint8                dummy_flags           = CF_CFDP_FileDirective_INVALID_MAX;
     uint16               initial_recv_spurious = Any_uint16();
     const char          *expected_Spec = "CF S%d(%u:%u): received pdu with invalid directive code %d for sub-state %d";
-    void                *arg_fns       = NULL;
-    CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
+    CF_CFDP_S_SubstateRecvDispatchTable_t arg_fns = {{NULL}};
+    CFE_EVS_SendEvent_context_t           context_CFE_EVS_SendEvent;
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.s.sub_state = Any_uint8_LessThan(CF_TxSubState_NUM_STATES);
-
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
@@ -2832,7 +2833,7 @@ void Test_CF_CFDP_S_DispatchRecv_DidNotHaveFlagsSetBut_fdh_directive_code_IsEqTo
     arg_t->history = &dummy_history;
 
     /* Act */
-    CF_CFDP_S_DispatchRecv(arg_t, arg_fns);
+    CF_CFDP_S_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns);
 
     /* Assert */
     UtAssert_True(CF_AppData.hk.channel_hk[dummy_chan_num].counters.recv.spurious ==
@@ -2865,14 +2866,12 @@ void Test_CF_CFDP_S_DispatchRecv_DidNotHaveFlagsSetBut_fdh_directive_code_IsGrea
     uint8                dummy_flags           = Any_uint8_GreaterThan(CF_CFDP_FileDirective_INVALID_MAX);
     uint16               initial_recv_spurious = Any_uint16();
     const char          *expected_Spec = "CF S%d(%u:%u): received pdu with invalid directive code %d for sub-state %d";
-    void                *arg_fns       = NULL;
-    CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent;
+    CF_CFDP_S_SubstateRecvDispatchTable_t arg_fns = {{NULL}};
+    CFE_EVS_SendEvent_context_t           context_CFE_EVS_SendEvent;
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.s.sub_state = Any_uint8_LessThan(CF_TxSubState_NUM_STATES);
-
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
@@ -2885,7 +2884,7 @@ void Test_CF_CFDP_S_DispatchRecv_DidNotHaveFlagsSetBut_fdh_directive_code_IsGrea
     arg_t->history = &dummy_history;
 
     /* Act */
-    CF_CFDP_S_DispatchRecv(arg_t, arg_fns);
+    CF_CFDP_S_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns);
 
     /* Assert */
     UtAssert_True(CF_AppData.hk.channel_hk[dummy_chan_num].counters.recv.spurious ==
@@ -2910,28 +2909,18 @@ void Test_CF_CFDP_S_DispatchRecv_Received_msg_ph_As_fdh_Has_flags_LessThan_PDU_I
     void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t                 = &dummy_t;
-    uint8                dummy_chan_num        = Any_cf_chan_num();
-    uint8                dummy_sub_state       = 0; /* 0 = always choose Dummy_fns_CF_CFDP_S_DispatchRecv */
-    uint8                dummy_flags           = 0; /* 0 = always choose Dummy_fns_CF_CFDP_S_DispatchRecv */
-    uint16               initial_recv_spurious = Any_uint16();
-    void (*const arg_fns[CF_TxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(CF_Transaction_t *,
-                                                                                       const CF_CFDP_PduHeader_t *) = {
-        {Dummy_fns_CF_CFDP_S_DispatchRecv, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-         NULL},                                                             /* CF_TxSubState_METADATA */
-        {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}, /* CF_TxSubState_FILEDATA */
-        {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}, /* CF_TxSubState_EOF */
-        {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}, /* CF_TxSubState_WAIT_FOR_EOF_ACK */
-        {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}, /* CF_TxSubState_WAIT_FOR_FIN */
-        {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}, /* CF_TxSubState_SEND_FIN_ACK */
-    };
+    CF_UT_inmsg_buffer_t                  dummy_msg;
+    CF_Transaction_t                      dummy_t;
+    CF_Transaction_t                     *arg_t           = &dummy_t;
+    uint8                                 dummy_chan_num  = Any_cf_chan_num();
+    uint8                                 dummy_sub_state = 0; /* 0 = always choose Dummy_fns_CF_CFDP_S_DispatchRecv */
+    uint8                                 dummy_flags     = 0; /* 0 = always choose Dummy_fns_CF_CFDP_S_DispatchRecv */
+    uint16                                initial_recv_spurious = Any_uint16();
+    CF_CFDP_FileDirectiveDispatchTable_t  fd_tbl  = {.fdirective = {[0] = Dummy_fns_CF_CFDP_S_DispatchRecv}};
+    CF_CFDP_S_SubstateRecvDispatchTable_t arg_fns = {.substate = {[0] = &fd_tbl}};
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
     arg_t->state_data.s.sub_state = dummy_sub_state;
-
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
@@ -2941,7 +2930,7 @@ void Test_CF_CFDP_S_DispatchRecv_Received_msg_ph_As_fdh_Has_flags_LessThan_PDU_I
     CF_AppData.hk.channel_hk[dummy_chan_num].counters.recv.spurious = initial_recv_spurious;
 
     /* Act */
-    CF_CFDP_S_DispatchRecv(arg_t, arg_fns);
+    CF_CFDP_S_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns);
 
     /* Assert */
     UtAssert_STUB_COUNT(Dummy_fns_CF_CFDP_S_DispatchRecv, 1);
@@ -2956,21 +2945,18 @@ void Test_CF_CFDP_S_DispatchRecv_Received_msg_ph_As_fdh_Has_flags_LessThan_PDU_I
 void Test_CF_CFDP_S_DispatchRecv_Received_msg_ph_As_fdh_Has_flags_LessThan_PDU_INVALID_MAX_But_fns_NULL_DoNothing(void)
 {
     /* Arrange */
-    CF_UT_inmsg_buffer_t dummy_msg;
-    CF_Transaction_t     dummy_t;
-    CF_Transaction_t    *arg_t                 = &dummy_t;
-    uint8                dummy_chan_num        = Any_cf_chan_num();
-    uint8                dummy_sub_state       = Any_uint8_LessThan(CF_TxSubState_NUM_STATES);
-    uint8                dummy_flags           = Any_uint8_LessThan(CF_CFDP_FileDirective_INVALID_MAX);
-    uint16               initial_recv_spurious = Any_uint16();
-    void (*const arg_fns[CF_TxSubState_NUM_STATES][CF_CFDP_FileDirective_INVALID_MAX])(
-        CF_Transaction_t *, const CF_CFDP_PduHeader_t *) = {{NULL}};
+    CF_UT_inmsg_buffer_t                  dummy_msg;
+    CF_Transaction_t                      dummy_t;
+    CF_Transaction_t                     *arg_t                 = &dummy_t;
+    uint8                                 dummy_chan_num        = Any_cf_chan_num();
+    uint8                                 dummy_sub_state       = Any_uint8_LessThan(CF_TxSubState_NUM_STATES);
+    uint8                                 dummy_flags           = Any_uint8_LessThan(CF_CFDP_FileDirective_INVALID_MAX);
+    uint16                                initial_recv_spurious = Any_uint16();
+    CF_CFDP_S_SubstateRecvDispatchTable_t arg_fns               = {{NULL}};
 
     memset(&dummy_msg, 0, sizeof(dummy_msg));
 
     arg_t->state_data.s.sub_state = dummy_sub_state;
-
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
 
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
@@ -2980,7 +2966,7 @@ void Test_CF_CFDP_S_DispatchRecv_Received_msg_ph_As_fdh_Has_flags_LessThan_PDU_I
     CF_AppData.hk.channel_hk[dummy_chan_num].counters.recv.spurious = initial_recv_spurious;
 
     /* Act */
-    CF_CFDP_S_DispatchRecv(arg_t, arg_fns);
+    CF_CFDP_S_DispatchRecv(arg_t, &dummy_msg.pdu_r_msg.ph, &arg_fns);
 
     /* Assert */
     UtAssert_True(CF_AppData.hk.channel_hk[dummy_chan_num].counters.recv.spurious == initial_recv_spurious,
@@ -3014,8 +3000,6 @@ void Test_CF_CFDP_S1_Recv_SendsAll_NULL_fns_To_CF_CFDP_S_DispatchRecv(void)
 
     arg_t->state_data.s.sub_state = dummy_sub_state;
 
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
-
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
     dummy_msg.pdu_r_msg.ph.flags = dummy_flags;
@@ -3024,7 +3008,7 @@ void Test_CF_CFDP_S1_Recv_SendsAll_NULL_fns_To_CF_CFDP_S_DispatchRecv(void)
     CF_AppData.hk.channel_hk[dummy_chan_num].counters.recv.spurious = initial_recv_spurious;
 
     /* Act */
-    CF_CFDP_S1_Recv(arg_t);
+    CF_CFDP_S1_Recv(arg_t, &dummy_msg.pdu_r_msg.ph);
 
     /* Assert */
     /* Assert for CF_CFDP_S_DispatchRecv */
@@ -3075,8 +3059,6 @@ void Test_CF_CFDP_S2_Recv_Call_CF_CFDP_S_DispatchRecv(void)
 
     arg_t->state_data.s.sub_state = dummy_sub_state;
 
-    CF_AppData.engine.in.msg = &dummy_msg.cfe_sb_buffer;
-
     UT_SetDefaultReturnValue(UT_KEY(FGV), 0);
 
     dummy_msg.pdu_r_msg.ph.flags = dummy_flags;
@@ -3085,7 +3067,7 @@ void Test_CF_CFDP_S2_Recv_Call_CF_CFDP_S_DispatchRecv(void)
     CF_AppData.hk.channel_hk[dummy_chan_num].counters.recv.spurious = initial_recv_spurious;
 
     /* Act */
-    CF_CFDP_S2_Recv(arg_t);
+    CF_CFDP_S2_Recv(arg_t, &dummy_msg.pdu_r_msg.ph);
 
     /* Assert */
     /* Assert for CF_CFDP_S_DispatchRecv */

--- a/unit-test/stubs/cf_cfdp_helpers_stubs.c
+++ b/unit-test/stubs/cf_cfdp_helpers_stubs.c
@@ -57,7 +57,7 @@ int CF_GetMemcpySize(const uint8_t *num, int size)
  * Generated stub function for CF_GetVariableHeader()
  * ----------------------------------------------------
  */
-int CF_GetVariableHeader(void)
+int CF_GetVariableHeader(CF_CFDP_PduHeader_t *ph)
 {
     UT_GenStub_SetupReturnBuffer(CF_GetVariableHeader, int);
 
@@ -102,7 +102,8 @@ void CF_MemcpyToBE(uint8 *dst, const uint8 *src, int src_size, int dst_size)
  * Generated stub function for CF_SetVariableHeader()
  * ----------------------------------------------------
  */
-void CF_SetVariableHeader(CF_EntityId_t src_eid, CF_EntityId_t dst_eid, CF_TransactionSeq_t tsn)
+void CF_SetVariableHeader(CF_CFDP_PduHeader_t *ph, CF_EntityId_t src_eid, CF_EntityId_t dst_eid,
+                          CF_TransactionSeq_t tsn)
 {
     UT_GenStub_AddParam(CF_SetVariableHeader, CF_EntityId_t, src_eid);
     UT_GenStub_AddParam(CF_SetVariableHeader, CF_EntityId_t, dst_eid);

--- a/unit-test/stubs/cf_cfdp_r_stubs.c
+++ b/unit-test/stubs/cf_cfdp_r_stubs.c
@@ -426,7 +426,7 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
 **       t must not be NULL.
 **
 *************************************************************************/
-void CF_CFDP_R1_Recv(CF_Transaction_t *t)
+void CF_CFDP_R1_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     UT_GenStub_AddParam(CF_CFDP_R_Init, CF_Transaction_t *, t);
 
@@ -440,7 +440,7 @@ void CF_CFDP_R1_Recv(CF_Transaction_t *t)
 **       t must not be NULL.
 **
 *************************************************************************/
-void CF_CFDP_R2_Recv(CF_Transaction_t *t)
+void CF_CFDP_R2_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     UT_GenStub_AddParam(CF_CFDP_R2_Recv, CF_Transaction_t *, t);
 

--- a/unit-test/stubs/cf_cfdp_s_stubs.c
+++ b/unit-test/stubs/cf_cfdp_s_stubs.c
@@ -325,7 +325,7 @@
 **       t must not be NULL.
 **
 *************************************************************************/
-void CF_CFDP_S1_Recv(CF_Transaction_t *t)
+void CF_CFDP_S1_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     UtPrintf("NOT YET IMPLEMENTED stub in \n%s:line #%d\n", __FILE__, __LINE__);
     exit(-86);
@@ -338,7 +338,7 @@ void CF_CFDP_S1_Recv(CF_Transaction_t *t)
 **       t must not be NULL.
 **
 *************************************************************************/
-void CF_CFDP_S2_Recv(CF_Transaction_t *t)
+void CF_CFDP_S2_Recv(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     UtPrintf("NOT YET IMPLEMENTED stub in \n%s:line #%d\n", __FILE__, __LINE__);
     exit(-86);

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -442,7 +442,7 @@ CF_CFDP_PduHeader_t *CF_CFDP_EarlySendFd(CF_Transaction_t *t)
 **  \endreturns
 **
 *************************************************************************/
-CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, uint32 offset, int len)
+CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph, uint32 offset, int len)
 {
     CF_SendRet_t forced_return;
 
@@ -575,7 +575,7 @@ CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, 
 **  \endreturns
 **
 *************************************************************************/
-CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, int num_segment_requests)
+CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph, int num_segment_requests)
 {
 
     CF_SendRet_t forced_return;
@@ -642,7 +642,7 @@ CF_CFDP_PduHeader_t *CF_CFDP_EarlySendNak(CF_Transaction_t *t)
 **  \endreturns
 **
 *************************************************************************/
-int CF_CFDP_RecvMd(CF_Transaction_t *t)
+int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvMd, int32);
 
@@ -666,7 +666,7 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t)
 **
 *************************************************************************/
 
-int CF_CFDP_RecvFd(CF_Transaction_t *t)
+int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     int forced_return = __INT_MAX__;
 
@@ -693,7 +693,7 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t)
 **  \endreturns
 **
 *************************************************************************/
-int CF_CFDP_RecvEof(void)
+int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     return (int)UT_DEFAULT_IMPL(CF_CFDP_RecvEof);
 }
@@ -710,7 +710,7 @@ int CF_CFDP_RecvEof(void)
 **  \endreturns
 **
 *************************************************************************/
-int CF_CFDP_RecvAck(void)
+int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     return (int)UT_DEFAULT_IMPL(CF_CFDP_RecvAck);
 }
@@ -727,7 +727,7 @@ int CF_CFDP_RecvAck(void)
 **  \endreturns
 **
 *************************************************************************/
-int CF_CFDP_RecvFin(void)
+int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph)
 {
     return UT_DEFAULT_IMPL(CF_CFDP_RecvFin);
 }
@@ -744,7 +744,7 @@ int CF_CFDP_RecvFin(void)
 **  \endreturns
 **
 *************************************************************************/
-int CF_CFDP_RecvNak(int *num_segment_requests)
+int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_CFDP_PduHeader_t *ph, int *num_segment_requests)
 {
     UT_Stub_CopyToLocal(UT_KEY(CF_CFDP_RecvNak), num_segment_requests, sizeof(int));
 


### PR DESCRIPTION
Standardize the dynamic handler functions to two basic types, one that accepts a PDU (recv) and one that does not (send).

Also create several dispatch table types, one based on file directive code, one based on Tx sub state, and one based
on Rx sub state.

Change the dispatcher functions to use these common types and create new dispatcher functions where there was not
a separate function already (this makes the pattern consistent).

Make all "receive" helper functions accept a pointer to the recieved PDU and actually use that pointer to read the data.  This
substantially reduces reliance on the global and fixes some cases where a pointer was actually passed into a function, but
ignored.  This takes a significant step toward removing the global entirely, but does not do so yet.

Fixes #111
Also related to/makes some progress on #90 and #91 but does not fix those yet.