### PR TITLE
Fix #110, #149, update identifier names

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -47,9 +47,6 @@
 #include <string.h>
 #include "cf_assert.h"
 
-const int CF_max_chunks[CF_Direction_NUM][CF_NUM_CHANNELS] = {CF_CHANNEL_NUM_RX_CHUNKS_PER_TRANSACTION,
-                                                              CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION};
-
 /**
  * @brief Initiate the process of encoding a new PDU to send
  *
@@ -1093,6 +1090,9 @@ int32 CF_CFDP_InitEngine(void)
     CF_ChunkWrapper_t *c                = CF_AppData.engine.chunks;
     int32              ret              = CFE_SUCCESS;
 
+    static const int CF_DIR_MAX_CHUNKS[CF_Direction_NUM][CF_NUM_CHANNELS] = {CF_CHANNEL_NUM_RX_CHUNKS_PER_TRANSACTION,
+                                                                             CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION};
+
     memset(&CF_AppData.engine, 0, sizeof(CF_AppData.engine));
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
@@ -1139,9 +1139,9 @@ int32 CF_CFDP_InitEngine(void)
 
             for (k = 0; k < CF_Direction_NUM; ++k, ++c)
             {
-                CF_Assert((chunk_mem_offset + CF_max_chunks[k][i]) <= CF_NUM_CHUNKS_ALL_CHANNELS);
-                CF_ChunkListInit(&c->chunks, CF_max_chunks[k][i], &CF_AppData.engine.chunk_mem[chunk_mem_offset]);
-                chunk_mem_offset += CF_max_chunks[k][i];
+                CF_Assert((chunk_mem_offset + CF_DIR_MAX_CHUNKS[k][i]) <= CF_NUM_CHUNKS_ALL_CHANNELS);
+                CF_ChunkListInit(&c->chunks, CF_DIR_MAX_CHUNKS[k][i], &CF_AppData.engine.chunk_mem[chunk_mem_offset]);
+                chunk_mem_offset += CF_DIR_MAX_CHUNKS[k][i];
                 CF_CList_InitNode(&c->cl_node);
                 CF_CList_InsertBack(&CF_AppData.engine.channels[i].cs[k], &c->cl_node);
             }
@@ -1178,7 +1178,7 @@ err_out:
 **  \endreturns
 **
 *************************************************************************/
-int CF_CFDP_CycleTx_(CF_CListNode_t *node, void *context)
+int CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
 {
     CF_CFDP_CycleTx_args_t *args = (CF_CFDP_CycleTx_args_t *)context;
     CF_Transaction_t       *t    = container_of(node, CF_Transaction_t, cl_node);
@@ -1246,7 +1246,7 @@ void CF_CFDP_CycleTx(CF_Channel_t *c)
                 CF_MoveTransaction(t, CF_QueueIdx_TXA);
                 /* args is ok, still { c, 0 } */
             entry_jump:
-                CF_CList_Traverse(c->qs[CF_QueueIdx_TXA], CF_CFDP_CycleTx_, &args);
+                CF_CList_Traverse(c->qs[CF_QueueIdx_TXA], CF_CFDP_CycleTxFirstActive, &args);
             }
         }
 
@@ -1269,9 +1269,9 @@ void CF_CFDP_CycleTx(CF_Channel_t *c)
 *************************************************************************/
 int CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
 {
-    int               ret  = CF_CLIST_CONT; /* CF_CLIST_CONT means don't tick one, keep looking for cur */
-    tick_args_t      *args = (tick_args_t *)context;
-    CF_Transaction_t *t    = container_of(node, CF_Transaction_t, cl_node);
+    int                  ret  = CF_CLIST_CONT; /* CF_CLIST_CONT means don't tick one, keep looking for cur */
+    CF_CFDP_Tick_args_t *args = (CF_CFDP_Tick_args_t *)context;
+    CF_Transaction_t    *t    = container_of(node, CF_Transaction_t, cl_node);
     if (!args->c->cur || (args->c->cur == t))
     {
         /* found where we left off, so clear that and move on */
@@ -1321,7 +1321,7 @@ void CF_CFDP_TickTransactions(CF_Channel_t *c)
 
     for (; c->tick_type < CF_TickType_NUM_TYPES; ++c->tick_type)
     {
-        tick_args_t args = {c, fns[c->tick_type], 0, 0};
+        CF_CFDP_Tick_args_t args = {c, fns[c->tick_type], 0, 0};
 
         do
         {
@@ -1384,8 +1384,8 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint
 **       t must not be NULL.
 **
 *************************************************************************/
-static void CF_CFDP_TxFile_(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan, uint8 priority,
-                            CF_EntityId_t dest_id)
+static void CF_CFDP_TxFile_Initiate(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan,
+                                    uint8 priority, CF_EntityId_t dest_id)
 {
     CFE_EVS_SendEvent(CF_EID_INF_CFDP_S_START_SEND, CFE_EVS_EventType_INFORMATION,
                       "CF: start class %d tx of file %d:%.*s -> %d:%.*s", cfdp_class + 1,
@@ -1448,7 +1448,7 @@ int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP
     t->history->fnames.src_filename[sizeof(t->history->fnames.src_filename) - 1] = 0;
     strncpy(t->history->fnames.dst_filename, dst_filename, sizeof(t->history->fnames.dst_filename) - 1);
     t->history->fnames.dst_filename[sizeof(t->history->fnames.dst_filename) - 1] = 0;
-    CF_CFDP_TxFile_(t, cfdp_class, keep, chan, priority, dest_id);
+    CF_CFDP_TxFile_Initiate(t, cfdp_class, keep, chan, priority, dest_id);
 
     ++c->num_cmd_tx;
     t->flags.tx.cmd_tx = 1;
@@ -1472,9 +1472,9 @@ err_out:
 **  \endreturns
 **
 *************************************************************************/
-static int32 CF_CFDP_PlaybackDir_(CF_Playback_t *p, const char *src_filename, const char *dst_filename,
-                                  CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan, uint8 priority,
-                                  CF_EntityId_t dest_id)
+static int32 CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *p, const char *src_filename, const char *dst_filename,
+                                          CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan, uint8 priority,
+                                          CF_EntityId_t dest_id)
 {
     int32 ret = CFE_SUCCESS;
 
@@ -1544,7 +1544,7 @@ int32 CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF
         return -1;
     }
 
-    return CF_CFDP_PlaybackDir_(p, src_filename, dst_filename, cfdp_class, keep, chan, priority, dest_id);
+    return CF_CFDP_PlaybackDir_Initiate(p, src_filename, dst_filename, cfdp_class, keep, chan, priority, dest_id);
 }
 
 /************************************************************************/
@@ -1598,7 +1598,8 @@ void CF_CFDP_ProcessPlaybackDirectory(CF_Channel_t *c, CF_Playback_t *p)
                 pt->history->fnames.src_filename[CF_FILENAME_MAX_LEN - 1] = 0;
                 pt->history->fnames.dst_filename[CF_FILENAME_MAX_LEN - 1] = 0;
 
-                CF_CFDP_TxFile_(pt, p->cfdp_class, p->keep, (c - CF_AppData.engine.channels), p->priority, p->dest_id);
+                CF_CFDP_TxFile_Initiate(pt, p->cfdp_class, p->keep, (c - CF_AppData.engine.channels), p->priority,
+                                        p->dest_id);
 
                 pt->p = p;
                 ++p->num_ts;
@@ -1707,8 +1708,8 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c)
                 else if (CF_Timer_Expired(&p->interval_timer))
                 {
                     /* the timer has expired */
-                    int ret = CF_CFDP_PlaybackDir_(&p->pb, pd->src_dir, pd->dst_dir, pd->cfdp_class, 0, chan_index,
-                                                   pd->priority, pd->dest_eid);
+                    int ret = CF_CFDP_PlaybackDir_Initiate(&p->pb, pd->src_dir, pd->dst_dir, pd->cfdp_class, 0,
+                                                           chan_index, pd->priority, pd->dest_eid);
                     if (!ret)
                     {
                         p->timer_set = 0;
@@ -1716,7 +1717,7 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c)
                     else
                     {
                         /* error occured in playback directory, so reset the timer */
-                        /* an event is sent in CF_CFDP_PlaybackDir_ so there is no reason to
+                        /* an event is sent in CF_CFDP_PlaybackDir_Initiate so there is no reason to
                          * to have another here */
                         CF_Timer_InitRelSec(&p->interval_timer, pd->interval_sec);
                     }

--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -29,19 +29,19 @@
 
 #include "cf_cfdp_types.h"
 
-typedef struct CF_CFDP_CycleTx_args_t
+typedef struct CF_CFDP_CycleTx_args
 {
     CF_Channel_t *c;
     int           ran_one;
 } CF_CFDP_CycleTx_args_t;
 
-typedef struct
+typedef struct CF_CFDP_Tick_args
 {
     CF_Channel_t *c;                       /* IN param */
     void (*fn)(CF_Transaction_t *, int *); /* IN param */
     int early_exit;                        /* OUT param */
     int cont;                              /* if 1, then re-traverse the list */
-} tick_args_t;
+} CF_CFDP_Tick_args_t;
 
 void CF_CFDP_EncodeStart(CF_EncoderState_t *penc, void *msgbuf, CF_Logical_PduBuffer_t *ph, size_t encap_hdr_size,
                          size_t total_size);
@@ -100,8 +100,6 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint
 /* returns number of bytes copied, or -1 on error */
 extern int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t *src_lv);
 
-extern const int CF_max_chunks[CF_Direction_NUM][CF_NUM_CHANNELS];
-
 extern void CF_CFDP_ArmAckTimer(CF_Transaction_t *t);
 
 void CF_CFDP_RecvDrop(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
@@ -110,7 +108,7 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 int CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context);
 
 void CF_CFDP_CycleTx(CF_Channel_t *c);
-int  CF_CFDP_CycleTx_(CF_CListNode_t *node, void *context);
+int  CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context);
 void CF_CFDP_TickTransactions(CF_Channel_t *c);
 void CF_CFDP_ProcessPlaybackDirectory(CF_Channel_t *c, CF_Playback_t *p);
 void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c);

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -571,9 +571,9 @@ int CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t)
 
             nak->scope_start = 0;
             cret             = CF_ChunkList_ComputeGaps(&t->chunks->chunks,
-                                            (t->chunks->chunks.count < t->chunks->chunks.CF_max_chunks)
-                                                            ? t->chunks->chunks.CF_max_chunks
-                                                            : (t->chunks->chunks.CF_max_chunks - 1),
+                                            (t->chunks->chunks.count < t->chunks->chunks.max_chunks)
+                                                            ? t->chunks->chunks.max_chunks
+                                                            : (t->chunks->chunks.max_chunks - 1),
                                                         t->fsize, 0, CF_CFDP_R2_GapCompute, &args);
 
             if (!cret)

