### PR TITLE
Fix #63, remove macros within C code

### DIFF
--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -116,7 +116,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg);
 void CF_CmdSendCfgParams(CFE_SB_Buffer_t *msg);
 int  CF_CmdValidateChunkSize(uint32 val, uint8 chan_num /* ignored */);
 int  CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num);
-void CF_CmdGetSetParam(uint8 is_set, uint8 param_id, uint32 value, uint8 chan_num);
+void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num);
 void CF_CmdSetParam(CFE_SB_Buffer_t *msg);
 void CF_CmdGetParam(CFE_SB_Buffer_t *msg);
 void CF_CmdEnableEngine(CFE_SB_Buffer_t *msg);

--- a/fsw/src/cf_msg.h
+++ b/fsw/src/cf_msg.h
@@ -117,8 +117,7 @@ typedef struct CF_ConfigPacket
     uint8  nak_limit; /* number of times to retry NAK before giving up (resets on a single response */
 
     CF_EntityId_t local_eid;
-/* must #define the number of data items in this struct for command processing */
-#define CF_NUM_CFG_PACKET_ITEMS 10
+
 } CF_ConfigPacket_t;
 
 /****************************************
@@ -183,6 +182,27 @@ typedef struct
     CF_UnionArgs_Payload_t  data;
 } CF_UnionArgsCmd_t;
 
+/**
+ * @brief Parameter IDs for use with Get/Set param messages
+ *
+ * Specifically these are used for the "key" field within CF_GetParamCmd_t and
+ * CF_SetParamCmd_t message structures.
+ */
+typedef enum
+{
+    CF_GetSet_ValueID_ticks_per_second,
+    CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup,
+    CF_GetSet_ValueID_ack_timer_s,
+    CF_GetSet_ValueID_nak_timer_s,
+    CF_GetSet_ValueID_inactivity_timer_s,
+    CF_GetSet_ValueID_outgoing_file_chunk_size,
+    CF_GetSet_ValueID_ack_limit,
+    CF_GetSet_ValueID_nak_limit,
+    CF_GetSet_ValueID_local_eid,
+    CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup,
+    CF_GetSet_ValueID_MAX
+} CF_GetSet_ValueID_t;
+
 typedef struct CF_GetParamCmd
 {
     CFE_MSG_CommandHeader_t cmd_header;
@@ -229,5 +249,6 @@ typedef struct CF_TransactionCmd
     CF_EntityId_t           eid;
     uint8                   chan; /* if 254, use ts. if 255, all channels */
 } CF_TransactionCmd_t;
+
 
 #endif /* !CF_MSG_H */

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -4157,12 +4157,12 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Retu
 **
 *******************************************************************************/
 
-void Test_CF_CmdGetSetParam_When_param_id_Eq_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd(void)
+void Test_CF_CmdGetSetParam_When_param_id_Eq_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd(void)
 {
     /* Arrange */
     CF_ConfigTable_t dummy_config_table;
     uint8            arg_is_set   = Any_uint8();
-    uint8            arg_param_id = CF_NUM_CFG_PACKET_ITEMS;
+    uint8            arg_param_id = CF_GetSet_ValueID_MAX;
     uint32           arg_value    = Any_uint32();
     uint8            arg_chan_num = Any_uint8();
 
@@ -4186,14 +4186,14 @@ void Test_CF_CmdGetSetParam_When_param_id_Eq_CF_NUM_CFG_PACKET_ITEMS_FailSendEve
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
 
-} /* end Test_CF_CmdGetSetParam_When_param_id_Eq_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd */
+} /* end Test_CF_CmdGetSetParam_When_param_id_Eq_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd */
 
