### PR TITLE
Fix #58, scrub all printf format codes

### DIFF
--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -84,7 +84,7 @@ void CF_CheckTables(void)
         if (status < CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_CHECK_REL, CFE_EVS_EventType_ERROR,
-                              "CF: error in CFE_TBL_ReleaseAddress (check), returned 0x%08x", status);
+                              "CF: error in CFE_TBL_ReleaseAddress (check), returned 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }
 
@@ -92,7 +92,7 @@ void CF_CheckTables(void)
         if (status < CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_CHECK_MAN, CFE_EVS_EventType_ERROR,
-                              "CF: error in CFE_TBL_Manage (check), returned 0x%08x", status);
+                              "CF: error in CFE_TBL_Manage (check), returned 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }
 
@@ -100,7 +100,7 @@ void CF_CheckTables(void)
         if (status < CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_CHECK_GA, CFE_EVS_EventType_ERROR,
-                              "CF: failed to get table address (check), returned 0x%08x", status);
+                              "CF: failed to get table address (check), returned 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }
     }
@@ -164,15 +164,15 @@ int32 CF_TableInit(void)
     if (status != CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_REG, CFE_EVS_EventType_ERROR,
-                          "CF: error registering table, returned 0x%08x", status);
+                          "CF: error registering table, returned 0x%08lx", (unsigned long)status);
         goto err_out;
     }
 
     status = CFE_TBL_Load(CF_AppData.config_handle, CFE_TBL_SRC_FILE, CF_CONFIG_TABLE_FILENAME);
     if (status != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_LOAD, CFE_EVS_EventType_ERROR, "CF: error loading table, returned 0x%08x",
-                          status);
+        CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_LOAD, CFE_EVS_EventType_ERROR,
+                          "CF: error loading table, returned 0x%08lx", (unsigned long)status);
         goto err_out;
     }
 
@@ -180,7 +180,7 @@ int32 CF_TableInit(void)
     if (status != CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_MANAGE, CFE_EVS_EventType_ERROR,
-                          "CF: error in CFE_TBL_Manage, returned 0x%08x", status);
+                          "CF: error in CFE_TBL_Manage, returned 0x%08lx", (unsigned long)status);
         goto err_out;
     }
 
@@ -189,7 +189,7 @@ int32 CF_TableInit(void)
     if ((status != CFE_TBL_INFO_UPDATED) && (status != CFE_SUCCESS))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_GETADDR, CFE_EVS_EventType_ERROR,
-                          "CF: error getting table address, returned 0x%08x", status);
+                          "CF: error getting table address, returned 0x%08lx", (unsigned long)status);
         goto err_out;
     }
     else
@@ -330,13 +330,13 @@ int32 CF_Init(void)
     if ((status = CFE_EVS_Register(cf_event_filters, sizeof(cf_event_filters) / sizeof(*cf_event_filters),
                                    CFE_EVS_EventFilter_BINARY)) != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CF app: error registering with EVS, returned 0x%08x", status);
+        CFE_ES_WriteToSysLog("CF app: error registering with EVS, returned 0x%08lx", (unsigned long)status);
         goto err_out;
     }
 
     if ((status = CFE_SB_CreatePipe(&CF_AppData.cmd_pipe, CF_PIPE_DEPTH, CF_PIPE_NAME)) != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CF app: error creating pipe %s, returend 0x%08x", CF_PIPE_NAME, status);
+        CFE_ES_WriteToSysLog("CF app: error creating pipe %s, returend 0x%08lx", CF_PIPE_NAME, (unsigned long)status);
         goto err_out;
     }
 
@@ -367,7 +367,7 @@ int32 CF_Init(void)
 
     if (status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CF: error sending init event, returned 0x%08x", status);
+        CFE_ES_WriteToSysLog("CF: error sending init event, returned 0x%08lx", (unsigned long)status);
         goto err_out;
     }
 
@@ -468,7 +468,7 @@ void CF_AppMain(void)
         else if (status != CFE_SB_TIME_OUT && status != CFE_SB_NO_MESSAGE)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_MSG_RECV, CFE_EVS_EventType_ERROR,
-                              "CF: exiting due to CFE_SB_ReceiveBuffer error 0x%08x", status);
+                              "CF: exiting due to CFE_SB_ReceiveBuffer error 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }
         else

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -672,7 +672,8 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_MD_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: metadata packet too short: %lu bytes received", CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: metadata packet too short: %lu bytes received",
+                          (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         goto err_out;
     }
 
@@ -748,7 +749,7 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: filedata pdu too short: %lu bytes received", CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: filedata pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
         ret = -1;
     }
@@ -782,7 +783,7 @@ int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_EOF_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: eof pdu too short: %lu bytes received", CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: eof pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = -1;
     }
 
@@ -807,7 +808,7 @@ int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_ACK_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: ack pdu too short: %lu bytes received", CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: ack pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = -1;
     }
 
@@ -833,7 +834,7 @@ int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FIN_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: fin pdu too short: %lu bytes received", CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: fin pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = -1;
     }
 
@@ -859,7 +860,7 @@ int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_NAK_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: nak pdu too short: %lu bytes received", CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: nak pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = -1;
     }
 
@@ -995,7 +996,7 @@ int32 CF_CFDP_InitEngine(void)
                                      CF_AppData.config_table->chan[i].pipe_depth_input, nbuf)) != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_PIPE, CFE_EVS_EventType_ERROR,
-                              "CF: failed to create pipe %s, returned 0x%08x", nbuf, ret);
+                              "CF: failed to create pipe %s, returned 0x%08lx", nbuf, (unsigned long)ret);
             goto err_out;
         }
 
@@ -1004,8 +1005,8 @@ int32 CF_CFDP_InitEngine(void)
                                          CF_AppData.config_table->chan[i].pipe_depth_input)) != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_SUB, CFE_EVS_EventType_ERROR,
-                              "CF: failed to subscribe to MID 0x%04x, returned 0x%08x",
-                              CF_AppData.config_table->chan[i].mid_input, ret);
+                              "CF: failed to subscribe to MID 0x%lx, returned 0x%08lx",
+                              (unsigned long)CF_AppData.config_table->chan[i].mid_input, (unsigned long)ret);
             goto err_out;
         }
 
@@ -1016,8 +1017,8 @@ int32 CF_CFDP_InitEngine(void)
             if (ret != OS_SUCCESS)
             {
                 CFE_EVS_SendEvent(CF_EID_ERR_INIT_SEM, CFE_EVS_EventType_ERROR,
-                                  "CF: failed to get sem id for name %s, error=0x%08x",
-                                  CF_AppData.config_table->chan[i].sem_name, ret);
+                                  "CF: failed to get sem id for name %s, error=%ld",
+                                  CF_AppData.config_table->chan[i].sem_name, (long)ret);
                 goto err_out;
             }
         }
@@ -1253,9 +1254,10 @@ static void CF_CFDP_TxFile_Initiate(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_cl
                                     uint8 priority, CF_EntityId_t dest_id)
 {
     CFE_EVS_SendEvent(CF_EID_INF_CFDP_S_START_SEND, CFE_EVS_EventType_INFORMATION,
-                      "CF: start class %d tx of file %d:%.*s -> %d:%.*s", cfdp_class + 1,
-                      CF_AppData.config_table->local_eid, CF_FILENAME_MAX_LEN, t->history->fnames.src_filename, dest_id,
-                      CF_FILENAME_MAX_LEN, t->history->fnames.dst_filename);
+                      "CF: start class %d tx of file %lu:%.*s -> %lu:%.*s", cfdp_class + 1,
+                      (unsigned long)CF_AppData.config_table->local_eid, CF_FILENAME_MAX_LEN,
+                      t->history->fnames.src_filename, (unsigned long)dest_id, CF_FILENAME_MAX_LEN,
+                      t->history->fnames.dst_filename);
 
     CF_CFDP_InitTxnTxFile(t, cfdp_class, keep, chan, priority);
 
@@ -1332,7 +1334,7 @@ static int32 CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *p, const char *src_file
     if (ret != OS_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_OPENDIR, CFE_EVS_EventType_ERROR,
-                          "CF: failed to open playback directory %s, error=0x%08x", src_filename, ret);
+                          "CF: failed to open playback directory %s, error=%ld", src_filename, (long)ret);
         ++CF_AppData.hk.channel_hk[chan].counters.fault.directory_read;
         goto err_out;
     }

--- a/fsw/src/cf_cfdp_dispatch.c
+++ b/fsw/src/cf_cfdp_dispatch.c
@@ -66,9 +66,9 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
         {
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_DC_INV, CFE_EVS_EventType_ERROR,
-                              "CF R%d(%u:%u): received pdu with invalid directive code %d for sub-state %d",
-                              (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num,
-                              fdh->directive_code, t->state_data.r.sub_state);
+                              "CF R%d(%lu:%lu): received pdu with invalid directive code %d for sub-state %d",
+                              (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                              (unsigned long)t->history->seq_num, fdh->directive_code, t->state_data.r.sub_state);
         }
     }
     else