--- a/fsw/src/cf_chunk.c
+++ b/fsw/src/cf_chunk.c
@@ -88,7 +88,7 @@ void CF_Chunks_EraseChunk(CF_ChunkList_t *chunks, CF_ChunkIdx_t erase_index)
 *************************************************************************/
 void CF_Chunks_InsertChunk(CF_ChunkList_t *chunks, CF_ChunkIdx_t index_before, const CF_Chunk_t *chunk)
 {
-    CF_Assert(chunks->count < chunks->CF_max_chunks);
+    CF_Assert(chunks->count < chunks->max_chunks);
     CF_Assert(index_before <= chunks->count);
 
     if (chunks->count && (index_before != chunks->count))
@@ -155,7 +155,7 @@ CF_ChunkIdx_t CF_Chunks_FindInsertPosition(CF_ChunkList_t *chunks, const CF_Chun
 int CF_Chunks_CombinePrevious(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk)
 {
     int ret = 0;
-    CF_Assert(i <= chunks->CF_max_chunks);
+    CF_Assert(i <= chunks->max_chunks);
 
     CF_ChunkOffset_t chunk_end = chunk->offset + chunk->size;
 
@@ -292,7 +292,7 @@ void CF_Chunks_Insert(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t 
         int combined = CF_Chunks_CombinePrevious(chunks, i, chunk);
         if (!combined)
         {
-            if (chunks->count < chunks->CF_max_chunks)
+            if (chunks->count < chunks->max_chunks)
             {
                 CF_Chunks_InsertChunk(chunks, i, chunk);
             }
@@ -395,11 +395,11 @@ const CF_Chunk_t *CF_ChunkList_GetFirstChunk(const CF_ChunkList_t *chunks)
 **       chunks must not be NULL. chunks_mem must not be NULL.
 **
 *************************************************************************/
-void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t CF_max_chunks, CF_Chunk_t *chunks_mem)
+void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t max_chunks, CF_Chunk_t *chunks_mem)
 {
-    CF_Assert(CF_max_chunks > 0);
-    chunks->CF_max_chunks = CF_max_chunks;
-    chunks->chunks        = chunks_mem;
+    CF_Assert(max_chunks > 0);
+    chunks->max_chunks = max_chunks;
+    chunks->chunks     = chunks_mem;
     CF_ChunkListReset(chunks);
 }
 
@@ -413,7 +413,7 @@ void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t CF_max_chunks, CF_Ch
 void CF_ChunkListReset(CF_ChunkList_t *chunks)
 {
     chunks->count = 0;
-    memset(chunks->chunks, 0, sizeof(*chunks->chunks) * chunks->CF_max_chunks);
+    memset(chunks->chunks, 0, sizeof(*chunks->chunks) * chunks->max_chunks);
 }
 
 /************************************************************************/

--- a/fsw/src/cf_chunk.h
+++ b/fsw/src/cf_chunk.h
@@ -45,7 +45,7 @@ typedef struct CF_Chunk
 typedef struct CF_ChunkList
 {
     CF_ChunkIdx_t count;
-    CF_ChunkIdx_t CF_max_chunks;
+    CF_ChunkIdx_t max_chunks;
     CF_Chunk_t   *chunks;
 } CF_ChunkList_t;
 
@@ -61,7 +61,7 @@ static inline CF_ChunkOffset_t CF_Chunk_MAX(CF_ChunkOffset_t a, CF_ChunkOffset_t
     }
 }
 
-void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t CF_max_chunks, CF_Chunk_t *chunks_mem);
+void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t max_chunks, CF_Chunk_t *chunks_mem);
 void CF_ChunkListAdd(CF_ChunkList_t *chunks, CF_ChunkOffset_t offset, CF_ChunkSize_t size);
 void CF_ChunkListReset(CF_ChunkList_t *chunks);
 /* CF_ChunkList_RemoveFromFirst -

--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -26,26 +26,26 @@
 #include "cf_app.h"
 #include "cf_utils.h"
 
-typedef int (*chan_action_fn_t)(uint8 chan_num, void *context);
+typedef int (*CF_ChanActionFn_t)(uint8 chan_num, void *context);
 
-typedef struct
+typedef struct CF_ChanAction_BoolArg
 {
-    uint8 barg;
-} bool_arg_t;
+    bool barg;
+} CF_ChanAction_BoolArg_t;
 
 typedef CF_TraverseAllTransactions_fn_t CF_TsnChanAction_fn_t;
 
-typedef struct
+typedef struct CF_ChanAction_SuspResArg
 {
-    int   same; /* out param -- indicates at least one action was set to its current value */
-    uint8 action;
-} susp_res_arg_t;
+    int  same; /* out param -- indicates at least one action was set to its current value */
+    bool action;
+} CF_ChanAction_SuspResArg_t;
 