-void Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd(void)
+void Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd(void)
 {
     /* Arrange */
     CF_ConfigTable_t dummy_config_table;
     uint8            arg_is_set   = Any_uint8();
-    uint8            arg_param_id = Any_uint8_GreaterThan(CF_NUM_CFG_PACKET_ITEMS);
+    uint8            arg_param_id = Any_uint8_GreaterThan(CF_GetSet_ValueID_MAX);
     uint32           arg_value    = Any_uint32();
     uint8            arg_chan_num = Any_uint8();
 
@@ -4217,14 +4217,14 @@ void Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_NUM_CFG_PACKET_ITEMS
                   "CF_AppData.hk.counters.err is %u and should be 1 more than %u", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
 
-} /* end Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd */
+} /* end Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd */
 
 void Test_CF_CmdGetSetParam_Given_chan_num_IsEqTo_CF_NUM_CHANNELS_ErrorOutAndCountError(void)
 {
     /* Arrange */
     CF_ConfigTable_t dummy_config_table;
     uint8            arg_is_set   = Any_uint8();
-    uint8            arg_param_id = Any_uint8_LessThan(CF_NUM_CFG_PACKET_ITEMS);
+    uint8            arg_param_id = Any_uint8_LessThan(CF_GetSet_ValueID_MAX);
     uint32           arg_value    = Any_uint32();
     uint8            arg_chan_num = CF_NUM_CHANNELS;
 
@@ -4255,7 +4255,7 @@ void Test_CF_CmdGetSetParam_Given_chan_num_IsGreaterThan_CF_NUM_CHANNELS_ErrorOu
     /* Arrange */
     CF_ConfigTable_t dummy_config_table;
     uint8            arg_is_set   = Any_uint8();
-    uint8            arg_param_id = Any_uint8_LessThan(CF_NUM_CFG_PACKET_ITEMS);
+    uint8            arg_param_id = Any_uint8_LessThan(CF_GetSet_ValueID_MAX);
     uint32           arg_value    = Any_uint32();
     uint8            arg_chan_num = Any_uint8_GreaterThan(CF_NUM_CHANNELS);
 
@@ -5344,12 +5344,12 @@ void add_CF_CmdValidateMaxOutgoing_tests(void)
 
 void add_CF_CmdGetSetParam_tests(void)
 {
-    UtTest_Add(Test_CF_CmdGetSetParam_When_param_id_Eq_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd,
+    UtTest_Add(Test_CF_CmdGetSetParam_When_param_id_Eq_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd,
                cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
-               "Test_CF_CmdGetSetParam_When_param_id_Eq_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd");
-    UtTest_Add(Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd,
+               "Test_CF_CmdGetSetParam_When_param_id_Eq_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd");
+    UtTest_Add(Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd,
                cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
-               "Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_NUM_CFG_PACKET_ITEMS_FailSendEventAndRejectCmd");
+               "Test_CF_CmdGetSetParam_When_param_id_AnyGreaterThan_CF_GetSet_ValueID_MAX_FailSendEventAndRejectCmd");
     UtTest_Add(Test_CF_CmdGetSetParam_Given_chan_num_IsEqTo_CF_NUM_CHANNELS_ErrorOutAndCountError, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_CmdGetSetParam_Given_chan_num_IsEqTo_CF_NUM_CHANNELS_ErrorOutAndCountError");

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -181,10 +181,10 @@ void CF_CmdGetParam(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_CmdGetSetParam()
  * ----------------------------------------------------
  */
-void CF_CmdGetSetParam(uint8 is_set, uint8 param_id, uint32 value, uint8 chan_num)
+void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num)
 {
     UT_GenStub_AddParam(CF_CmdGetSetParam, uint8, is_set);
-    UT_GenStub_AddParam(CF_CmdGetSetParam, uint8, param_id);
+    UT_GenStub_AddParam(CF_CmdGetSetParam, CF_GetSet_ValueID_t, param_id);
     UT_GenStub_AddParam(CF_CmdGetSetParam, uint32, value);
     UT_GenStub_AddParam(CF_CmdGetSetParam, uint8, chan_num);
 


### PR DESCRIPTION
**Describe the contribution**
Reworks the CF_CmdGetSetParam to be clearer in its implementation, not require the use of endian-specific conditionally-compiled code.

Fixes #63

**Testing performed**
Build and sanity test CF app
Send various get/set param commands (CC 10 and 11) and confirm working as expected

**Expected behavior changes**
None visible externally (i.e. CMD handling) but much cleaner internal handling of these values.

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