@@ -127,16 +127,16 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
         {
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_DC_INV, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%u:%u): received pdu with invalid directive code %d for sub-state %d",
-                              (t->state == CF_TxnState_S2), t->history->src_eid, t->history->seq_num,
-                              fdh->directive_code, t->state_data.s.sub_state);
+                              "CF S%d(%lu:%lu): received pdu with invalid directive code %d for sub-state %d",
+                              (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,
+                              (unsigned long)t->history->seq_num, fdh->directive_code, t->state_data.s.sub_state);
         }
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_NON_FD_PDU, CFE_EVS_EventType_ERROR,
-                          "CF S%d(%u:%u): received non-file directive pdu", (t->state == CF_TxnState_S2),
-                          t->history->src_eid, t->history->seq_num);
+                          "CF S%d(%lu:%lu): received non-file directive pdu", (t->state == CF_TxnState_S2),
+                          (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
     }
 
     /* check that there's a valid function pointer. if there isn't,

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -106,9 +106,10 @@ int CF_CFDP_R_CheckCrc(CF_Transaction_t *t, uint32 expected_crc)
     if (t->crc.result != expected_crc)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_CRC, CFE_EVS_EventType_ERROR,
-                          "CF R%d(%u:%u): crc mismatch for R trans. got 0x%x expected 0x%x",
-                          (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num, t->crc.result,
-                          expected_crc);
+                          "CF R%d(%lu:%lu): crc mismatch for R trans. got 0x%08lx expected 0x%08lx",
+                          (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                          (unsigned long)t->history->seq_num, (unsigned long)t->crc.result,
+                          (unsigned long)expected_crc);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.crc_mismatch;
         ret = 1;
     }
@@ -162,8 +163,9 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *t, int ok_to_send_nak)
     {
         if (++t->state_data.r.r2.acknak_count >= CF_AppData.config_table->nak_limit)
         {
-            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_NAK_LIMIT, CFE_EVS_EventType_ERROR, "CF R%d(%u:%u): nak limited reach",
-                              (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num);
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_NAK_LIMIT, CFE_EVS_EventType_ERROR,
+                              "CF R%d(%lu:%lu): nak limited reach", (t->state == CF_TxnState_R2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
             send_fin = 1;
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.nak_limit;
             t->history->cc = CF_CFDP_ConditionCode_NAK_LIMIT_REACHED; /* don't use CF_CFDP_R2_SetCc because many places
@@ -218,8 +220,9 @@ int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         if (fret != fd->offset)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_SEEK_FD, CFE_EVS_EventType_ERROR,
-                              "CF R%d(%u:%u): failed to seek offset %ld, got %ld", (t->state == CF_TxnState_R2),
-                              t->history->src_eid, t->history->seq_num, (long)fd->offset, (long)fret);
+                              "CF R%d(%lu:%lu): failed to seek offset %ld, got %ld", (t->state == CF_TxnState_R2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, (long)fd->offset,
+                              (long)fret);
             t->history->cc = CF_CFDP_ConditionCode_FILE_SIZE_ERROR;
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
             goto err_out; /* connection will reset in caller */
@@ -230,8 +233,9 @@ int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (fret != fd->data_len)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_WRITE, CFE_EVS_EventType_ERROR,
-                          "CF R%d(%u:%u): OS_write expected %ld, got %ld", (t->state == CF_TxnState_R2),
-                          t->history->src_eid, t->history->seq_num, (long)fd->data_len, (long)fret);
+                          "CF R%d(%lu:%lu): OS_write expected %ld, got %ld", (t->state == CF_TxnState_R2),
+                          (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, (long)fd->data_len,
+                          (long)fret);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_write;
         t->history->cc = CF_CFDP_ConditionCode_FILESTORE_REJECTION;
         goto err_out; /* connection will reset in caller */
@@ -267,9 +271,9 @@ int CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         if (t->flags.rx.md_recv && (eof->size != t->fsize))
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_SIZE_MISMATCH, CFE_EVS_EventType_ERROR,
-                              "CF R%d(%u:%u): eof file size mismatch: got %lu expected %lu",
-                              (t->state == CF_TxnState_R2), (unsigned int)t->history->src_eid,
-                              (unsigned int)t->history->seq_num, (unsigned long)eof->size, (unsigned long)t->fsize);
+                              "CF R%d(%lu:%lu): eof file size mismatch: got %lu expected %lu",
+                              (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                              (unsigned long)t->history->seq_num, (unsigned long)eof->size, (unsigned long)t->fsize);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_size_mismatch;
             ret = CF_RxEofRet_FSIZE_MISMATCH;
             goto err_out;
@@ -277,8 +281,9 @@ int CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_EOF, CFE_EVS_EventType_ERROR, "CF R%d(%u:%u): invalid eof packet",
-                          (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num);
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_EOF, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid eof packet",
+                          (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                          (unsigned long)t->history->seq_num);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
         ret = CF_RxEofRet_BAD_EOF;
         goto err_out;
@@ -539,8 +544,8 @@ int CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t)
             /* need to send simple nak packet to request metadata pdu again */
             /* after doing so, transition to recv md state */
             CFE_EVS_SendEvent(CF_EID_INF_CFDP_R_REQUEST_MD, CFE_EVS_EventType_INFORMATION,
-                              "CF R%d(%u:%u): requesting MD", (t->state == CF_TxnState_R2), t->history->src_eid,
-                              t->history->seq_num);
+                              "CF R%d(%lu:%lu): requesting MD", (t->state == CF_TxnState_R2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
             /* scope start/end, and sr[0] start/end == 0 special value to request metadata */
             nak->scope_start                           = 0;
             nak->scope_end                             = 0;
@@ -581,12 +586,12 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
             /* the transaction already has a history, and that has a buffer that we can use to
              * hold the temp filename */
             /* the -1 below is to make room for the slash */
-            snprintf(t->history->fnames.dst_filename, sizeof(t->history->fnames.dst_filename) - 1, "%.*s/%d.tmp",
-                     CF_FILENAME_MAX_PATH - 1, CF_AppData.config_table->tmp_dir, t->history->seq_num);
+            snprintf(t->history->fnames.dst_filename, sizeof(t->history->fnames.dst_filename) - 1, "%.*s/%lu.tmp",
+                     CF_FILENAME_MAX_PATH - 1, CF_AppData.config_table->tmp_dir, (unsigned long)t->history->seq_num);
             CFE_EVS_SendEvent(CF_EID_INF_CFDP_R_TEMP_FILE, CFE_EVS_EventType_INFORMATION,
-                              "CF R%d(%u:%u): making temp file %s for transaction without MD",
-                              (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num,
-                              t->history->fnames.dst_filename);
+                              "CF R%d(%lu:%lu): making temp file %s for transaction without MD",
+                              (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                              (unsigned long)t->history->seq_num, t->history->fnames.dst_filename);
         }
 
         CF_CFDP_ArmAckTimer(t);
@@ -596,9 +601,9 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
     if (ret < 0)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_CREAT, CFE_EVS_EventType_ERROR,
-                          "CF R%d(%u:%u): failed to create file %s for writing, error=0x%08x",
-                          (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num,
-                          t->history->fnames.dst_filename, ret);
+                          "CF R%d(%lu:%lu): failed to create file %s for writing, error=%ld",
+                          (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                          (unsigned long)t->history->seq_num, t->history->fnames.dst_filename, (long)ret);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
         t->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
         if (t->state == CF_TxnState_R2)
@@ -661,9 +666,9 @@ int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
             if (fret != t->state_data.r.r2.rx_crc_calc_bytes)
             {
                 CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_SEEK_CRC, CFE_EVS_EventType_ERROR,
-                                  "CF R%d(%u:%u): failed to seek offset %lu, got 0x%08x", (t->state == CF_TxnState_R2),
-                                  t->history->src_eid, t->history->seq_num,
-                                  (unsigned long)t->state_data.r.r2.rx_crc_calc_bytes, fret);
+                                  "CF R%d(%lu:%lu): failed to seek offset %lu, got %ld", (t->state == CF_TxnState_R2),
+                                  (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
+                                  (unsigned long)t->state_data.r.r2.rx_crc_calc_bytes, (long)fret);
                 t->history->cc = CF_CFDP_ConditionCode_FILE_SIZE_ERROR; /* should be ok to use this one */
                 ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
                 goto err_out;
@@ -674,9 +679,9 @@ int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
         if (fret != read_size)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_READ, CFE_EVS_EventType_ERROR,
-                              "CF R%d(%u:%u): failed to read file expected %lu, got 0x%08x",
-                              (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num,
-                              (unsigned long)read_size, fret);
+                              "CF R%d(%lu:%lu): failed to read file expected %lu, got %ld",
+                              (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                              (unsigned long)t->history->seq_num, (unsigned long)read_size, (long)fret);
             t->history->cc = CF_CFDP_ConditionCode_FILE_SIZE_ERROR; /* should be ok to use this one */
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_read;
             goto err_out;
@@ -769,8 +774,9 @@ void CF_CFDP_R2_Recv_fin_ack(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_FINACK, CFE_EVS_EventType_ERROR, "CF R%d(%u:%u): invalid fin-ack",
-                          (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num);
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_FINACK, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid fin-ack",
+                          (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                          (unsigned long)t->history->seq_num);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
     }
 }
@@ -808,9 +814,10 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                 if (t->state_data.r.r2.eof_size != t->fsize)
                 {
                     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_EOF_MD_SIZE, CFE_EVS_EventType_ERROR,
-                                      "CF R%d(%u:%u): eof/md size mismatch md: %d, eof: %d",
-                                      (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num, t->fsize,
-                                      t->state_data.r.r2.eof_size);
+                                      "CF R%d(%lu:%lu): eof/md size mismatch md: %lu, eof: %lu",
+                                      (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                                      (unsigned long)t->history->seq_num, (unsigned long)t->fsize,
+                                      (unsigned long)t->state_data.r.r2.eof_size);
                     ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_size_mismatch;
                     CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILE_SIZE_ERROR);
                     goto err_out;
@@ -825,8 +832,9 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
             if (status != OS_SUCCESS)
             {
                 CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_RENAME, CFE_EVS_EventType_ERROR,
-                                  "CF R%d(%u:%u): failed to rename file in R2, error=0x%08x",
-                                  (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num, status);
+                                  "CF R%d(%lu:%lu): failed to rename file in R2, error=%ld",
+                                  (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                                  (unsigned long)t->history->seq_num, (long)status);
                 t->fd = OS_OBJECT_ID_UNDEFINED;
                 CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILESTORE_REJECTION);
                 ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_rename;
@@ -839,8 +847,9 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                 if (ret < 0)
                 {
                     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_OPEN, CFE_EVS_EventType_ERROR,
-                                      "CF R%d(%u:%u): failed to open renamed file in R2, error=0x%08x",
-                                      (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num, ret);
+                                      "CF R%d(%lu:%lu): failed to open renamed file in R2, error=%ld",
+                                      (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                                      (unsigned long)t->history->seq_num, (long)ret);
                     CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILESTORE_REJECTION);
                     ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
                     t->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
@@ -854,8 +863,9 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         }
         else
         {
-            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_MD, CFE_EVS_EventType_ERROR, "CF R%d(%u:%u): invalid md received",
-                              (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num);
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_MD, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid md received",
+                              (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
+                              (unsigned long)t->history->seq_num);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
             /* do nothing here, since it will be nak'd again later */
         }