-typedef struct
+typedef struct CF_ChanAction_BoolMsgArg
 {
     const CF_UnionArgsCmd_t *msg;
-    uint8                    barg;
-} bool_msg_arg_t;
+    bool                     barg;
+} CF_ChanAction_BoolMsgArg_t;
 
 /************************************************************************/
 /** \brief Increment the command accepted counter.
@@ -88,24 +88,24 @@ void              CF_CmdNoop(CFE_SB_Buffer_t *msg);
 void              CF_CmdReset(CFE_SB_Buffer_t *msg);
 void              CF_CmdTxFile(CFE_SB_Buffer_t *msg);
 void              CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg);
-int               CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, chan_action_fn_t fn, void *context);
-int               CF_DoFreezeThaw(uint8 chan_num, const bool_arg_t *context);
+int               CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context);
+int               CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context);
 void              CF_CmdFreeze(CFE_SB_Buffer_t *msg);
 void              CF_CmdThaw(CFE_SB_Buffer_t *msg);
 CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSeq_t ts, CF_EntityId_t eid);
 int  CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context);
-void CF_DoSuspRes_(CF_Transaction_t *t, susp_res_arg_t *context);
+void CF_DoSuspRes_Txn(CF_Transaction_t *t, CF_ChanAction_SuspResArg_t *context);
 void CF_DoSuspRes(CF_TransactionCmd_t *cmd, uint8 action);
 void CF_CmdSuspend(CFE_SB_Buffer_t *msg);
 void CF_CmdResume(CFE_SB_Buffer_t *msg);
-void CF_CmdCancel_(CF_Transaction_t *t, void *ignored);
+void CF_CmdCancel_Txn(CF_Transaction_t *t, void *ignored);
 void CF_CmdCancel(CFE_SB_Buffer_t *msg);
-void CF_CmdAbandon_(CF_Transaction_t *t, void *ignored);
+void CF_CmdAbandon_Txn(CF_Transaction_t *t, void *ignored);
 void CF_CmdAbandon(CFE_SB_Buffer_t *msg);
-int  CF_DoEnableDisableDequeue(uint8 chan_num, const bool_arg_t *context);
+int  CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context);
 void CF_CmdEnableDequeue(CFE_SB_Buffer_t *msg);
 void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg);
-int  CF_DoEnableDisablePolldir(uint8 chan_num, const bool_msg_arg_t *context);
+int  CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context);
 void CF_CmdEnablePolldir(CFE_SB_Buffer_t *msg);
 void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg);
 int  CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c);

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -31,34 +31,34 @@
 #include "cf_app.h"
 #include "cf_assert.h"
 
-typedef struct trans_seq_arg_t
+typedef struct CF_Traverse_TransSeqArg
 {
     CF_TransactionSeq_t transaction_sequence_number;
     CF_EntityId_t       src_eid;
     CF_Transaction_t   *t; /* out param */
-} trans_seq_arg_t;
+} CF_Traverse_TransSeqArg_t;
 
-typedef struct
+typedef struct CF_Traverse_WriteFileArg
 {
     osal_id_t fd;
     int32     result;
     int32     counter;
-} trav_arg_t;
+} CF_Traverse_WriteFileArg_t;
 
 typedef void (*CF_TraverseAllTransactions_fn_t)(CF_Transaction_t *t, void *context);
 
-typedef struct
+typedef struct CF_TraverseAll_Arg
 {
     CF_TraverseAllTransactions_fn_t fn;
     void                           *context;
     int                             counter;
-} traverse_all_args_t;
+} CF_TraverseAll_Arg_t;
 
-typedef struct priority_arg_t
+typedef struct CF_Traverse_PriorityArg
 {
     CF_Transaction_t *t;        /* OUT: holds value of transaction with which to call CF_CList_InsertAfter on */
     uint8             priority; /* seeking this priority */
-} priority_arg_t;
+} CF_Traverse_PriorityArg_t;
 
 /* free a transaction from the queue it's on.
  * NOTE: this leaves the transaction in a bad state,
@@ -162,7 +162,7 @@ void CF_FreeTransaction(CF_Transaction_t *t);
 CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *c, CF_TransactionSeq_t transaction_sequence_number,
                                                      CF_EntityId_t src_eid);
 
-int CF_FindTransactionBySequenceNumber_(CF_CListNode_t *n, trans_seq_arg_t *context);
+int CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context);
 
 int32 CF_WriteQueueDataToFile(int32 fd, CF_Channel_t *c, CF_QueueIdx_t q);
 int32 CF_WriteHistoryQueueDataToFile(int32 fd, CF_Channel_t *c, CF_Direction_t dir);
@@ -173,9 +173,9 @@ void CF_InsertSortPrio(CF_Transaction_t *t, CF_QueueIdx_t q);
 int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t fn, void *context);
 int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context);
 
-int CF_TraverseAllTransactions_(CF_CListNode_t *n, traverse_all_args_t *args);
-int CF_TraverseHistory(CF_CListNode_t *n, trav_arg_t *context);
-int CF_TraverseTransactions(CF_CListNode_t *n, trav_arg_t *context);
+int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args);
+int CF_TraverseHistory(CF_CListNode_t *n, CF_Traverse_WriteFileArg_t *context);
+int CF_TraverseTransactions(CF_CListNode_t *n, CF_Traverse_WriteFileArg_t *context);
 
 int32 CF_WriteQueueDataToFile(int32 fd, CF_Channel_t *c, CF_QueueIdx_t q);
 int32 CF_WriteHistoryQueueDataToFile(int32 fd, CF_Channel_t *c, CF_Direction_t dir);

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -848,10 +848,10 @@ void Test_CF_CFDP_R_SubstateSendNak(void)
     /* this requires the chunks list to be set up, and by default compute_gaps will
        return 0 (no gaps) so the transaction goes to complete */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, &t, NULL);
-    t->flags.rx.md_recv         = true;
-    t->chunks                   = &chunks;
-    chunks.chunks.count         = 1;
-    chunks.chunks.CF_max_chunks = 2;
+    t->flags.rx.md_recv      = true;
+    t->chunks                = &chunks;
+    chunks.chunks.count      = 1;
+    chunks.chunks.max_chunks = 2;
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateSendNak(t), 0);
     UtAssert_STUB_COUNT(CF_ChunkList_ComputeGaps, 1);
     UtAssert_STUB_COUNT(CF_CFDP_SendNak, 2); /* did not increment */
