### PR TITLE
Fix #61, remove dependence on ENDIAN macro for checksum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,6 @@ add_cfe_app(cf ${APP_SRC_FILES})
 # configuration table
 add_cfe_tables(cf fsw/tables/cf_def_config.c)
 
-add_definitions("-D_DEFAULT_SOURCE")
-
-add_definitions(-D_DEFAULT_SOURCE=1)
-add_definitions(-D_EL -DENDIAN=_EL -DSOFTWARE_BIG_BIT_ORDER)
 if (ENABLE_UNIT_TESTS)
   add_subdirectory(unit-test)
 endif (ENABLE_UNIT_TESTS)

--- a/fsw/platform_inc/cf_platform_cfg.h
+++ b/fsw/platform_inc/cf_platform_cfg.h
@@ -59,18 +59,6 @@ typedef uint8 CF_EntityId_t;
 typedef uint32 CF_TransactionSeq_t;
 
 /**
- ** \cfcfg CF_HW_ALIGNMENT and CF_SW_ALIGNMENT
- **
- **  \par Description:
- **       ONE AND ONLY ONE must be #define.
- **
- **     CF_HW_ALIGNMENT is set for platforms that can handle alignment in hardware (load/store used)
- **     CF_SW_ALIGNMENT is for platforms that can't handle alignment natively (memcpy used)
- */
-#define CF_HW_ALIGNMENT
-#undef CF_SW_ALIGNMENT
-
-/**
 **  \cfcfg Application Pipe Depth
 **
 **  \par Description:

--- a/fsw/src/cf_crc.c
+++ b/fsw/src/cf_crc.c
@@ -61,8 +61,6 @@ void CF_CRC_Digest(CF_Crc_t *c, const uint8 *data, int len)
 {
     int i = 0;
 
-    /* can't use big-endian optimization with CF_SW_ALIGNMENT */
-#if (ENDIAN == _EL) || defined(CF_SW_ALIGNMENT)
     for (; i < len; ++i)
     {
         c->working <<= 8;
@@ -74,37 +72,6 @@ void CF_CRC_Digest(CF_Crc_t *c, const uint8 *data, int len)
             c->index = 0;
         }
     }
-#elif (ENDIAN == _EB) && defined(CF_HW_ALIGNMENT)
-    /* first get index to 0 byte-by-byte */
-    if (c->index)
-    {
-        for (; (c->index < 4) && (i < len); ++i, ++c->index)
-        {
-            c->working <<= 8;
-            c->working |= data[i];
-        }
-
-        c->result += c->working;
-        c->index = 0;
-    }
-
-    /* next, process data 4 bytes at a time like a boss */
-    for (/* keep previous i value */; (i + 4) <= len; i += 4)
-    {
-        c->result += (*(uint32 *)(void *)(data + i));
-    }
-
-    /* anything left over has to go back into the shift register */
-    for (/* keep previous i value */; i < len; ++i)
-    {
-        c->working <<= 8;
-        c->working |= data[i];
-
-        ++c->index;
-    }
-#else
-#error well this is odd
-#endif
 }
 
 /************************************************************************/

--- a/fsw/src/cf_verify.h
+++ b/fsw/src/cf_verify.h
@@ -44,22 +44,6 @@
 #error refactor code for 32 bit CF_NUM_HISTORIES
 #endif
 
-#if !defined(CF_HW_ALIGNMENT) && !defined(CF_SW_ALIGNMENT)
-#error Must define one of CF_HW_ALIGNMENT or CF_SW_ALIGNMENT
-#endif
-
-#if defined(CF_HW_ALIGNMENT) && defined(CF_SW_ALIGNMENT)
-#error Must define ONLY ONE of CF_HW_ALIGNMENT or CF_SW_ALIGNMENT
-#endif
-
-#if !defined(ENDIAN)
-#error Must define ENDIAN as _EL or _EB for little or big endian
-#endif
-
-#if (ENDIAN != _EL) && (ENDIAN != _EB)
-#error Must define ENDIAN as either _EL or _EB for little or big endian
-#endif
-
 #if (CF_PERF_ID_PDURCVD(CF_NUM_CHANNELS - 1) >= CF_PERF_ID_PDUSENT(0))
 #error Collision between CF_PERF_ID_PDURCVD and CF_PERF_ID_PDUSENT given number of channels
 #endif


### PR DESCRIPTION
**Describe the contribution**
Removes the checksum "optimization" for big endian, as it is unlikely to be useful and creates endianness dependencies.

Fixes #61

**Testing performed**
Build and sanity check CF

**Expected behavior changes**
None on x86/little endian (removes code that was not used)
PPC/big endian will use the same code as x86, might be a bit slower but its safer and more testable (because its the same code)

**System(s) tested on**
Ubuntu 21.10

**Additional context**
The big endian optimization is probably not that useful because it requires that the HW can do misaligned 32-bit reads.  AFAIK most embedded CPUs do not have this capability, and if they can, it might not be all that much faster than reading it byte-by-byte.  So even though it looks like a 32-bit read in C code (and therefore 4x fewer loop iterations) it probably doesn't have much of a payoff, if one could find a hardware with this capability (not sure how it was originally tested).  In the end I don't think its worth trying to test and maintain this "optimization".

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