@@ -943,8 +953,9 @@ void CF_CFDP_R_Cancel(CF_Transaction_t *t)
  *-----------------------------------------------------------------*/
 void CF_CFDP_R_SendInactivityEvent(CF_Transaction_t *t)
 {
-    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_INACT_TIMER, CFE_EVS_EventType_ERROR, "CF R%d(%u:%u): inactivity timer expired",
-                      (t->state == CF_TxnState_R2), t->history->src_eid, t->history->seq_num);
+    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_INACT_TIMER, CFE_EVS_EventType_ERROR,
+                      "CF R%d(%lu:%lu): inactivity timer expired", (t->state == CF_TxnState_R2),
+                      (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
     ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.inactivity_timer;
 }
 
@@ -1027,8 +1038,8 @@ void CF_CFDP_R_Tick(CF_Transaction_t *t, int *cont /* unused */)
                     if (++t->state_data.r.r2.acknak_count >= CF_AppData.config_table->ack_limit)
                     {
                         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_ACK_LIMIT, CFE_EVS_EventType_ERROR,
-                                          "CF R2(%u:%u): ack limit reached, no fin-ack", t->history->src_eid,
-                                          t->history->seq_num);
+                                          "CF R2(%lu:%lu): ack limit reached, no fin-ack",
+                                          (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
                         ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit;
                         CF_CFDP_R2_Reset(t);
                         goto err_out; /* must return after reset */

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -177,8 +177,8 @@ int32 CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_
         if (status != foffs)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEEK_FD, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%u:%u): error seeking to offset %ld, got %ld", (t->state == CF_TxnState_S2),
-                              (unsigned int)t->history->src_eid, (unsigned int)t->history->seq_num, (long)foffs,
+                              "CF S%d(%lu:%lu): error seeking to offset %ld, got %ld", (t->state == CF_TxnState_S2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, (long)foffs,
                               (long)status);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
             goto err_out;
@@ -189,8 +189,8 @@ int32 CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_
     if (status != actual_bytes)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_READ, CFE_EVS_EventType_ERROR,
-                          "CF S%d(%u:%u): error reading bytes: expected %ld, got %ld", (t->state == CF_TxnState_S2),
-                          (unsigned int)t->history->src_eid, (unsigned int)t->history->seq_num, (long)actual_bytes,
+                          "CF S%d(%lu:%lu): error reading bytes: expected %ld, got %ld", (t->state == CF_TxnState_S2),
+                          (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, (long)actual_bytes,
                           (long)status);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_read;
         goto err_out;
@@ -205,8 +205,9 @@ int32 CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_
     }
     else if (status == CF_SendRet_ERROR)
     {
-        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEND_FD, CFE_EVS_EventType_ERROR, "CF S%d(%u:%u): error sending fd",
-                          (t->state == CF_TxnState_S2), t->history->src_eid, t->history->seq_num);
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEND_FD, CFE_EVS_EventType_ERROR, "CF S%d(%lu:%lu): error sending fd",
+                          (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,
+                          (unsigned long)t->history->seq_num);
         goto err_out;
     }
     else
@@ -362,8 +363,9 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
         if (OS_FileOpenCheck(t->history->fnames.src_filename) == OS_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_ALREADY_OPEN, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%u:%u): file %s already open", (t->state == CF_TxnState_S2), t->history->src_eid,
-                              t->history->seq_num, t->history->fnames.src_filename);
+                              "CF S%d(%lu:%lu): file %s already open", (t->state == CF_TxnState_S2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
+                              t->history->fnames.src_filename);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
             goto err_out;
         }
@@ -372,8 +374,9 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
         if (ret < 0)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_OPEN, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%u:%u): failed to open file %s, error=0x%08x", (t->state == CF_TxnState_S2),
-                              t->history->src_eid, t->history->seq_num, t->history->fnames.src_filename, ret);
+                              "CF S%d(%lu:%lu): failed to open file %s, error=%ld", (t->state == CF_TxnState_S2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
+                              t->history->fnames.src_filename, (long)ret);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
             t->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
             goto err_out;
@@ -383,8 +386,9 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
         if (status < 0)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEEK_END, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%u:%u): failed to seek end file %s, error=0x%08x", (t->state == CF_TxnState_S2),
-                              t->history->src_eid, t->history->seq_num, t->history->fnames.src_filename, status);
+                              "CF S%d(%lu:%lu): failed to seek end file %s, error=%ld", (t->state == CF_TxnState_S2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
+                              t->history->fnames.src_filename, (long)status);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
             goto err_out;
         }
@@ -395,8 +399,9 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
         if (status != 0)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEEK_BEG, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%u:%u): failed to seek begin file %s, got 0x%08x", (t->state == CF_TxnState_S2),
-                              t->history->src_eid, t->history->seq_num, t->history->fnames.src_filename, status);
+                              "CF S%d(%lu:%lu): failed to seek begin file %s, got %ld", (t->state == CF_TxnState_S2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
+                              t->history->fnames.src_filename, (long)status);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
             goto err_out;
         }
@@ -406,8 +411,9 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
     if (sret == CF_SendRet_ERROR)
     {
         /* failed to send md */
-        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEND_MD, CFE_EVS_EventType_ERROR, "CF S%d(%u:%u): failed to send md",
-                          (t->state == CF_TxnState_S2), t->history->src_eid, t->history->seq_num);
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEND_MD, CFE_EVS_EventType_ERROR, "CF S%d(%lu:%lu): failed to send md",
+                          (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,
+                          (unsigned long)t->history->seq_num);
         goto err_out;
     }
     else if (sret == CF_SendRet_SUCCESS)
@@ -459,8 +465,8 @@ void CF_CFDP_S2_EarlyFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
     /* received early fin, so just cancel */
     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_EARLY_FIN, CFE_EVS_EventType_ERROR,
-                      "CF S%d(%u:%u): got early fin -- cancelling", (t->state == CF_TxnState_S2), t->history->src_eid,
-                      t->history->seq_num);
+                      "CF S%d(%lu:%lu): got early fin -- cancelling", (t->state == CF_TxnState_S2),
+                      (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
     CF_CFDP_S_Reset(t);
 }
 
@@ -533,14 +539,15 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         if (bad_sr)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INVALID_SR, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%u:%u): received %d invalid nak segment requests", (t->state == CF_TxnState_S2),
-                              t->history->src_eid, t->history->seq_num, bad_sr);
+                              "CF S%d(%lu:%lu): received %d invalid nak segment requests", (t->state == CF_TxnState_S2),
+                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, bad_sr);
         }
     }
     else
     {
-        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_NAK, CFE_EVS_EventType_ERROR, "CF S%d(%u:%u): received invalid nak pdu",
-                          (t->state == CF_TxnState_S2), t->history->src_eid, t->history->seq_num);
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_NAK, CFE_EVS_EventType_ERROR,
+                          "CF S%d(%lu:%lu): received invalid nak pdu", (t->state == CF_TxnState_S2),
+                          (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
     }
 }
@@ -585,8 +592,9 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_EOF, CFE_EVS_EventType_ERROR, "CF S%d(%u:%u): received invalid eof pdu",
-                          (t->state == CF_TxnState_S2), t->history->src_eid, t->history->seq_num);
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_EOF, CFE_EVS_EventType_ERROR,
+                          "CF S%d(%lu:%lu): received invalid eof pdu", (t->state == CF_TxnState_S2),
+                          (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
     }
 }
@@ -721,7 +729,8 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
         if (CF_Timer_Expired(&t->inactivity_timer))
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INACT_TIMER, CFE_EVS_EventType_ERROR,
-                              "CF S2(%u:%u): inactivity timer expired", t->history->src_eid, t->history->seq_num);
+                              "CF S2(%lu:%lu): inactivity timer expired", (unsigned long)t->history->src_eid,
+                              (unsigned long)t->history->seq_num);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.inactivity_timer;
             CF_CFDP_S_Reset(t);
         }
@@ -738,8 +747,8 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
                         if (++t->state_data.s.s2.acknak_count >= CF_AppData.config_table->ack_limit)
                         {
                             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_ACK_LIMIT, CFE_EVS_EventType_ERROR,
-                                              "CF S2(%u:%u), ack limit reached, no eof-ack", t->history->src_eid,
-                                              t->history->seq_num);
+                                              "CF S2(%lu:%lu), ack limit reached, no eof-ack",
+                                              (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
                             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit;
 
                             /* no reason to reset this timer, as it isn't used again */

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -305,7 +305,8 @@ int CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAct
         else
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CMD_TRANS_NOT_FOUND, CFE_EVS_EventType_ERROR,
-                              "CF: %s cmd: failed to find transactino for (eid %d, ts %d)", cmdstr, cmd->eid, cmd->ts);
+                              "CF: %s cmd: failed to find transactino for (eid %lu, ts %lu)", cmdstr,
+                              (unsigned long)cmd->eid, (unsigned long)cmd->ts);
         }
     }
     else if (cmd->chan == ALL_CHANNELS)

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -424,7 +424,7 @@ void CF_WrappedClose(osal_id_t fd)
     if (ret != OS_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_CLOSE_ERR, CFE_EVS_EventType_ERROR,
-                          "CF: failed to close file 0x%x, OS_close returned 0x%08x", fd, ret);
+                          "CF: failed to close file 0x%lx, OS_close returned %ld", OS_ObjectIdToInteger(fd), (long)ret);
     }
 }
 

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -70,12 +70,12 @@ void Test_CF_HkCmd_TimestampAndSendMessageWith_CF_AppData_hk(void)
     UtAssert_STUB_COUNT(CFE_MSG_SetMsgTime, 1);
     UtAssert_ADDRESS_EQ(context_CFE_MSG_SetMsgTime.MsgPtr, &CF_AppData.hk.tlm_header.Msg);
     UtAssert_True(context_CFE_MSG_SetMsgTime.Time.Seconds == fake_time.Seconds,
-                  "CFE_MSG_SetMsgTime received Time.Seconds %u and should be %u (call to CFE_TIME_GetTime Seconds)",
-                  context_CFE_MSG_SetMsgTime.Time.Seconds, fake_time.Seconds);
+                  "CFE_MSG_SetMsgTime received Time.Seconds %lu and should be %lu (call to CFE_TIME_GetTime Seconds)",
+                  (unsigned long)context_CFE_MSG_SetMsgTime.Time.Seconds, (unsigned long)fake_time.Seconds);
     UtAssert_True(
         context_CFE_MSG_SetMsgTime.Time.Subseconds == fake_time.Subseconds,
-        "CFE_MSG_SetMsgTime received Time.Subseconds %u and should be %u (call to CFE_TIME_GetTime Subseconds)",
-        context_CFE_MSG_SetMsgTime.Time.Subseconds, fake_time.Subseconds);
+        "CFE_MSG_SetMsgTime received Time.Subseconds %lu and should be %lu (call to CFE_TIME_GetTime Subseconds)",
+        (unsigned long)context_CFE_MSG_SetMsgTime.Time.Subseconds, (unsigned long)fake_time.Subseconds);
     UtAssert_STUB_COUNT(CFE_SB_TransmitMsg, 1);
     UtAssert_ADDRESS_EQ(context_CFE_SB_TransmitMsg.MsgPtr, &CF_AppData.hk.tlm_header.Msg);
     UtAssert_True(context_CFE_SB_TransmitMsg.IncrementSequenceCount == true,
@@ -326,17 +326,14 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Register_DidNotReturnSuccess(void)
 {
     /* Arrange */
     int32 expected_result = Any_int32_Except(CFE_SUCCESS);
-    int32 result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Register), expected_result);
     UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
 
     /* Act */