@@ -861,10 +861,10 @@ void Test_CF_CFDP_R_SubstateSendNak(void)
     /* this also should use the max chunks instead of count */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, &t, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_ChunkList_ComputeGaps), 1, 1);
-    t->flags.rx.md_recv         = true;
-    t->chunks                   = &chunks;
-    chunks.chunks.count         = 3;
-    chunks.chunks.CF_max_chunks = 2;
+    t->flags.rx.md_recv      = true;
+    t->chunks                = &chunks;
+    chunks.chunks.count      = 3;
+    chunks.chunks.max_chunks = 2;
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateSendNak(t), 0);
     UtAssert_STUB_COUNT(CF_CFDP_SendNak, 3);
     UtAssert_BOOL_TRUE(t->flags.rx.fd_nak_sent);

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -934,7 +934,7 @@ void Test_CF_DoChanAction_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t        *arg_cmd    = &utbuf.ua;
     const char               *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    chan_action_fn_t          arg_fn     = &Dummy_chan_action_fn_t;
+    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
     int                       dummy_context;
     void                     *arg_context    = &dummy_context;
     uint8                     random_fn_call = Any_uint8_LessThan(CF_NUM_CHANNELS) + 1;
@@ -965,7 +965,7 @@ void Test_CF_DoChanAction_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t        *arg_cmd    = &utbuf.ua;
     const char               *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    chan_action_fn_t          arg_fn     = &Dummy_chan_action_fn_t;
+    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
     int                       dummy_context;
     void                     *arg_context = &dummy_context;
     int                       local_result;
@@ -995,7 +995,7 @@ void Test_CF_DoChanAction_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t        *arg_cmd    = &utbuf.ua;
     const char               *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    chan_action_fn_t          arg_fn     = &Dummy_chan_action_fn_t;
+    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
     int                       dummy_context;
     void                     *arg_context = &dummy_context;
     int                       local_result;
@@ -1025,7 +1025,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t        *arg_cmd    = &utbuf.ua;
     const char               *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    chan_action_fn_t          arg_fn     = &Dummy_chan_action_fn_t;
+    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
     int                       dummy_context;
     void                     *arg_context = &dummy_context;
     int                       local_result;
@@ -1055,7 +1055,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t        *arg_cmd    = &utbuf.ua;
     const char               *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    chan_action_fn_t          arg_fn     = &Dummy_chan_action_fn_t;
+    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
     int                       dummy_context;
     void                     *arg_context = &dummy_context;
     int                       local_result;
@@ -1085,7 +1085,7 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t        *arg_cmd    = &utbuf.ua;
     const char               *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    chan_action_fn_t          arg_fn     = &Dummy_chan_action_fn_t;
+    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
     int                       dummy_context;
     void                     *arg_context = &dummy_context;
     int                       local_result;
@@ -1118,7 +1118,7 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t        *arg_cmd    = &utbuf.ua;
     const char               *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    chan_action_fn_t          arg_fn     = &Dummy_chan_action_fn_t;
+    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
     int                       dummy_context;
     void                     *arg_context = &dummy_context;
     int                       local_result;
@@ -1169,10 +1169,10 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
 void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
 {
     /* Arrange */
-    uint8             arg_chan_num = Any_cf_channel();
-    bool_arg_t        dummy_context;
-    const bool_arg_t *arg_context;
-    int               local_result;
+    uint8                          arg_chan_num = Any_cf_channel();
+    CF_ChanAction_BoolArg_t        dummy_context;
+    const CF_ChanAction_BoolArg_t *arg_context;
+    int                            local_result;
 
     dummy_context.barg = Any_bool_arg_t_barg();
 
@@ -1564,11 +1564,11 @@ void Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid(void)
 
 /*******************************************************************************
 **
-**  CF_DoSuspRes_ tests
+**  CF_DoSuspRes_Txn tests
 **
 *******************************************************************************/
 
-void Test_CF_DoSuspRes__Asserts_t_Is_NULL(void)
+void Test_CF_DoSuspRes_Txn_Asserts_t_Is_NULL(void)
 {
     // /* Arrange */
 
@@ -1576,15 +1576,15 @@ void Test_CF_DoSuspRes__Asserts_t_Is_NULL(void)
 
     // /* Assert */
     UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert");
-} /* end Test_CF_DoSuspRes__Asserts_t_Is_NULL */
+} /* end Test_CF_DoSuspRes_Txn_Asserts_t_Is_NULL */
 
-void Test_CF_DoSuspRes__Set_context_same_To_1_suspended_Eq_action(void)
+void Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action(void)
 {
     /* Arrange */
-    CF_Transaction_t  dummy_t;
-    CF_Transaction_t *arg_t = &dummy_t;
-    susp_res_arg_t    dummy_context;
-    susp_res_arg_t   *arg_context = &dummy_context;
+    CF_Transaction_t            dummy_t;
+    CF_Transaction_t           *arg_t = &dummy_t;
+    CF_ChanAction_SuspResArg_t  dummy_context;
+    CF_ChanAction_SuspResArg_t *arg_context = &dummy_context;
 
     /* set same to 0 to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
@@ -1594,20 +1594,20 @@ void Test_CF_DoSuspRes__Set_context_same_To_1_suspended_Eq_action(void)
     arg_t->flags.com.suspended = arg_context->action;
 
     /* Act */
-    CF_DoSuspRes_(arg_t, arg_context);
+    CF_DoSuspRes_Txn(arg_t, arg_context);
 
     /* Assert */
-    UtAssert_True(arg_context->same == 1, "CF_DoSuspRes_ set context->same to %d and should be 1 (direct set)",
+    UtAssert_True(arg_context->same == 1, "CF_DoSuspRes_Txn set context->same to %d and should be 1 (direct set)",
                   arg_context->same);
-} /* end Test_CF_DoSuspRes__Set_context_same_To_1_suspended_Eq_action */
+} /* end Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action */
 
-void Test_CF_DoSuspRes__When_suspended_NotEqTo_action_Set_suspended_To_action(void)
+void Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action(void)
 {
     /* Arrange */
-    CF_Transaction_t  dummy_t;
-    CF_Transaction_t *arg_t = &dummy_t;
-    susp_res_arg_t    dummy_context;
-    susp_res_arg_t   *arg_context = &dummy_context;
+    CF_Transaction_t            dummy_t;
+    CF_Transaction_t           *arg_t = &dummy_t;
+    CF_ChanAction_SuspResArg_t  dummy_context;
+    CF_ChanAction_SuspResArg_t *arg_context = &dummy_context;
 
     /* set same to 0 to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
@@ -1617,13 +1617,13 @@ void Test_CF_DoSuspRes__When_suspended_NotEqTo_action_Set_suspended_To_action(vo
     arg_t->flags.com.suspended = !arg_context->action;
 
     /* Act */
-    CF_DoSuspRes_(arg_t, arg_context);
+    CF_DoSuspRes_Txn(arg_t, arg_context);
 
     /* Assert */
     UtAssert_True(arg_t->flags.com.suspended == arg_context->action,
-                  "CF_DoSuspRes_ set arg_t->flags.com.suspended to %d and should be %d (context->action)",
+                  "CF_DoSuspRes_Txn set arg_t->flags.com.suspended to %d and should be %d (context->action)",
                   arg_t->flags.com.suspended, arg_context->action);
-} /* end Test_CF_DoSuspRes__When_suspended_NotEqTo_action_Set_suspended_To_action */
+} /* end Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action */
 
 /*******************************************************************************
 **
@@ -1653,7 +1653,7 @@ void Test_CF_DoSuspRes_CallTo_CF_TsnChanAction_Returns_0_And_args_same_WasChange
     UT_SetDataBuffer(UT_KEY(CF_FindTransactionBySequenceNumber), &context_CF_FindTransactionBySequenceNumber,
                      sizeof(context_CF_FindTransactionBySequenceNumber), false);
 
-    /* Arrange unstubbable: CF_DoSuspRes_ */
+    /* Arrange unstubbable: CF_DoSuspRes_Txn */
     dummy_t->flags.com.suspended = arg_action;
 
     /* Arrange unstubbable: CF_CmdRej */
