### PR TITLE
Fix #62, make entity ID default to 32 bit

### DIFF
--- a/fsw/platform_inc/cf_platform_cfg.h
+++ b/fsw/platform_inc/cf_platform_cfg.h
@@ -43,7 +43,7 @@
  ** \par Limits
  **         Must be one of uint8, uint16, uint32, uint64.
  */
-typedef uint8 CF_EntityId_t;
+typedef uint32 CF_EntityId_t;
 
 /**
  ** \cfcfg transaction sequence number size

--- a/fsw/src/cf_msg.h
+++ b/fsw/src/cf_msg.h
@@ -227,7 +227,8 @@ typedef struct CF_TransactionCmd
     CFE_MSG_CommandHeader_t cmd_header;
     CF_TransactionSeq_t     ts;
     CF_EntityId_t           eid;
-    uint8                   chan; /* if 254, use ts. if 255, all channels */
+    uint8                   chan;     /* if 254, use ts. if 255, all channels */
+    uint8                   spare[3]; /* To make structure a multiple of uint32 */
 } CF_TransactionCmd_t;
 
 #endif /* !CF_MSG_H */


### PR DESCRIPTION
**Describe the contribution**
Entity IDs should be larger by default for real-world applicability, as this also restricts what CFDP can receive, not just what it sends.  Note CFDP will only use the number of bytes required to express the value, so values less than 256 will
still only use 1 byte, regardless of this config.  This just allows use of larger values.

Fixes #62

**Testing performed**
Build and sanity check CF

**Expected behavior changes**
Default "out of the box" config should support entity ID values up to 32 bits.  

**System(s) tested on**
Ubuntu 21.10

**Additional context**
This only affects what CF is capable of handling, if running with small (<256) entity ID values, there is no change to the runtime behavior at all; they will still be 8 bits in practice.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