-    result = CF_TableInit();
+    UtAssert_INT32_EQ(CF_TableInit(), expected_result);
 
     /* Assert */
-    UtAssert_True(result == expected_result, "CF_TableInit should have returned 0x%08X and was 0x%08X", result,
-                  expected_result);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_REG);
     /* TODO: CFE_EVS_SendEvent needs to check all context values! */
@@ -346,16 +343,14 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Load_DidNotReturnSuccess(void)
 {
     /* Arrange */
     int32 expected_result = Any_int32_Except(CFE_SUCCESS);
-    int32 result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Load), expected_result);
     UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
 
     /* Act */
-    result = CF_TableInit();
+    UtAssert_INT32_EQ(CF_TableInit(), expected_result);
 
     /* Assert */
-    UtAssert_True(result == expected_result, "CF_TableInit returned 0x%08X and was 0x%08X", result, expected_result);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_LOAD);
     /* TODO: CFE_EVS_SendEvent needs to check all context values! */
@@ -365,17 +360,14 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Manage_DidNotReturnSuccess(void)
 {
     /* Arrange */
     int32 expected_result = Any_int32_Except(CFE_SUCCESS);
-    int32 result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Manage), expected_result);
     UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
 
     /* Act */
-    result = CF_TableInit();
+    UtAssert_INT32_EQ(CF_TableInit(), expected_result);
 
     /* Assert */
-    UtAssert_True(result == expected_result, "CF_TableInit should have returned 0x%08X and was 0x%08X", result,
-                  expected_result);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_MANAGE);
     /* TODO: CFE_EVS_SendEvent needs to check all context values! */
@@ -387,17 +379,14 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_GetAddress_DidNotReturnSuccess(void)
     int32 possible_success_results[2] = {CFE_SUCCESS, CFE_TBL_INFO_UPDATED};
     int32 expected_result = Any_int32_ExceptThese(possible_success_results, sizeof(possible_success_results) /
                                                                                 sizeof(possible_success_results[0]));
-    int32 result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), expected_result);
     UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
 
     /* Act */
-    result = CF_TableInit();
+    UtAssert_INT32_EQ(CF_TableInit(), expected_result);
 
     /* Assert */
-    UtAssert_True(result == expected_result, "CF_TableInit should have returned 0x%08X and was 0x%08X", result,
-                  expected_result);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_GETADDR);
     /* TODO: CFE_EVS_SendEvent needs to check all context values! */
@@ -406,32 +395,26 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_GetAddress_DidNotReturnSuccess(void)
 void Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_SUCCESS_SuccessAndDoNotSendEvent(void)
 {
     /* Arrange */
-    int32 result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
 
     /* Act */
-    result = CF_TableInit();
+    UtAssert_INT32_EQ(CF_TableInit(), CFE_SUCCESS);
 
     /* Assert */
-    UtAssert_True(result == CFE_SUCCESS, "CF_TableInit returned 0x%08X and should be 0x%08X (CFE_SUCCESS)", result,
-                  CFE_SUCCESS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 } /* end Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_SUCCESS_SuccessAndDoNotSendEvent */
 
 void Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED_SuccessAndDoNotSendEvent(void)
 {
     /* Arrange */
-    int32 result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
 
     /* Act */
-    result = CF_TableInit();
+    UtAssert_INT32_EQ(CF_TableInit(), CFE_SUCCESS);
 
     /* Assert */
-    UtAssert_True(result == CFE_SUCCESS, "CF_TableInit returned 0x%08X and should be 0x%08X (CFE_SUCCESS)", result,
-                  CFE_SUCCESS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 } /* end Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED_SuccessAndDoNotSendEvent */
 

--- a/unit-test/cf_chunk_tests.c
+++ b/unit-test/cf_chunk_tests.c
@@ -1371,9 +1371,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_non0_CallTo_CF_C
     CF_Chunks_Insert(arg_chunks, arg_i, arg_chunk);
 
     /* Assert */
-    UtAssert_True(arg_chunks->count == initial_i + 1,
-                  "chunks->count is %u and should be 1 more than %u (value of i at call)", arg_chunks->count,
-                  initial_i);
+    UtAssert_UINT32_EQ(arg_chunks->count, initial_i + 1);
 } /* end
      Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_non0_CallTo_CF_Chunks_CombinePrevious_Returns_0_DoNothing
    */
@@ -1410,9 +1408,7 @@ void Test_CF_Chunks_Insert_CombinesNextSuccessButCombinePreviousSuccessCalls_CF_
     CF_Chunks_Insert(arg_chunks, arg_i, arg_chunk);
 
     /* Assert */
-    UtAssert_True(arg_chunks->count == dummy_chunks_count - 1,
-                  "chunks->count is %u and should be 1 less than %u (value before call)", arg_chunks->count,
-                  dummy_chunks_count);
+    UtAssert_UINT32_EQ(arg_chunks->count, dummy_chunks_count - 1);
 } /* end Test_CF_Chunks_Insert_CombinesNextSuccessButCombinePreviousSuccessCalls_CF_Chunks_EraseChunk */
 
 void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chunks_CombinePrevious_Returns_1_DoNothing(
@@ -1448,8 +1444,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chun
 
     /* Assert */
     /* Assert for CF_Chunks_InsertChunk */
-    UtAssert_True(arg_chunks->count == dummy_chunks_count, "chunks->count is %u and should be %u (value before call)",
-                  arg_chunks->count, dummy_chunks_count);
+    UtAssert_UINT32_EQ(arg_chunks->count, dummy_chunks_count);
 } /* end
      Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chunks_CombinePrevious_Returns_1_DoNothing
    */
@@ -1464,7 +1459,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chun
     CF_Chunk_t     *arg_chunk   = &dummy_chunk;
 
     /* Arrange for CF_Chunks_CombineNext to return 0 and CF_Chunks_CombinePrevious to return 0 */
-    uint8          dummy_chunks_count      = 10;    /* 10 for dummy_chunks_count is arbitrary, chosen for speed */
+    CF_ChunkIdx_t  dummy_chunks_count      = 10;    /* 10 for dummy_chunks_count is arbitrary, chosen for speed */
     CF_Chunk_t     dummy_chunks_chunks[10] = {{0}}; /* 10 repeated for dummy_chunks for build ability */
     CF_ChunkList_t dummy_chunks;
 
@@ -1487,9 +1482,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chun
 
     /* Assert */
     /* Assert for CF_Chunks_InsertChunk */
-    UtAssert_True(arg_chunks->count == (uint16)(dummy_chunks_count + 1),
-                  "chunks->count is %u and should be 1 more than %u (value before call)", arg_chunks->count,
-                  dummy_chunks_count);
+    UtAssert_UINT32_EQ(arg_chunks->count, dummy_chunks_count + 1);
 } /* end
      Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chunks_CombinePrevious_Returns_0_And_chunks_count_IsLessThan_chunks_CF_max_Chunks_Call_CF_Chunks_InsertChunk
    */
@@ -1504,7 +1497,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chun
     CF_Chunk_t     *arg_chunk   = &dummy_chunk;
 
     /* Arrange for CF_Chunks_CombineNext to return 0 and CF_Chunks_CombinePrevious to return 0 */
-    uint8          dummy_chunks_count      = 3;     /* 10 for dummy_chunks_count is arbitrary, chosen for speed */
+    CF_ChunkIdx_t  dummy_chunks_count      = 3;     /* 10 for dummy_chunks_count is arbitrary, chosen for speed */
     CF_Chunk_t     dummy_chunks_chunks[10] = {{0}}; /* 10 repeated for dummy_chunks for build ability */
     CF_ChunkList_t dummy_chunks;
 
@@ -1531,8 +1524,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chun
     CF_Chunks_Insert(arg_chunks, arg_i, arg_chunk);
 
     /* Assert */
-    UtAssert_True(arg_chunks->count == dummy_chunks_count, "chunks->count is %u and should be %u (value before call)",
-                  arg_chunks->count, dummy_chunks_count);
+    UtAssert_UINT32_EQ(arg_chunks->count, dummy_chunks_count);
 } /* end
      Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chunks_CombinePrevious_Returns_0_And_chunks_count_IsGreaterThan_max_chunks_And_smallest_c_size_IsGreaterThan_chunk_size_DoNothing
    */
@@ -1547,7 +1539,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chun
     CF_Chunk_t     *arg_chunk   = &dummy_chunk;
 
     /* Arrange for CF_Chunks_CombineNext to return 0 and CF_Chunks_CombinePrevious to return 0 */
-    uint8          dummy_chunks_count      = 3;     /* 10 for dummy_chunks_count is arbitrary, chosen for speed */
+    CF_ChunkIdx_t  dummy_chunks_count      = 3;     /* 10 for dummy_chunks_count is arbitrary, chosen for speed */
     CF_Chunk_t     dummy_chunks_chunks[10] = {{0}}; /* 10 repeated for dummy_chunks for build ability */
     CF_ChunkList_t dummy_chunks;
 
@@ -1576,8 +1568,7 @@ void Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chun
     /* Assert */
     /* Assert for CF_Chunks_EraseChunk and CF_Chunks_InsertChunk (-1/+1 thus no change? NOTE: better way to prove these
      * ran)*/