@@ -1777,7 +1777,7 @@ void Test_CF_DoSuspRes_CallTo_CF_TsnChanAction_Returns_0_And_args_same_WasNotCha
     UT_SetDataBuffer(UT_KEY(CF_TraverseAllTransactions_All_Channels), &context_CF_TraverseAllTransactions_All_Channels,
                      sizeof(context_CF_TraverseAllTransactions_All_Channels), false);
 
-    /* Arrange unstubbable: CF_DoSuspRes_ */
+    /* Arrange unstubbable: CF_DoSuspRes_Txn */
     dummy_t->flags.com.suspended = arg_action;
 
     /* Arrange unstubbable: CF_CmdAcc */
@@ -1884,11 +1884,11 @@ void Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0(void)
 
 /*******************************************************************************
 **
-**  CF_CmdCancel_ tests
+**  CF_CmdCancel_Txn tests
 **
 *******************************************************************************/
 
-void Test_CF_CmdCancel__Call_CF_CFDP_CancelTransaction_WithGiven_t(void)
+void Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t(void)
 {
     /* Arrange */
     CF_Transaction_t  dummy_t;
@@ -1900,12 +1900,12 @@ void Test_CF_CmdCancel__Call_CF_CFDP_CancelTransaction_WithGiven_t(void)
                      sizeof(context_CF_CFDP_CancelTransaction), false);
 
     /* Act */
-    CF_CmdCancel_(arg_t, arg_ignored);
+    CF_CmdCancel_Txn(arg_t, arg_ignored);
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_CF_CFDP_CancelTransaction, arg_t);
 
-} /* end Test_CF_CmdCancel__Call_CF_CFDP_CancelTransaction_WithGiven_t */
+} /* end Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t */
 
 /*******************************************************************************
 **
@@ -1945,8 +1945,8 @@ void Test_CF_CmdCancel_Call_CF_CmdCond_WithNotted_CF_TsnChanAction(void)
     /* Assert for CF_TsnChanAction */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_ADDRESS_EQ(context_CF_TraverseAllTransactions.c, CF_AppData.engine.channels + dummy_msg->chan);
-    UtAssert_True(context_CF_TraverseAllTransactions.fn == CF_CmdCancel_,
-                  "context_CF_TraverseAllTransactions.fn ==  CF_CmdCancel_");
+    UtAssert_True(context_CF_TraverseAllTransactions.fn == CF_CmdCancel_Txn,
+                  "context_CF_TraverseAllTransactions.fn ==  CF_CmdCancel_Txn");
     UtAssert_ADDRESS_EQ(context_CF_TraverseAllTransactions.context, NULL);
     /* Assert for CF_CmdRej */
     UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
@@ -1956,11 +1956,11 @@ void Test_CF_CmdCancel_Call_CF_CmdCond_WithNotted_CF_TsnChanAction(void)
 
 /*******************************************************************************
 **
-**  CF_CmdAbandon_ tests
+**  CF_CmdAbandon_Txn tests
 **
 *******************************************************************************/
 
-void Test_CF_CmdAbandon__Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void)
+void Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void)
 {
     /* Arrange */
     CF_Transaction_t                   dummy_t;
@@ -1972,7 +1972,7 @@ void Test_CF_CmdAbandon__Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void)
                      sizeof(context_CF_CFDP_ResetTransaction), false);
 
     /* Act */
-    CF_CmdAbandon_(arg_t, arg_ignored);
+    CF_CmdAbandon_Txn(arg_t, arg_ignored);
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetTransaction.t, arg_t);
@@ -1980,7 +1980,7 @@ void Test_CF_CmdAbandon__Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void)
                   "CF_CFDP_CancelTransaction was called with int %d and should be 0 (constant in call)",
                   context_CF_CFDP_ResetTransaction.keep_history);
 
-} /* end Test_CF_CmdAbandon__Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0 */
+} /* end Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0 */
 
 /*******************************************************************************
 **
@@ -2020,8 +2020,8 @@ void Test_CF_CmdAbandon_Call_CF_CmdCond_WithNotted_CF_TsnChanAction(void)
     /* Assert for CF_TsnChanAction */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_ADDRESS_EQ(context_CF_TraverseAllTransactions.c, CF_AppData.engine.channels + dummy_msg->chan);
-    UtAssert_True(context_CF_TraverseAllTransactions.fn == CF_CmdAbandon_,
-                  "context_CF_TraverseAllTransactions.fn ==  CF_CmdAbandon_");
+    UtAssert_True(context_CF_TraverseAllTransactions.fn == CF_CmdAbandon_Txn,
+                  "context_CF_TraverseAllTransactions.fn ==  CF_CmdAbandon_Txn");
     UtAssert_ADDRESS_EQ(context_CF_TraverseAllTransactions.context, NULL);
     /* Assert for CF_CmdRej */
     UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
