### PR TITLE
Fix #129, reject FD packets with segment_metadata flag set

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -839,6 +839,14 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
         ret = -1;
     }
+    else if (ph->pdu_header.segment_meta_flag)
+    {
+        /* If recv PDU has the "segment_meta_flag" set, this is not currently handled in CF. */
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_UNSUPPORTED, CFE_EVS_EventType_ERROR,
+                          "CF: filedata pdu with segment metadata received");
+        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ret = -1;
+    }
 
     return ret;
 }

--- a/fsw/src/cf_events.h
+++ b/fsw/src/cf_events.h
@@ -63,6 +63,7 @@
 #define CF_EID_ERR_PDU_BAD_RX_MSG_SIZE 51
 #define CF_EID_ERR_PDU_GET_EID_SIZE    52
 #define CF_EID_ERR_PDU_GET_TSN_SIZE    53
+#define CF_EID_ERR_PDU_FD_UNSUPPORTED  54
 
 /* CF_CFDP event ids (engine) */
 #define CF_EID_ERR_CFDP_RX_DROPPED      60

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -336,6 +336,12 @@ void Test_CF_CFDP_RecvFd(void)
     ph->int_header.fd.data_len = sizeof(CF_CFDP_uint32_t) - 1;
     UtAssert_INT32_EQ(CF_CFDP_RecvFd(t, ph), -1);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(ph->pdec));
+
+    /* with segment metadata (unimplemented) */
+    UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
+    ph->pdu_header.segment_meta_flag = 1;
+    UtAssert_INT32_EQ(CF_CFDP_RecvFd(t, ph), -1);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_FD_UNSUPPORTED);
 }
 
 void Test_CF_CFDP_RecvEof(void)


### PR DESCRIPTION
**Describe the contribution**
The CF does not currently interpret/use the segment metadata option inside file data PDUs.  Packets with this bit set should
be rejected.

Fixes #129

**Testing performed**
Build CF and run all tests
Execute test file transfers between two CFE nodes

**Expected behavior changes**
None, CF does not set this bit on Tx, it should never be set on Rx.

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