-    UtAssert_True(arg_chunks->count == dummy_chunks_count, "chunks->count is %u and should be %u (value before call)",
-                  arg_chunks->count, dummy_chunks_count);
+    UtAssert_UINT32_EQ(arg_chunks->count, dummy_chunks_count);
 } /* end
      Test_CF_Chunks_Insert_CallTo_CF_Chunks_CombineNext_Returns_0_CallTo_CF_Chunks_CombinePrevious_Returns_0_And_chunks_count_IsGreaterThan_max_chunks_And_smallest_c_size_IsLessThan_chunk_size_Call_CF_Chunks_EraseChunk_And_CF_Chunks_InsertChunk
    */
@@ -1928,7 +1919,7 @@ void Test_CF_Chunks_Init_SetGiven_chunks_max_chunks_ToGiven_max_chunks(void)
     UtAssert_ZERO(arg_chunks->count);
     UtAssert_MemCmpValue(arg_chunks->chunks, 0x00, sizeof(*arg_chunks->chunks) * arg_max_chunks,
                          "The chunks, %lu bytes (sizeof(*chunks->chunks)*chunks->max_chunks), were all set to 0",
-                         sizeof(CF_Chunk_t) * arg_max_chunks);
+                         (unsigned long)sizeof(CF_Chunk_t) * arg_max_chunks);
 } /* end Test_CF_Chunks_Init_SetGiven_chunks_max_chunks_ToGiven_max_chunks */
 
 /* CF_ChunkListInit tests */
@@ -1961,7 +1952,7 @@ void Test_CF_ChunksReset_Set_count_To_0_Keeps_max_chunks_AndMemsets_chunks_ToAll
     UtAssert_UINT32_EQ(arg_chunks->max_chunks, initial_max_chunks);
     UtAssert_MemCmpValue(arg_chunks->chunks, 0x00, sizeof(CF_Chunk_t) * initial_max_chunks,
                          "The chunks, %lu bytes (sizeof(CF_Chunk_t)*chunks->max_chunks), were all set to 0",
-                         sizeof(CF_Chunk_t) * initial_max_chunks);
+                         (unsigned long)sizeof(CF_Chunk_t) * initial_max_chunks);
 } /* end Test_CF_ChunksReset_Set_count_To_0_Keeps_max_chunks_AndMemsets_chunks_ToAll_0 */
 
 /* CF_ChunkListReset tests */

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -166,9 +166,8 @@ void Test_CF_CmdAcc_Increment_CF_AppData_hk_cmd_counter(void)
     CF_CmdAcc();
 
     /* Assert */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdAcc_Increment_CF_AppData_hk_cmd_counter */
 
 /* end CF_CmdAcc tests */
@@ -189,9 +188,8 @@ void Test_CF_CmdRej_Increment_CF_AppData_hk_err_counter(void)
     CF_CmdRej();
 
     /* Assert */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdRej_Increment_CF_AppData_hk_err_counter */
 
 /* end CF_CmdRej tests */
@@ -217,9 +215,7 @@ void Test_CF_CmdCond_When_cond_Is_0_Call_CF_CmdAcc(void)
 
     /* Assert */
     /* Assert for CF-CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 
 } /* Test_CF_CmdCond_When_cond_Is_0_Call_CF_CmdAcc */
 
@@ -238,9 +234,7 @@ void Test_CF_CmdCond_When_cond_IsNot_0_Call_CF_CmdRej(void)
 
     /* Assert */
     /* Assert for CF-CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 
 } /* Test_CF_CmdCond_When_cond_IsNot_0_Call_CF_CmdRej */
 
@@ -271,9 +265,7 @@ void Test_CF_CmdNoop_SendNoopEventAndAcceptCommand(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
     /* Assert to show CF_CmdAcc was called */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 
 } /* Test_CF_CmdNoop_SendNoopEventAndAcceptCommand */
 
@@ -310,9 +302,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert to show CF_CmdRej was called */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand */
 
 void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCommand(void)
@@ -340,9 +330,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert to show CF_CmdRej was called */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCommand */
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSendEvent(void)
@@ -367,10 +355,8 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
-    UtAssert_True(CF_AppData.hk.counters.cmd == 0, "CF_AppData.hk.counters.cmd is %hu and should be 0 (was reset)",
-                  CF_AppData.hk.counters.cmd);
-    UtAssert_True(CF_AppData.hk.counters.err == 0, "CF_AppData.hk.counters.err is %hu and should be 0 (was reset)",
-                  CF_AppData.hk.counters.err);
+    UtAssert_ZERO(CF_AppData.hk.counters.cmd);
+    UtAssert_ZERO(CF_AppData.hk.counters.err);
 } /* end Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSendEvent */
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEventAndAcceptCommand(void)
@@ -417,50 +403,25 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.file_open == 0,
-                      "fault.file_open for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.file_open);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.file_read == 0,
-                      "fault.file_read for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.file_read);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.file_seek == 0,
-                      "fault.file_seek for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.file_seek);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.file_write == 0,
-                      "fault.file_write for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.file_write);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.file_rename == 0,
-                      "fault.file_rename for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.file_rename);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.directory_read == 0,
-                      "fault.directory_read for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.directory_read);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch == 0,
-                      "fault.crc_mismatch for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch == 0,
-                      "fault.file_size_mismatch for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.nak_limit == 0,
-                      "fault.nak_limit for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.nak_limit);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.ack_limit == 0,
-                      "fault.ack_limit for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.ack_limit);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer == 0,
-                      "fault.inactivity_timer for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.fault.spare == 0,
-                      "fault.spare for channel %hu is %hu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.fault.spare);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_open);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_read);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_seek);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_write);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_rename);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.directory_read);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.nak_limit);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.ack_limit);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.spare);
         UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.fault, 0,
                              sizeof(&CF_AppData.hk.channel_hk[i].counters.fault),
                              "fault channel %d was completely cleared to 0", i);
     }
     /* Assert to show CF_CmdAcc was called */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEventAndAcceptCommand */
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEventAndAcceptCommand(void)
@@ -501,32 +462,19 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes == 0,
-                      "recv.file_data_bytes for channel %u is %lu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.recv.pdu == 0,
-                      "recv.pdu for channel %u is %u and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.recv.pdu);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.recv.error == 0,
-                      "recv.error for channel %u is %u and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.recv.error);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.recv.spurious == 0,
-                      "recv.spurious for channel %u is %u and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.recv.spurious);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.recv.pdu == 0,
-                      "recv.pdu for channel %u is %u and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.recv.pdu);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests == 0,
-                      "recv.nak_segment_requests for channel %u is %u and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.pdu);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.error);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.spurious);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.pdu);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests);
         UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.recv, 0,
                              sizeof(&CF_AppData.hk.channel_hk[i].counters.recv),
                              "recv channel %d was completely cleared to 0", i);
     }
     /* Assert to show CF_CmdAcc was called */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEventAndAcceptCommand */
 
 void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEventAcceptCommand(void)
@@ -564,23 +512,16 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes == 0,
-                      "sent.file_data_bytes for channel %u is %lu and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests == 0,
-                      "sent.nak_segment_requests for channel %u is %u and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests);
-        UtAssert_True(CF_AppData.hk.channel_hk[i].counters.sent.pdu == 0,
-                      "sent.pdu for channel %u is %u and should be 0", i,
-                      CF_AppData.hk.channel_hk[i].counters.sent.pdu);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests);
+        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.pdu);
         UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.sent, 0,
                              sizeof(&CF_AppData.hk.channel_hk[i].counters.sent),
                              "sent channel %d was completely cleared to 0", i);
     }
     /* Assert to show CF_CmdAcc was called */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEventAcceptCommand */
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(void)
@@ -640,10 +581,8 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
 
-    UtAssert_True(CF_AppData.hk.counters.cmd == 0, "CF_AppData.hk.counters.cmd is %hu and should be 0 (was reset)",
-                  CF_AppData.hk.counters.cmd);
-    UtAssert_True(CF_AppData.hk.counters.err == 0, "CF_AppData.hk.counters.err is %hu and should be 0 (was reset)",
-                  CF_AppData.hk.counters.err);
+    UtAssert_ZERO(CF_AppData.hk.counters.cmd);
+    UtAssert_ZERO(CF_AppData.hk.counters.err);
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
         UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.fault, 0,
@@ -1305,12 +1244,8 @@ void Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundRe
     /* Assert */
     UtAssert_STUB_COUNT(CF_FindTransactionBySequenceNumber, CF_NUM_CHANNELS);
     UtAssert_ADDRESS_EQ(context_CF_CFDP_FTBSN.c, CF_AppData.engine.channels);
-    UtAssert_True(context_CF_CFDP_FTBSN.transaction_sequence_number == arg_ts,
-                  "CF_CFDP_FTBSN (abbr.) received transaction_sequence_number %u and should be %u (ts)",
-                  context_CF_CFDP_FTBSN.transaction_sequence_number, arg_ts);
-    UtAssert_True(context_CF_CFDP_FTBSN.src_eid == arg_eid,
-                  "CF_CFDP_FTBSN (abbr.) received src_eid %u and should be %u (eid)", context_CF_CFDP_FTBSN.src_eid,
-                  arg_eid);
+    UtAssert_UINT32_EQ(context_CF_CFDP_FTBSN.transaction_sequence_number, arg_ts);
+    UtAssert_UINT32_EQ(context_CF_CFDP_FTBSN.src_eid, arg_eid);
     UtAssert_ADDRESS_EQ(local_result, expected_result);
 
 } /* end Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundReturn_NULL */
@@ -1349,20 +1284,12 @@ void Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound(
     for (i = 0; i < number_transaction_match; ++i)
     {
         UtAssert_ADDRESS_EQ(contexts_CF_CFDP_FTBSN[i].c, CF_AppData.engine.channels + i);
-        UtAssert_True(contexts_CF_CFDP_FTBSN[i].transaction_sequence_number == arg_ts,
-                      "CF_CFDP_FTBSN (abbr.) received transaction_sequence_number %u and should be %u (ts)",
-                      contexts_CF_CFDP_FTBSN[i].transaction_sequence_number, arg_ts);
-        UtAssert_True(contexts_CF_CFDP_FTBSN[i].src_eid == arg_eid,
-                      "CF_CFDP_FTBSN (abbr.) received src_eid %u and should be %u (eid)",
-                      contexts_CF_CFDP_FTBSN[i].src_eid, arg_eid);
+        UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].transaction_sequence_number, arg_ts);
+        UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].src_eid, arg_eid);
     }
     UtAssert_ADDRESS_EQ(contexts_CF_CFDP_FTBSN[i].c, CF_AppData.engine.channels + i);