@@ -2038,10 +2038,10 @@ void Test_CF_CmdAbandon_Call_CF_CmdCond_WithNotted_CF_TsnChanAction(void)
 void Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg(void)
 {
     /* Arrange */
-    CF_ConfigTable_t dummy_config_table;
-    uint8            arg_chan_num = Any_cf_channel();
-    bool_arg_t       dummy_context;
-    bool_arg_t      *arg_context = &dummy_context;
+    CF_ConfigTable_t         dummy_config_table;
+    uint8                    arg_chan_num = Any_cf_channel();
+    CF_ChanAction_BoolArg_t  dummy_context;
+    CF_ChanAction_BoolArg_t *arg_context = &dummy_context;
 
     CF_AppData.config_table = &dummy_config_table;
     dummy_context.barg      = Any_bool_arg_t_barg();
@@ -2152,14 +2152,14 @@ void Test_CF_CmdDisableDequeue_Call_CmdCond_WithResultsOf_CF_DoChanAction(void)
 void Test_CF_DoEnableDisablePolldir_When_ALL_CHANNELS_SetAllPolldirsInChannelEnabledTo_context_barg(void)
 {
     /* Arrange */
-    uint8                     arg_chan_num = Any_cf_channel();
-    CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t        *dummy_msg = &utbuf.ua;
-    bool_msg_arg_t            dummy_context;
-    bool_msg_arg_t           *arg_context = &dummy_context;
-    CF_ConfigTable_t          dummy_config_table;
-    uint8                     expected_enabled;
-    int                       local_result;
+    uint8                       arg_chan_num = Any_cf_channel();
+    CF_UT_cmd_unionargs_buf_t   utbuf;
+    CF_UnionArgsCmd_t          *dummy_msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  dummy_context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
+    CF_ConfigTable_t            dummy_config_table;
+    uint8                       expected_enabled;
+    int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2190,15 +2190,15 @@ void Test_CF_DoEnableDisablePolldir_When_ALL_CHANNELS_SetAllPolldirsInChannelEna
 void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg(void)
 {
     /* Arrange */
-    uint8                     arg_chan_num  = Any_cf_channel();
-    uint8                     dummy_polldir = Any_cf_polldir();
-    CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t        *dummy_msg = &utbuf.ua;
-    bool_msg_arg_t            dummy_context;
-    bool_msg_arg_t           *arg_context = &dummy_context;
-    CF_ConfigTable_t          dummy_config_table;
-    uint8                     expected_enabled;
-    int                       local_result;
+    uint8                       arg_chan_num  = Any_cf_channel();
+    uint8                       dummy_polldir = Any_cf_polldir();
+    CF_UT_cmd_unionargs_buf_t   utbuf;
+    CF_UnionArgsCmd_t          *dummy_msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  dummy_context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
+    CF_ConfigTable_t            dummy_config_table;
+    uint8                       expected_enabled;
+    int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2224,13 +2224,13 @@ void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_conte
 void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent(void)
 {
     /* Arrange */
-    uint8                     arg_chan_num = Any_cf_channel();
-    CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t        *dummy_msg = &utbuf.ua;
-    bool_msg_arg_t            dummy_context;
-    bool_msg_arg_t           *arg_context = &dummy_context;
-    CF_ConfigTable_t          dummy_config_table;
-    int                       local_result;
+    uint8                       arg_chan_num = Any_cf_channel();
+    CF_UT_cmd_unionargs_buf_t   utbuf;
+    CF_UnionArgsCmd_t          *dummy_msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  dummy_context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
+    CF_ConfigTable_t            dummy_config_table;
+    int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2255,13 +2255,13 @@ void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_An
 void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
 {
     /* Arrange */
-    uint8                     arg_chan_num = Any_cf_channel();
-    CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t        *dummy_msg = &utbuf.ua;
-    bool_msg_arg_t            dummy_context;
-    bool_msg_arg_t           *arg_context = &dummy_context;
-    CF_ConfigTable_t          dummy_config_table;
-    int                       local_result;
+    uint8                       arg_chan_num = Any_cf_channel();
+    CF_UT_cmd_unionargs_buf_t   utbuf;
+    CF_UnionArgsCmd_t          *dummy_msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  dummy_context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
+    CF_ConfigTable_t            dummy_config_table;
+    int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -5085,15 +5085,15 @@ void add_CF_TsnChanAction_tests(void)
                "Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid");
 } /* end add_CF_TsnChanAction_tests */
 
-void add_CF_DoSuspRes__tests(void)
+void add_CF_DoSuspRes_Txn_tests(void)
 {
-    UtTest_Add(Test_CF_DoSuspRes__Asserts_t_Is_NULL, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
-               "Test_CF_DoSuspRes__Asserts_t_Is_NULL");
-    UtTest_Add(Test_CF_DoSuspRes__Set_context_same_To_1_suspended_Eq_action, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
-               "Test_CF_DoSuspRes__Set_context_same_To_1_suspended_Eq_action");
-    UtTest_Add(Test_CF_DoSuspRes__When_suspended_NotEqTo_action_Set_suspended_To_action, cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown, "Test_CF_DoSuspRes__When_suspended_NotEqTo_action_Set_suspended_To_action");
-} /* end add_CF_DoSuspRes__tests */
+    UtTest_Add(Test_CF_DoSuspRes_Txn_Asserts_t_Is_NULL, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
+               "Test_CF_DoSuspRes_Txn_Asserts_t_Is_NULL");
+    UtTest_Add(Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action, cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown, "Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action");
+    UtTest_Add(Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action, cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown, "Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action");
+} /* end add_CF_DoSuspRes_Txn_tests */
 
 void add_CF_DoSuspRes_tests(void)
 {
@@ -5127,11 +5127,11 @@ void add_CF_CmdResume_tests(void)
                cf_cmd_tests_Teardown, "Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0");
 } /* end add_CF_CmdResume_tests */
 
-void add_CF_CmdCancel__tests(void)
+void add_CF_CmdCancel_Txn_tests(void)
 {
-    UtTest_Add(Test_CF_CmdCancel__Call_CF_CFDP_CancelTransaction_WithGiven_t, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
-               "Test_CF_CmdCancel__Call_CF_CFDP_CancelTransaction_WithGiven_t");
-} /* end add_CF_CF_CmdCancel__tests */
+    UtTest_Add(Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t, cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown, "Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t");
+} /* end add_CF_CF_CmdCancel_Txn_tests */
 
 void add_CF_CmdCancel_tests(void)
 {
@@ -5139,17 +5139,17 @@ void add_CF_CmdCancel_tests(void)
                "Test_CF_CmdCancel_Call_CF_CmdCond_WithNotted_CF_TsnChanAction");
 } /* end add_CF_CmdCancel_tests */
 
-void add_CF_CmdAbandon__tests(void)
+void add_CF_CmdAbandon_Txn_tests(void)
 {
-    UtTest_Add(Test_CF_CmdAbandon__Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0, cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown, "Test_CF_CmdAbandon__Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0");
-} /* end add_CF_CmdAbandon__tests */
+    UtTest_Add(Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0, cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown, "Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0");
+} /* end add_CF_CmdAbandon_Txn_tests */
 
 void add_CF_CmdAbandon_tests(void)
 {
     UtTest_Add(Test_CF_CmdAbandon_Call_CF_CmdCond_WithNotted_CF_TsnChanAction, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdAbandon_Call_CF_CmdCond_WithNotted_CF_TsnChanAction");
-} /* end add_CF_CmdAbandon__tests */
+} /* end add_CF_CmdAbandon_Txn_tests */
 
 void add_CF_DoEnableDisableDequeue_tests(void)
 {
@@ -5467,7 +5467,7 @@ void UtTest_Setup(void)
 
     add_CF_TsnChanAction_tests();
 
-    add_CF_DoSuspRes__tests();
+    add_CF_DoSuspRes_Txn_tests();
 
     add_CF_DoSuspRes_tests();
 
@@ -5475,11 +5475,11 @@ void UtTest_Setup(void)
 
     add_CF_CmdResume_tests();
 
-    add_CF_CmdCancel__tests();
+    add_CF_CmdCancel_Txn_tests();
 
     add_CF_CmdCancel_tests();
 
-    add_CF_CmdAbandon__tests();
+    add_CF_CmdAbandon_Txn_tests();
 
     add_CF_CmdAbandon_tests();
 

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -160,19 +160,19 @@ void CF_CFDP_CycleTx(CF_Channel_t *c)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CFDP_CycleTx_()
+ * Generated stub function for CF_CFDP_CycleTxFirstActive()
  * ----------------------------------------------------
  */
-int CF_CFDP_CycleTx_(CF_CListNode_t *node, void *context)
+int CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_CycleTx_, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_CycleTxFirstActive, int);
 
-    UT_GenStub_AddParam(CF_CFDP_CycleTx_, CF_CListNode_t *, node);
-    UT_GenStub_AddParam(CF_CFDP_CycleTx_, void *, context);
+    UT_GenStub_AddParam(CF_CFDP_CycleTxFirstActive, CF_CListNode_t *, node);
+    UT_GenStub_AddParam(CF_CFDP_CycleTxFirstActive, void *, context);
 
