### PR TITLE
Fix #161, disable the engine in CF_CFDP_DisableEngine

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -1921,6 +1921,8 @@ void CF_CFDP_DisableEngine(void)
     static const CF_QueueIdx_t CLOSE_QUEUES[] = {CF_QueueIdx_RX, CF_QueueIdx_TXA, CF_QueueIdx_TXW};
     CF_Channel_t              *c;
 
+    CF_AppData.engine.enabled = 0;
+
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
         c = &CF_AppData.engine.channels[i];

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -1351,8 +1351,10 @@ void Test_CF_CFDP_DisableEngine(void)
      */
 
     /* nominal call */
+    CF_AppData.engine.enabled = 1;
     UtAssert_VOIDCALL(CF_CFDP_DisableEngine());
     UtAssert_STUB_COUNT(CFE_SB_DeletePipe, CF_NUM_CHANNELS);
+    UtAssert_BOOL_FALSE(CF_AppData.engine.enabled);
 
     /* nominal call with playbacks and polls active */
     CF_AppData.engine.channels[UT_CFDP_CHANNEL].playback[0].busy = 1;


### PR DESCRIPTION
**Describe the contribution**
Restores setting a global flag which was mistakenly deleted in a previous cleanup.  This also adds a unit test check to confirm the global was set false.

Fixes #161

**Testing performed**
Build CF and run tests

**Expected behavior changes**
Engine gets disabled when CF_CFDP_DisableEngine is called

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