-    UtAssert_True(contexts_CF_CFDP_FTBSN[i].transaction_sequence_number == arg_ts,
-                  "CF_CFDP_FTBSN (abbr.) received transaction_sequence_number %u and should be %u (ts)",
-                  contexts_CF_CFDP_FTBSN[i].transaction_sequence_number, arg_ts);
-    UtAssert_True(contexts_CF_CFDP_FTBSN[i].src_eid == arg_eid,
-                  "CF_CFDP_FTBSN (abbr.) received src_eid %u and should be %u (eid)", contexts_CF_CFDP_FTBSN[i].src_eid,
-                  arg_eid);
+    UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].transaction_sequence_number, arg_ts);
+    UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].src_eid, arg_eid);
     UtAssert_ADDRESS_EQ(local_result, expected_result);
 
 } /* end Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound */
@@ -1462,10 +1389,8 @@ void Test_CF_TsnChanAction_cmd_chan_Eq_COMPOUND_KEY_TransactionFoundRun_fn_AndRe
                   local_result, CFE_SUCCESS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(Dummy_CF_TsnChanAction_fn_t, 1);
-    UtAssert_True(context_Dummy_CF_TsnChanAction_fn_t.t == &dummy_t,
-                  "context_Dummy_CF_TsnChanAction_fn_t.t ==  &dummy_t");
-    UtAssert_True(context_Dummy_CF_TsnChanAction_fn_t.context == arg_context,
-                  "context_Dummy_CF_TsnChanAction_fn_t.context ==  arg_context");
+    UtAssert_ADDRESS_EQ(context_Dummy_CF_TsnChanAction_fn_t.t, &dummy_t);
+    UtAssert_ADDRESS_EQ(context_Dummy_CF_TsnChanAction_fn_t.context, arg_context);
 } /* end Test_CF_TsnChanAction_cmd_chan_Eq_COMPOUND_KEY_TransactionFoundRun_fn_AndReturn_CFE_SUCCESS */
 
 void Test_CF_TsnChanAction_cmd_chan_Eq_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels(void)
@@ -1949,9 +1874,7 @@ void Test_CF_CmdCancel_Call_CF_CmdCond_WithNotted_CF_TsnChanAction(void)
                   "context_CF_TraverseAllTransactions.fn ==  CF_CmdCancel_Txn");
     UtAssert_ADDRESS_EQ(context_CF_TraverseAllTransactions.context, NULL);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end Test_CF_CmdCancel_Call_CF_CmdCond_WithNotted_CF_TsnChanAction */
 
 /*******************************************************************************
@@ -2024,9 +1947,7 @@ void Test_CF_CmdAbandon_Call_CF_CmdCond_WithNotted_CF_TsnChanAction(void)
                   "context_CF_TraverseAllTransactions.fn ==  CF_CmdAbandon_Txn");
     UtAssert_ADDRESS_EQ(context_CF_TraverseAllTransactions.context, NULL);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end Test_CF_CmdAbandon_Call_CF_CmdCond_WithNotted_CF_TsnChanAction */
 
 /*******************************************************************************
@@ -2749,9 +2670,7 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectCommand */
 
 void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand(void)
@@ -2781,9 +2700,7 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
 
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand */
 
 void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
@@ -2817,9 +2734,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_ARGS);
 
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand */
 
 void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_IsNot_q_pend_SendEventAndRejectCommand(
@@ -2860,16 +2775,12 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_WrappedOpenCreate, 1);
-    UtAssert_True(context_CF_WrappedOpenCreate.access == OS_WRITE_ONLY,
-                  "CF_WrappedCreat received access %d and should be %d (OS_WRITE_ONLY)",
-                  context_CF_WrappedOpenCreate.access, OS_WRITE_ONLY);
+    UtAssert_INT32_EQ(context_CF_WrappedOpenCreate.access, OS_WRITE_ONLY);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_IsNot_q_pend_SendEventAndRejectCommand
    */
@@ -2912,16 +2823,12 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_WrappedOpenCreate, 1);
-    UtAssert_True(context_CF_WrappedOpenCreate.access == OS_WRITE_ONLY,
-                  "CF_WrappedCreat received access %d and should be %d (OS_WRITE_ONLY)",
-                  context_CF_WrappedOpenCreate.access, OS_WRITE_ONLY);
+    UtAssert_INT32_EQ(context_CF_WrappedOpenCreate.access, OS_WRITE_ONLY);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_queue_Is_q_pend_SendEventAndRejectCommand
    */
@@ -2977,9 +2884,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteQueueDataToFile_Fails
    */
@@ -3040,9 +2945,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queu
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand
    */
@@ -3103,9 +3006,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(void)
    */
@@ -3166,9 +3067,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand
    */
@@ -3231,9 +3130,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand
    */
@@ -3294,9 +3191,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_PEND);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsPend_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(void)
    */
@@ -3357,9 +3252,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 } /* end
      Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(void)
    */
@@ -3414,9 +3307,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_All(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_All */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_History(void)
@@ -3464,9 +3356,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_History(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_History */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Active(void)
@@ -3514,9 +3405,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Active(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_All */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Pend(void)
@@ -3564,9 +3454,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Pend */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_All(void)
@@ -3619,9 +3508,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_All(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_All */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_History(void)
@@ -3669,9 +3557,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_History(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_History */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_Active(void)
@@ -3719,9 +3606,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_Active(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_Active */
 
 /* Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_Pend IS an error and is handled by a previous test */
@@ -3771,9 +3657,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_All(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Active */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_History(void)
@@ -3821,9 +3706,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_History(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Active */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Active(void)
@@ -3871,9 +3755,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Active(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Active */
 
 void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Pend(void)
@@ -3921,9 +3804,8 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Pend */
 
 /* end CF_CmdWriteQueue tests */
@@ -3973,52 +3855,27 @@ void Test_CF_CmdSendCfgParams_Set_cfg_TimeStampAndSendMsg_AcceptCommand(void)
     CF_CmdSendCfgParams(arg_msg);
 
     /* Assert */
-    UtAssert_True(CF_AppData.cfg.ticks_per_second == CF_AppData.config_table->ticks_per_second,
-                  "cfg.ticks_per_second is %u and should be %u (config_table->ticks_per_second)",
-                  CF_AppData.cfg.ticks_per_second, CF_AppData.config_table->ticks_per_second);
-    UtAssert_True(
-        CF_AppData.cfg.rx_crc_calc_bytes_per_wakeup == CF_AppData.config_table->rx_crc_calc_bytes_per_wakeup,
-        "cfg.rx_crc_calc_bytes_per_wakeup is %u and should be %u (config_table->rx_crc_calc_bytes_per_wakeup)",
-        CF_AppData.cfg.rx_crc_calc_bytes_per_wakeup, CF_AppData.config_table->rx_crc_calc_bytes_per_wakeup);
-    UtAssert_True(CF_AppData.cfg.ack_timer_s == CF_AppData.config_table->ack_timer_s,
-                  "cfg.ack_timer_s is %u and should be %u (config_table->ack_timer_s)", CF_AppData.cfg.ack_timer_s,
-                  CF_AppData.config_table->ack_timer_s);
-    UtAssert_True(CF_AppData.cfg.nak_timer_s == CF_AppData.config_table->nak_timer_s,
-                  "cfg.nak_timer_s is %u and should be %u (config_table->nak_timer_s)", CF_AppData.cfg.nak_timer_s,
-                  CF_AppData.config_table->nak_timer_s);
-    UtAssert_True(CF_AppData.cfg.inactivity_timer_s == CF_AppData.config_table->inactivity_timer_s,
-                  "cfg.inactivity_timer_s is %u and should be %u (config_table->inactivity_timer_s)",
-                  CF_AppData.cfg.inactivity_timer_s, CF_AppData.config_table->inactivity_timer_s);
-    UtAssert_True(CF_AppData.cfg.outgoing_file_chunk_size == CF_AppData.config_table->outgoing_file_chunk_size,
-                  "cfg.outgoing_file_chunk_size is %u and should be %u (config_table->outgoing_file_chunk_size)",
-                  CF_AppData.cfg.outgoing_file_chunk_size, CF_AppData.config_table->outgoing_file_chunk_size);
-    UtAssert_True(CF_AppData.cfg.ack_limit == CF_AppData.config_table->ack_limit,
-                  "cfg.ack_limit is %u and should be %u (config_table->ack_limit)", CF_AppData.cfg.ack_limit,
-                  CF_AppData.config_table->ack_limit);
-    UtAssert_True(CF_AppData.cfg.nak_limit == CF_AppData.config_table->nak_limit,
-                  "cfg.nak_limit is %u and should be %u (config_table->nak_limit)", CF_AppData.cfg.nak_limit,
-                  CF_AppData.config_table->nak_limit);
-    UtAssert_True(CF_AppData.cfg.local_eid == CF_AppData.config_table->local_eid,
-                  "cfg.local_eid is %u and should be %u (config_table->local_eid)", CF_AppData.cfg.local_eid,
-                  CF_AppData.config_table->local_eid);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.ticks_per_second, CF_AppData.config_table->ticks_per_second);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.rx_crc_calc_bytes_per_wakeup,
+                       CF_AppData.config_table->rx_crc_calc_bytes_per_wakeup);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.ack_timer_s, CF_AppData.config_table->ack_timer_s);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.nak_timer_s, CF_AppData.config_table->nak_timer_s);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.inactivity_timer_s, CF_AppData.config_table->inactivity_timer_s);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.outgoing_file_chunk_size, CF_AppData.config_table->outgoing_file_chunk_size);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.ack_limit, CF_AppData.config_table->ack_limit);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.nak_limit, CF_AppData.config_table->nak_limit);
+    UtAssert_UINT32_EQ(CF_AppData.cfg.local_eid, CF_AppData.config_table->local_eid);
     UtAssert_STUB_COUNT(CFE_MSG_SetMsgTime, 1);
     UtAssert_ADDRESS_EQ(context_CFE_MSG_SetMsgTime.MsgPtr, &CF_AppData.cfg.tlm_header.Msg);
-    UtAssert_True(context_CFE_MSG_SetMsgTime.Time.Seconds == fake_time.Seconds,
-                  "CFE_MSG_SetMsgTime received Time.Seconds %u and should be %u (call to CFE_TIME_GetTime Seconds)",
-                  context_CFE_MSG_SetMsgTime.Time.Seconds, fake_time.Seconds);
-    UtAssert_True(
-        context_CFE_MSG_SetMsgTime.Time.Subseconds == fake_time.Subseconds,
-        "CFE_MSG_SetMsgTime received Time.Subseconds %u and should be %u (call to CFE_TIME_GetTime Subseconds)",
-        context_CFE_MSG_SetMsgTime.Time.Subseconds, fake_time.Subseconds);
+    UtAssert_UINT32_EQ(context_CFE_MSG_SetMsgTime.Time.Seconds, fake_time.Seconds);
+    UtAssert_UINT32_EQ(context_CFE_MSG_SetMsgTime.Time.Subseconds, fake_time.Subseconds);
     UtAssert_STUB_COUNT(CFE_SB_TransmitMsg, 1);
     UtAssert_ADDRESS_EQ(context_CFE_SB_TransmitMsg.MsgPtr, &CF_AppData.cfg.tlm_header.Msg);
-    UtAssert_True(context_CFE_SB_TransmitMsg.IncrementSequenceCount == true,
-                  "CFE_SB_TransmitMsg received IncrementSequenceCount '%s' and should be 'true'",
-                  context_CFE_SB_TransmitMsg.IncrementSequenceCount ? "true" : "false");
+    UtAssert_BOOL_TRUE(context_CFE_SB_TransmitMsg.IncrementSequenceCount);
+
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_CmdSendCfgParams_Set_cfg_TimeStampAndSendMsg_AcceptCommand */
 
 /*******************************************************************************
@@ -4468,15 +4325,11 @@ void Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value(void)
     CF_CmdSetParam(arg_msg);
 
     /* Assert */
-    UtAssert_True(CF_AppData.config_table->ticks_per_second == dummy_msg->value,
-                  "ticks_per_second is %u and should be %u (msg->value)", CF_AppData.config_table->ticks_per_second,
-                  dummy_msg->value);
+    UtAssert_UINT32_EQ(CF_AppData.config_table->ticks_per_second, dummy_msg->value);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET1);
     /* Assert for CF_CmdAcc() */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 
 } /* end Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value */
 