-    UT_GenStub_Execute(CF_CFDP_CycleTx_, Basic, NULL);
+    UT_GenStub_Execute(CF_CFDP_CycleTxFirstActive, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_CycleTx_, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_CycleTxFirstActive, int);
 }
 
 /*

--- a/unit-test/stubs/cf_chunk_stubs.c
+++ b/unit-test/stubs/cf_chunk_stubs.c
@@ -54,10 +54,10 @@ void CF_ChunkListAdd(CF_ChunkList_t *chunks, CF_ChunkOffset_t offset, CF_ChunkSi
  * Generated stub function for CF_ChunkListInit()
  * ----------------------------------------------------
  */
-void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t CF_max_chunks, CF_Chunk_t *chunks_mem)
+void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t max_chunks, CF_Chunk_t *chunks_mem)
 {
     UT_GenStub_AddParam(CF_ChunkListInit, CF_ChunkList_t *, chunks);
-    UT_GenStub_AddParam(CF_ChunkListInit, CF_ChunkIdx_t, CF_max_chunks);
+    UT_GenStub_AddParam(CF_ChunkListInit, CF_ChunkIdx_t, max_chunks);
     UT_GenStub_AddParam(CF_ChunkListInit, CF_Chunk_t *, chunks_mem);
 
     UT_GenStub_Execute(CF_ChunkListInit, Basic, NULL);

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -44,15 +44,15 @@ void CF_CmdAbandon(CFE_SB_Buffer_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CmdAbandon_()
+ * Generated stub function for CF_CmdAbandon_Txn()
  * ----------------------------------------------------
  */
-void CF_CmdAbandon_(CF_Transaction_t *t, void *ignored)
+void CF_CmdAbandon_Txn(CF_Transaction_t *t, void *ignored)
 {
-    UT_GenStub_AddParam(CF_CmdAbandon_, CF_Transaction_t *, t);
-    UT_GenStub_AddParam(CF_CmdAbandon_, void *, ignored);
+    UT_GenStub_AddParam(CF_CmdAbandon_Txn, CF_Transaction_t *, t);
+    UT_GenStub_AddParam(CF_CmdAbandon_Txn, void *, ignored);
 
-    UT_GenStub_Execute(CF_CmdAbandon_, Basic, NULL);
+    UT_GenStub_Execute(CF_CmdAbandon_Txn, Basic, NULL);
 }
 
 /*
@@ -69,15 +69,15 @@ void CF_CmdCancel(CFE_SB_Buffer_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CmdCancel_()
+ * Generated stub function for CF_CmdCancel_Txn()
  * ----------------------------------------------------
  */
-void CF_CmdCancel_(CF_Transaction_t *t, void *ignored)
+void CF_CmdCancel_Txn(CF_Transaction_t *t, void *ignored)
 {
-    UT_GenStub_AddParam(CF_CmdCancel_, CF_Transaction_t *, t);
-    UT_GenStub_AddParam(CF_CmdCancel_, void *, ignored);
+    UT_GenStub_AddParam(CF_CmdCancel_Txn, CF_Transaction_t *, t);
+    UT_GenStub_AddParam(CF_CmdCancel_Txn, void *, ignored);
 
-    UT_GenStub_Execute(CF_CmdCancel_, Basic, NULL);
+    UT_GenStub_Execute(CF_CmdCancel_Txn, Basic, NULL);
 }
 
 /*
@@ -362,13 +362,13 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_DoChanAction()
  * ----------------------------------------------------
  */
-int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, chan_action_fn_t fn, void *context)
+int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_DoChanAction, int);
 
     UT_GenStub_AddParam(CF_DoChanAction, CF_UnionArgsCmd_t *, cmd);
     UT_GenStub_AddParam(CF_DoChanAction, const char *, errstr);
-    UT_GenStub_AddParam(CF_DoChanAction, chan_action_fn_t, fn);
+    UT_GenStub_AddParam(CF_DoChanAction, CF_ChanActionFn_t, fn);
     UT_GenStub_AddParam(CF_DoChanAction, void *, context);
 
     UT_GenStub_Execute(CF_DoChanAction, Basic, NULL);
@@ -381,12 +381,12 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, chan_action_fn_t
  * Generated stub function for CF_DoEnableDisableDequeue()
  * ----------------------------------------------------
  */
-int CF_DoEnableDisableDequeue(uint8 chan_num, const bool_arg_t *context)
+int CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_DoEnableDisableDequeue, int);
 
     UT_GenStub_AddParam(CF_DoEnableDisableDequeue, uint8, chan_num);
-    UT_GenStub_AddParam(CF_DoEnableDisableDequeue, const bool_arg_t *, context);
+    UT_GenStub_AddParam(CF_DoEnableDisableDequeue, const CF_ChanAction_BoolArg_t *, context);
 
     UT_GenStub_Execute(CF_DoEnableDisableDequeue, Basic, NULL);
 
@@ -398,12 +398,12 @@ int CF_DoEnableDisableDequeue(uint8 chan_num, const bool_arg_t *context)
  * Generated stub function for CF_DoEnableDisablePolldir()
  * ----------------------------------------------------
  */
-int CF_DoEnableDisablePolldir(uint8 chan_num, const bool_msg_arg_t *context)
+int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_DoEnableDisablePolldir, int);
 
     UT_GenStub_AddParam(CF_DoEnableDisablePolldir, uint8, chan_num);
-    UT_GenStub_AddParam(CF_DoEnableDisablePolldir, const bool_msg_arg_t *, context);
+    UT_GenStub_AddParam(CF_DoEnableDisablePolldir, const CF_ChanAction_BoolMsgArg_t *, context);
 
     UT_GenStub_Execute(CF_DoEnableDisablePolldir, Basic, NULL);
 
@@ -415,12 +415,12 @@ int CF_DoEnableDisablePolldir(uint8 chan_num, const bool_msg_arg_t *context)
  * Generated stub function for CF_DoFreezeThaw()
  * ----------------------------------------------------
  */
-int CF_DoFreezeThaw(uint8 chan_num, const bool_arg_t *context)
+int CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_DoFreezeThaw, int);
 
     UT_GenStub_AddParam(CF_DoFreezeThaw, uint8, chan_num);
-    UT_GenStub_AddParam(CF_DoFreezeThaw, const bool_arg_t *, context);
+    UT_GenStub_AddParam(CF_DoFreezeThaw, const CF_ChanAction_BoolArg_t *, context);
 
     UT_GenStub_Execute(CF_DoFreezeThaw, Basic, NULL);
 
@@ -459,15 +459,15 @@ void CF_DoSuspRes(CF_TransactionCmd_t *cmd, uint8 action)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_DoSuspRes_()
+ * Generated stub function for CF_DoSuspRes_Txn()
  * ----------------------------------------------------
  */
-void CF_DoSuspRes_(CF_Transaction_t *t, susp_res_arg_t *context)
+void CF_DoSuspRes_Txn(CF_Transaction_t *t, CF_ChanAction_SuspResArg_t *context)
 {
-    UT_GenStub_AddParam(CF_DoSuspRes_, CF_Transaction_t *, t);
-    UT_GenStub_AddParam(CF_DoSuspRes_, susp_res_arg_t *, context);
+    UT_GenStub_AddParam(CF_DoSuspRes_Txn, CF_Transaction_t *, t);
+    UT_GenStub_AddParam(CF_DoSuspRes_Txn, CF_ChanAction_SuspResArg_t *, context);
 
-    UT_GenStub_Execute(CF_DoSuspRes_, Basic, NULL);
+    UT_GenStub_Execute(CF_DoSuspRes_Txn, Basic, NULL);
 }
 
 /*

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -63,19 +63,19 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *c, CF_Transac
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_FindTransactionBySequenceNumber_()
+ * Generated stub function for CF_FindTransactionBySequenceNumber_Impl()
  * ----------------------------------------------------
  */
