### PR TITLE
Fix #164, consistent "chunk" test sizes

### DIFF
--- a/unit-test/cf_chunk_tests.c
+++ b/unit-test/cf_chunk_tests.c
@@ -1910,11 +1910,9 @@ void Test_CF_Chunks_Init_SetGiven_chunks_max_chunks_ToGiven_max_chunks(void)
 {
     /* Arrange */
     CF_ChunkList_t  dummy_chunks;
-    CF_ChunkList_t *arg_chunks = &dummy_chunks;
-    CF_ChunkIdx_t   arg_max_chunks =
-        Any_uint16() + 2; /* 2-65537, uint8 is used instead of CF_ChunkIdx_t to have a reasonably
-                       decent size for the test without being too large (segfault) */
-    CF_Chunk_t arg_chunks_mem[arg_max_chunks];
+    CF_ChunkList_t *arg_chunks     = &dummy_chunks;
+    CF_ChunkIdx_t   arg_max_chunks = 14;
+    CF_Chunk_t      arg_chunks_mem[14];
 
     arg_chunks->count = 0;
 
@@ -1943,11 +1941,9 @@ void Test_CF_ChunksReset_Set_count_To_0_Keeps_max_chunks_AndMemsets_chunks_ToAll
 {
     /* Arrange */
     CF_ChunkList_t  dummy_chunks;
-    CF_ChunkList_t *arg_chunks = &dummy_chunks;
-    CF_ChunkIdx_t   initial_max_chunks =
-        Any_uint16() + 2; /* 2-65537, uint8 is used instead of CF_ChunkIdx_t to have a reasonably
-                       decent size for the test without being too large (segfault) */
-    CF_Chunk_t dummy_chunks_chunks[initial_max_chunks];
+    CF_ChunkList_t *arg_chunks         = &dummy_chunks;
+    CF_ChunkIdx_t   initial_max_chunks = 17;
+    CF_Chunk_t      dummy_chunks_chunks[17];
 
     arg_chunks->count      = Any_index_t();
     arg_chunks->max_chunks = initial_max_chunks;


### PR DESCRIPTION
**Describe the contribution**
Do not use a random uint16 to size the structure that is allocated on the stack.  Pick a reasonable size that is not likely to overrun
the stack, and use it.

This fixes a crash/stack overrun issue when running on RTEMS.

Fixes #164

**Testing performed**
Build and sanity check CF on PC-RTEMS

**Expected behavior changes**
Tests pass

**System(s) tested on**
RTEMS 4.11.3 via QEMU+pc686 BSP

**Additional context**
This _only_ fixes the random values that caused a stack overrun/crash.  Would still recommend fixing other use of random numbers in tests.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