@@ -4525,9 +4378,7 @@ void Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstant
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET2);
     /* Assert for CF_CmdAcc() */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 
 } /* end Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstantValue_0 */
 
@@ -4561,9 +4412,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdAccCou
     UtAssert_STUB_COUNT(CF_CFDP_InitEngine, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     /* Assert for CF-CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 
 } /* end Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdAccCounter */
 
@@ -4593,9 +4442,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementCm
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_ENGINE);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 
 } /* end Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementCmdRejCounter */
 
@@ -4623,9 +4470,7 @@ void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementCmdRejCou
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_ENA);
     /* Assert for CF_CmdRej */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 
 } /* end Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementCmdRejCounter */
 
@@ -4654,9 +4499,7 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdAccCounter(
     UtAssert_STUB_COUNT(CF_CFDP_DisableEngine, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     /* Assert for CF_CmdAcc */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 
 } /* end Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdAccCounter */
 
@@ -4682,6 +4525,7 @@ void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementCmdAccCounterThenFai
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_DIS);
     /* Assert for CF_CmdRej */
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
     UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
@@ -4736,11 +4580,9 @@ void Test_CF_ProcessGroundCommand_When_cmd_EqTo_CF_NUM_COMMANDS_FailAndSendEvent
     UtAssert_StrCmp(context_CFE_EVS_SendEvent.Spec, expected_Spec,
                     "CFE_EVS_SendEvent received expected Spec\n'%s' - Received\n'%s' - Expected",
                     context_CFE_EVS_SendEvent.Spec, expected_Spec);
-    /* Assert for CF_CmdRej */ /* TODO: This will fail if initial_hk_err_counter is MAX value, but left this way to show
-                                  this later and decide on a permanent fix */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    /* Assert for CF_CmdRej */
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_ProcessGroundCommand_When_cmd_EqTo_CF_NUM_COMMANDS_FailAndSendEvent */
 
 void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSendEvent(void)
@@ -4783,11 +4625,9 @@ void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSe
     UtAssert_StrCmp(context_CFE_EVS_SendEvent.Spec, expected_Spec,
                     "CFE_EVS_SendEvent received expected Spec\n'%s' - Received\n'%s' - Expected",
                     context_CFE_EVS_SendEvent.Spec, expected_Spec);
-    /* Assert for CF_CmdRej */ /* TODO: This will fail if initial_hk_err_counter is MAX value, but left this way to show
-                                  this later and decide on a permanent fix */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    /* Assert for CF_CmdRej */
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSendEvent */
 
 void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForThatCommandSendEventAndCall_CF_CmdRej(
@@ -4838,11 +4678,9 @@ void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForT
     UtAssert_StrCmp(context_CFE_EVS_SendEvent.Spec, expected_Spec,
                     "CFE_EVS_SendEvent received expected Spec\n'%s' - Received\n'%s' - Expected",
                     context_CFE_EVS_SendEvent.Spec, expected_Spec);
-    /* Assert for CF_CmdRej */ /* TODO: This will fail if initial_hk_err_counter is MAX value, but left this way to show
-                                  this later and decide on a permanent fix */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    /* Assert for CF_CmdRej */
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForThatCommandSendEventAndCall_CF_CmdRej
    */
 
@@ -4893,11 +4731,9 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_m
     UtAssert_StrCmp(context_CFE_EVS_SendEvent.Spec, expected_Spec,
                     "CFE_EVS_SendEvent received expected Spec\n'%s' - Received\n'%s' - Expected",
                     context_CFE_EVS_SendEvent.Spec, expected_Spec);
-    /* Assert for CF_CmdAcc */ /* TODO: This will fail if intial_hk_cmd_counter is MAX value, but left this way to show
-                                  this later and decide on a permanent fix */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %u and should be 1 more than %u (value before call)",
-                  CF_AppData.hk.counters.cmd, initial_hk_cmd_counter);
+    /* Assert for CF_CmdAcc */
+    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+
 } /* end Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_msg */
 
 /* TODO: Not sure if it is even possible to have a NULL get to this check, but

--- a/unit-test/cf_crc_tests.c
+++ b/unit-test/cf_crc_tests.c
@@ -59,9 +59,9 @@ void test_CF_CRC_Start_ReinitializeGiven_c_ToAllZeroValues(void)
     CF_CRC_Start(arg_c);
 
     /* Assert */
-    UtAssert_True(arg_c->working == 0, "c->working was set to %d and should be 0", arg_c->working);
-    UtAssert_True(arg_c->result == 0, "c->result was set to %d and should be 0", arg_c->result);
-    UtAssert_True(arg_c->index == 0, "c->index was set to %d and should be 0", arg_c->index);
+    UtAssert_ZERO(arg_c->working);
+    UtAssert_ZERO(arg_c->result);
+    UtAssert_ZERO(arg_c->index);
 
 } /* end test_CF_CRC_Start_ReinitializeGiven_c_ToAllZeroValues*/
 
@@ -95,12 +95,9 @@ void Test_CF_CRC_Digest_When_len_Is_0_DoNotAlter_c_working_or_c_result_or_c_inde
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->working == initial_c_working, "c->working is %d which is unchanged from %d", arg_c->working,
-                  initial_c_working);
-    UtAssert_True(arg_c->result == initial_c_result, "c->result is %d which is unchanged from %d", arg_c->result,
-                  initial_c_result);
-    UtAssert_True(arg_c->index == initial_c_index, "c->index is %d which is unchanged from %d", arg_c->index,
-                  initial_c_index);
+    UtAssert_UINT32_EQ(arg_c->working, initial_c_working);
+    UtAssert_UINT32_EQ(arg_c->result, initial_c_result);
+    UtAssert_UINT32_EQ(arg_c->index, initial_c_index);
 
 } /* end Test_CF_CRC_Digest_When_len_Is_0_DoNotAlter_c_working_or_c_result_or_c_index */
 
@@ -125,8 +122,7 @@ void Test_CF_CRC_Digest_When_len_Eq_1_PushDataLeftOnto_c_working(void)
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->working == expected_c_working, "c->working is %u and should be %u", arg_c->working,
-                  expected_c_working);
+    UtAssert_UINT32_EQ(arg_c->working, expected_c_working);
 
 } /* end Test_CF_CRC_Digest_When_len_Eq_1_PushDataLeftOnto_c_working */
 
@@ -161,8 +157,7 @@ void Test_CF_CRC_Digest_PushDataLeftOnto_c_working_NumberOfTimesEqTo_len(void)
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->working == expected_c_working, "c->working is %u and should be %u", arg_c->working,
-                  expected_c_working);
+    UtAssert_UINT32_EQ(arg_c->working, expected_c_working);
 
     /* local Teardown */
     free((uint8 *)arg_data);
@@ -186,8 +181,7 @@ void Test_CF_CRC_Digest_When_index_IsNot_3_DoNotUpdate_c_result(void)
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->result == initial_c_result, "c->result was not altered and is %u and should be %u",
-                  arg_c->result, initial_c_result);
+    UtAssert_UINT32_EQ(arg_c->result, initial_c_result);
 
 } /* end Test_CF_CRC_Digest_When_index_IsNot_3_DoNotUpdate_c_result */
 
@@ -215,8 +209,7 @@ void Test_CF_CRC_Digest_When_c_index_Is_3_Update_c_result(void)
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->result == expected_c_result, "c->result is %u and should be %u", arg_c->result,
-                  expected_c_result);
+    UtAssert_UINT32_EQ(arg_c->result, expected_c_result);
 
 } /* end Test_CF_CRC_Digest_When_c_index_Is_3_Update_c_result */
 