-int CF_FindTransactionBySequenceNumber_(CF_CListNode_t *n, trans_seq_arg_t *context)
+int CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_FindTransactionBySequenceNumber_, int);
+    UT_GenStub_SetupReturnBuffer(CF_FindTransactionBySequenceNumber_Impl, int);
 
-    UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber_, CF_CListNode_t *, n);
-    UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber_, trans_seq_arg_t *, context);
+    UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber_Impl, CF_CListNode_t *, n);
+    UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber_Impl, CF_Traverse_TransSeqArg_t *, context);
 
-    UT_GenStub_Execute(CF_FindTransactionBySequenceNumber_, Basic, NULL);
+    UT_GenStub_Execute(CF_FindTransactionBySequenceNumber_Impl, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_FindTransactionBySequenceNumber_, int);
+    return UT_GenStub_GetReturnValue(CF_FindTransactionBySequenceNumber_Impl, int);
 }
 
 /*
@@ -169,23 +169,6 @@ int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t 
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_TraverseAllTransactions_()
- * ----------------------------------------------------
- */
-int CF_TraverseAllTransactions_(CF_CListNode_t *n, traverse_all_args_t *args)
-{
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_, int);
-
-    UT_GenStub_AddParam(CF_TraverseAllTransactions_, CF_CListNode_t *, n);
-    UT_GenStub_AddParam(CF_TraverseAllTransactions_, traverse_all_args_t *, args);
-
-    UT_GenStub_Execute(CF_TraverseAllTransactions_, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_, int);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_TraverseAllTransactions_All_Channels()
  * ----------------------------------------------------
  */
@@ -204,15 +187,32 @@ int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, 
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_TraverseAllTransactions_Impl()
+ * ----------------------------------------------------
+ */
+int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args)
+{
+    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_Impl, int);
+
+    UT_GenStub_AddParam(CF_TraverseAllTransactions_Impl, CF_CListNode_t *, n);
+    UT_GenStub_AddParam(CF_TraverseAllTransactions_Impl, CF_TraverseAll_Arg_t *, args);
+
+    UT_GenStub_Execute(CF_TraverseAllTransactions_Impl, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_Impl, int);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_TraverseHistory()
  * ----------------------------------------------------
  */
-int CF_TraverseHistory(CF_CListNode_t *n, trav_arg_t *context)
+int CF_TraverseHistory(CF_CListNode_t *n, CF_Traverse_WriteFileArg_t *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_TraverseHistory, int);
 
     UT_GenStub_AddParam(CF_TraverseHistory, CF_CListNode_t *, n);
-    UT_GenStub_AddParam(CF_TraverseHistory, trav_arg_t *, context);
+    UT_GenStub_AddParam(CF_TraverseHistory, CF_Traverse_WriteFileArg_t *, context);
 
     UT_GenStub_Execute(CF_TraverseHistory, Basic, NULL);
 
@@ -224,12 +224,12 @@ int CF_TraverseHistory(CF_CListNode_t *n, trav_arg_t *context)
  * Generated stub function for CF_TraverseTransactions()
  * ----------------------------------------------------
  */
-int CF_TraverseTransactions(CF_CListNode_t *n, trav_arg_t *context)
+int CF_TraverseTransactions(CF_CListNode_t *n, CF_Traverse_WriteFileArg_t *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_TraverseTransactions, int);
 
     UT_GenStub_AddParam(CF_TraverseTransactions, CF_CListNode_t *, n);
-    UT_GenStub_AddParam(CF_TraverseTransactions, trav_arg_t *, context);
+    UT_GenStub_AddParam(CF_TraverseTransactions, CF_Traverse_WriteFileArg_t *, context);
 
     UT_GenStub_Execute(CF_TraverseTransactions, Basic, NULL);
 

--- a/unit-test/utilities/cf_test_alt_handler.c
+++ b/unit-test/utilities/cf_test_alt_handler.c
@@ -16,13 +16,13 @@
  * Function: UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T
  *
  * A handler for CF_CList_Traverse which saves its arguments
- * including the opaque context pointer as a trav_arg_t object.
+ * including the opaque context pointer as a CF_Traverse_WriteFileArg_t object.
  *
  *-----------------------------------------------------------------*/
 void UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     CF_CList_Traverse_TRAV_ARG_T_context_t *ctxt;
-    trav_arg_t                             *arg = UT_Hook_GetArgValueByName(Context, "context", trav_arg_t *);
+    CF_Traverse_WriteFileArg_t *arg = UT_Hook_GetArgValueByName(Context, "context", CF_Traverse_WriteFileArg_t *);
 
     if (UserObj)
     {
@@ -51,14 +51,14 @@ void UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T(void *UserObj, UT_EntryKey_t Fun
  * Function: UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T
  *
  * A handler for CF_CList_Traverse which saves its arguments
- * including the opaque context pointer as a traverse_all_args_t object.
+ * including the opaque context pointer as a CF_TraverseAll_Arg_t object.
  *
  *-----------------------------------------------------------------*/
 void UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T(void *UserObj, UT_EntryKey_t FuncKey,
                                                          const UT_StubContext_t *Context)
 {
     CF_CList_Traverse_TRAVERSE_ALL_ARGS_T_context_t *ctxt;
-    traverse_all_args_t *arg = UT_Hook_GetArgValueByName(Context, "context", traverse_all_args_t *);
+    CF_TraverseAll_Arg_t *arg = UT_Hook_GetArgValueByName(Context, "context", CF_TraverseAll_Arg_t *);
 
     if (UserObj)
     {
@@ -122,13 +122,13 @@ void UT_AltHandler_CF_CList_Traverse_POINTER(void *UserObj, UT_EntryKey_t FuncKe
  * Function: UT_AltHandler_CF_CList_Traverse_R_PRIO
  *
  * A handler for CF_CList_Traverse which saves its arguments
- * including the opaque context pointer as a priority_arg_t object.
+ * including the opaque context pointer as a CF_Traverse_PriorityArg_t object.
  *
  *-----------------------------------------------------------------*/
 void UT_AltHandler_CF_CList_Traverse_R_PRIO(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     CF_CList_Traverse_R_context_t *ctxt;
-    priority_arg_t                *arg = UT_Hook_GetArgValueByName(Context, "context", priority_arg_t *);
+    CF_Traverse_PriorityArg_t     *arg = UT_Hook_GetArgValueByName(Context, "context", CF_Traverse_PriorityArg_t *);
 
     if (UserObj)
     {


### PR DESCRIPTION
**Describe the contribution**
Renames all remaining identifiers that did not have an appropriate name per the coding standards.  Specifically, this is anything
that did not start with CF prefix (#149) and anything that ended with an underscore only (#110).

Fixes #149 
Fixes #110

**Testing performed**
Build and sanity check CF, run all tests
Execute test file transfer between two CFE nodes

**Expected behavior changes**
None, internal symbol rename only

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