@@ -278,8 +271,7 @@ void Test_CF_CRC_Digest_Update_c_result_TheNumberOfTimes_index_Reaches4(void)
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->result == expected_c_result, "c->result is %u and should be %u", arg_c->result,
-                  expected_c_result);
+    UtAssert_UINT32_EQ(arg_c->result, expected_c_result);
 
     /* local Teardown */
     free((uint8 *)arg_data);
@@ -306,7 +298,7 @@ void Test_CF_CRC_Digest_When_len_Eq1_And_c_index_LessThan_3_Update_c_index_By_1(
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->index == expected_c_index, "c->index is %u and should be %u", arg_c->index, expected_c_index);
+    UtAssert_UINT32_EQ(arg_c->index, expected_c_index);
 
 } /* end Test_CF_CRC_Digest_When_len_Eq1_And_c_index_LessThan_3_Update_c_index_By_1 */
 
@@ -327,7 +319,7 @@ void Test_CF_CRC_Digest_When_len_Eq1_And_c_index_Is_3_Update_c_index_To_0(void)
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->index == 0, "c->index is %u and should be 0", arg_c->index);
+    UtAssert_ZERO(arg_c->index);
 
 } /* end Test_CF_CRC_Digest_When_len_Eq1_And_c_index_Is_3_Update_c_index_To_0 */
 
@@ -357,7 +349,7 @@ void Test_CF_CRC_Digest_Update_c_index_CorrectlyDependingOn_c_index_And_len_Valu
     CF_CRC_Digest(arg_c, arg_data, arg_len);
 
     /* Assert */
-    UtAssert_True(arg_c->index == expected_c_index, "c->index is %u and should be %u", arg_c->index, expected_c_index);
+    UtAssert_UINT32_EQ(arg_c->index, expected_c_index);
 
     /* local Teardown */
     free((uint8 *)arg_data);
@@ -388,11 +380,9 @@ void Test_CF_CRC_Finalize_When_index_Is_0_DoNothing(void)
     CF_CRC_Finalize(arg_c);
 
     /* Assert */
-    UtAssert_True(arg_c->working == initial_c_working, "c->working is %d which is unchanged from %d", arg_c->working,
-                  initial_c_working);
-    UtAssert_True(arg_c->result == initial_c_result, "c->result is %d which is unchanged from %d", arg_c->result,
-                  initial_c_result);
-    UtAssert_True(arg_c->index == 0, "c->index is %d which is unchanged from 0", arg_c->index);
+    UtAssert_UINT32_EQ(arg_c->working, initial_c_working);
+    UtAssert_UINT32_EQ(arg_c->result, initial_c_result);
+    UtAssert_ZERO(arg_c->index);
 } /* end Test_CF_CRC_Finalize_When_index_Is_0_DoNothing */
 
 void Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_1(void)
@@ -413,9 +403,9 @@ void Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_1(void)
     CF_CRC_Finalize(arg_c);
 
     /* Assert */
-    UtAssert_True(arg_c->working == 0, "c->working is %u and it should be 0", arg_c->working);
-    UtAssert_True(arg_c->result == expected_result, "c->result %u and it should be %u", arg_c->result, expected_result);
-    UtAssert_True(arg_c->index == 0, "c->index is %u and it should be 0", arg_c->index);
+    UtAssert_ZERO(arg_c->working);
+    UtAssert_UINT32_EQ(arg_c->result, expected_result);
+    UtAssert_ZERO(arg_c->index);
 } /* end Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_1 */
 
 void Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_2(void)
@@ -437,9 +427,9 @@ void Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_2(void)
     CF_CRC_Finalize(arg_c);
 
     /* Assert */
-    UtAssert_True(arg_c->working == 0, "c->working is %u and it should be 0", arg_c->working);
-    UtAssert_True(arg_c->result == expected_result, "c->result %u and it should be %u", arg_c->result, expected_result);
-    UtAssert_True(arg_c->index == 0, "c->index is %u and it should be 0", arg_c->index);
+    UtAssert_ZERO(arg_c->working);
+    UtAssert_UINT32_EQ(arg_c->result, expected_result);
+    UtAssert_ZERO(arg_c->index);
 } /* end Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_2 */
 
 void Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_3(void)
@@ -461,9 +451,9 @@ void Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_3(void)
     CF_CRC_Finalize(arg_c);
 
     /* Assert */
-    UtAssert_True(arg_c->working == 0, "c->working is %u and it should be 0", arg_c->working);
-    UtAssert_True(arg_c->result == expected_result, "c->result %u and it should be %u", arg_c->result, expected_result);
-    UtAssert_True(arg_c->index == 0, "c->index is %u and it should be 0", arg_c->index);
+    UtAssert_ZERO(arg_c->working);
+    UtAssert_UINT32_EQ(arg_c->result, expected_result);
+    UtAssert_ZERO(arg_c->index);
 } /* end Test_CF_CRC_Finalize_ReceiveExpectedResultAt_index_3 */
 
 /* end CF_CRC_Finalize tests */

--- a/unit-test/cf_timer_tests.c
+++ b/unit-test/cf_timer_tests.c
@@ -32,17 +32,13 @@ void Test_CF_Timer_Sec2Ticks_ReturnExpectedValue(void)
     CF_Timer_Seconds_t arg_sec                = Any_uint32();
     uint32             dummy_ticks_per_second = Any_uint32();
     CF_ConfigTable_t   dummy_config_table;
-    int32              result;
 
     CF_AppData.config_table                   = &dummy_config_table;
     CF_AppData.config_table->ticks_per_second = dummy_ticks_per_second;
 
     /* Act */
-    result = CF_Timer_Sec2Ticks(arg_sec);
+    UtAssert_UINT32_EQ(CF_Timer_Sec2Ticks(arg_sec), arg_sec * dummy_ticks_per_second);
 
-    /* Assert */
-    UtAssert_True(result == arg_sec * dummy_ticks_per_second, "Result was %u and should be %u", result,
-                  arg_sec * dummy_ticks_per_second);
 } /* end Test_CF_Timer_Sec2Ticks_ReturnExpectedValue */
 
 /* end CF_Timer_Sec2Ticks tests */
@@ -73,9 +69,7 @@ void Test_CF_Timer_InitRelSec_ReceiveExpectedValue(void)
     CF_Timer_InitRelSec(arg_t, arg_rel_sec);
 
     /* Assert */
-    UtAssert_True(arg_t->tick == arg_rel_sec * dummy_ticks_per_second,
-                  "Timer ticks are %u and should be %u (return from CF_Timer_Sec2Ticks)", arg_t->tick,
-                  arg_rel_sec * dummy_ticks_per_second);
+    UtAssert_UINT32_EQ(arg_t->tick, arg_rel_sec * dummy_ticks_per_second);
 } /* end Test_CF_Timer_InitRelSec_ReceiveExpectedValue */
 
 /* end CF_Timer_InitRelSec tests */
@@ -90,48 +84,38 @@ void Test_CF_Timer_Expired_When_t_tick_Is_0_Return_1(void)
 {
     /* Arrange */
     CF_Timer_t dummy_timer;
-    dummy_timer.tick        = 0;
-    const CF_Timer_t *arg_t = &dummy_timer;
-    int               local_result;
+    dummy_timer.tick                  = 0;
+    const CF_Timer_t *arg_t           = &dummy_timer;
     int               expected_result = 1;
 
     /* Act */
-    local_result = CF_Timer_Expired(arg_t);
+    UtAssert_INT32_EQ(CF_Timer_Expired(arg_t), expected_result);
 
-    /* Assert */
-    UtAssert_True(local_result == expected_result, "Result was %u and should be %u", local_result, expected_result);
 } /* end Test_CF_Timer_Expired_When_t_tick_Is_0_Return_1 */
 
 void Test_CF_Timer_Expired_When_t_tick_Is_1_Return_0(void)
 {
     /* Arrange */
     CF_Timer_t dummy_timer;
-    dummy_timer.tick        = 1;
-    const CF_Timer_t *arg_t = &dummy_timer;
-    int               local_result;
+    dummy_timer.tick                  = 1;
+    const CF_Timer_t *arg_t           = &dummy_timer;
     int               expected_result = 0;
 
     /* Act */
-    local_result = CF_Timer_Expired(arg_t);
+    UtAssert_INT32_EQ(CF_Timer_Expired(arg_t), expected_result);
 
-    /* Assert */
-    UtAssert_True(local_result == expected_result, "Result was %u and should be %u", local_result, expected_result);
 } /* end Test_CF_Timer_Expired_When_t_tick_Is_1_Return_0 */
 
 void Test_CF_Timer_Expired_When_t_tick_IsAnyIntegerExcept_0_Return_0(void)
 {
     /* Arrange */
     CF_Timer_t dummy_timer;
-    dummy_timer.tick        = Any_int_Except(0);
-    const CF_Timer_t *arg_t = &dummy_timer;
-    int               local_result;
+    dummy_timer.tick                  = Any_int_Except(0);
+    const CF_Timer_t *arg_t           = &dummy_timer;
     int               expected_result = 0;
 
     /* Act */
-    local_result = CF_Timer_Expired(arg_t);
-
-    /* Assert */
-    UtAssert_True(local_result == expected_result, "Result was %u and should be %u", local_result, expected_result);
+    UtAssert_INT32_EQ(CF_Timer_Expired(arg_t), expected_result);
 } /* end Test_CF_Timer_Expired_When_t_tick_IsAnyIntegerExcept_0_Return_0 */
 
 /* end CF_Timer_Expired tests */
@@ -165,8 +149,7 @@ void Test_CF_Timer_Tick_When_t_tick_Is_non0_Decrement_t_tick(void)
     CF_Timer_Tick(arg_t);
 
     /* Assert */
-    UtAssert_True(arg_t->tick == initial_tick - 1, "tick is %d and should have decreased by 1 from %d", arg_t->tick,
-                  initial_tick);
+    UtAssert_UINT32_EQ(arg_t->tick, initial_tick - 1);
 
 } /* Test_CF_Timer_Tick_When_t_tick_Is_non0_Decrement_t_tick */
 


### PR DESCRIPTION
**Describe the contribution**
Use the correct printf format code and typecast for printing various values in log messages and events.

Fixes #58

**Testing performed**
Build and run tests on RTEMS and 32-bit PowerPC 

**Expected behavior changes**
Build succeeds without warnings or errors

**System(s) tested on**
RTEMS 4.11.3 on pc686 + QEMU
Yocto/Poky Linux on PPC 7400  + QEMU

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
