### PR TITLE
Fix #40, update traverse history/write file

### DIFF
--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -716,7 +716,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
         /* process uplink queue data */
         if ((wq->queue == q_all) || (wq->queue == q_active))
         {
-            ret = CF_WriteQueueDataToFile(fd, c, CF_QueueIdx_RX);
+            ret = CF_WriteTxnQueueDataToFile(fd, c, CF_QueueIdx_RX);
             if (ret)
             {
                 CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_RX, CFE_EVS_EventType_ERROR,
@@ -747,7 +747,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
             static const int qs[2] = {CF_QueueIdx_TXA, CF_QueueIdx_TXW};
             for (i = 0; i < 2; ++i)
             {
-                ret = CF_WriteQueueDataToFile(fd, c, qs[i]);
+                ret = CF_WriteTxnQueueDataToFile(fd, c, qs[i]);
                 if (ret)
                 {
                     CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_TX, CFE_EVS_EventType_ERROR,
@@ -760,7 +760,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
         if ((wq->queue == q_all) || (wq->queue == q_pend))
         {
             /* write pending queue */
-            ret = CF_WriteQueueDataToFile(fd, c, CF_QueueIdx_PEND);
+            ret = CF_WriteTxnQueueDataToFile(fd, c, CF_QueueIdx_PEND);
             if (ret)
             {
                 CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_PEND, CFE_EVS_EventType_ERROR,

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -2926,7 +2926,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
      Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_queue_Is_q_pend_SendEventAndRejectCommand
    */
 
-void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteQueueDataToFile_Fails(
+void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails(
     void)
 {
     /* Arrange */
@@ -2953,13 +2953,13 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* invalid result from CF_WriteQueueDataToFile */
-    int32                             forced_return_CF_WriteQueueDataToFile = Any_int32_Except(0);
-    CF_WriteQueueDataToFile_context_t context_CF_WriteQueueDataToFile;
+    /* invalid result from CF_WriteTxnQueueDataToFile */
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
 
-    UT_SetDataBuffer(UT_KEY(CF_WriteQueueDataToFile), &context_CF_WriteQueueDataToFile,
-                     sizeof(context_CF_WriteQueueDataToFile), false);
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
+                     sizeof(context_CF_WriteTxnQueueDataToFile), false);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
 
@@ -2972,7 +2972,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
@@ -2981,10 +2981,10 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
 } /* end
-     Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteQueueDataToFile_Fails
+     Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails
    */
 
-void Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand(
+void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand(
     void)
 {
     /* Arrange */
@@ -3011,13 +3011,13 @@ void Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queu
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* invalid result from CF_WriteQueueDataToFile */
-    int32                             forced_return_CF_WriteQueueDataToFile = Any_int32_Except(0);
-    CF_WriteQueueDataToFile_context_t context_CF_WriteQueueDataToFile;
+    /* invalid result from CF_WriteTxnQueueDataToFile */
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
 
-    UT_SetDataBuffer(UT_KEY(CF_WriteQueueDataToFile), &context_CF_WriteQueueDataToFile,
-                     sizeof(context_CF_WriteQueueDataToFile), false);
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
+                     sizeof(context_CF_WriteTxnQueueDataToFile), false);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* goto out_close */
     int32 context_CF_WrappedClose_fd;
@@ -3035,7 +3035,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queu
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
@@ -3044,7 +3044,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queu
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
 } /* end
-     Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand
+     Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand
    */
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -3098,7 +3098,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 0);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
@@ -3137,13 +3137,13 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* invalid result from CF_WriteQueueDataToFile */
-    int32                             forced_return_CF_WriteQueueDataToFile = Any_int32_Except(0);
-    CF_WriteQueueDataToFile_context_t context_CF_WriteQueueDataToFile;
+    /* invalid result from CF_WriteTxnQueueDataToFile */
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
 
-    UT_SetDataBuffer(UT_KEY(CF_WriteQueueDataToFile), &context_CF_WriteQueueDataToFile,
-                     sizeof(context_CF_WriteQueueDataToFile), false);
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
+                     sizeof(context_CF_WriteTxnQueueDataToFile), false);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* goto out_close */
     int32 context_CF_WrappedClose_fd;
@@ -3161,7 +3161,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
@@ -3200,15 +3200,16 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* invalid result from CF_WriteQueueDataToFile */
-    int32                             forced_return_CF_WriteQueueDataToFile_1st_call = 0;
-    int32                             forced_return_CF_WriteQueueDataToFile_2nd_call = Any_int32_Except(0);
-    CF_WriteQueueDataToFile_context_t context_CF_WriteQueueDataToFile[2];
+    /* invalid result from CF_WriteTxnQueueDataToFile */
+    int32                                forced_return_CF_WriteTxnQueueDataToFile_1st_call = 0;
+    int32                                forced_return_CF_WriteTxnQueueDataToFile_2nd_call = Any_int32_Except(0);
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile[2];
 
-    UT_SetDataBuffer(UT_KEY(CF_WriteQueueDataToFile), &context_CF_WriteQueueDataToFile,
-                     sizeof(context_CF_WriteQueueDataToFile), false);
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile_1st_call);
-    UT_SetDeferredRetcode(UT_KEY(CF_WriteQueueDataToFile), SECOND_CALL, forced_return_CF_WriteQueueDataToFile_2nd_call);
+    UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
+                     sizeof(context_CF_WriteTxnQueueDataToFile), false);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile_1st_call);
+    UT_SetDeferredRetcode(UT_KEY(CF_WriteTxnQueueDataToFile), SECOND_CALL,
+                          forced_return_CF_WriteTxnQueueDataToFile_2nd_call);
 
     /* goto out_close */
     int32 context_CF_WrappedClose_fd;
@@ -3226,7 +3227,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 2);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
@@ -3265,13 +3266,13 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* invalid result from CF_WriteQueueDataToFile */
-    int32                             forced_return_CF_WriteQueueDataToFile = Any_int32_Except(0);
-    CF_WriteQueueDataToFile_context_t context_CF_WriteQueueDataToFile;
+    /* invalid result from CF_WriteTxnQueueDataToFile */
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
 
-    UT_SetDataBuffer(UT_KEY(CF_WriteQueueDataToFile), &context_CF_WriteQueueDataToFile,
-                     sizeof(context_CF_WriteQueueDataToFile), false);
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
+                     sizeof(context_CF_WriteTxnQueueDataToFile), false);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* goto out_close */
     int32 context_CF_WrappedClose_fd;
@@ -3289,7 +3290,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_PEND);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
@@ -3352,7 +3353,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 0);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
@@ -3390,10 +3391,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_All(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
     int32 forced_return_CF_WriteHistoryQueueDataToFile = 0;
@@ -3409,7 +3410,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_All(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 4);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 4);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3459,7 +3460,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_History(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 0);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3495,10 +3496,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Active(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();
@@ -3509,7 +3510,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Active(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 3);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 3);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3545,10 +3546,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Pend(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();
@@ -3559,7 +3560,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_AllAnd_q_Pend(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3595,10 +3596,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_All(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
     int32 forced_return_CF_WriteHistoryQueueDataToFile = 0;
@@ -3614,7 +3615,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_All(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3664,7 +3665,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_History(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 0);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3700,10 +3701,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_Active(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();
@@ -3714,7 +3715,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_UpAnd_q_Active(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3752,10 +3753,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_All(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();
@@ -3766,7 +3767,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_All(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 3);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 3);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3802,10 +3803,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_History(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();
@@ -3816,7 +3817,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_History(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 0);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3852,10 +3853,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Active(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();
@@ -3866,7 +3867,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Active(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 2);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -3902,10 +3903,10 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Pend(void)
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    /* valid result from CF_WriteQueueDataToFile */
-    int32 forced_return_CF_WriteQueueDataToFile = 0;
+    /* valid result from CF_WriteTxnQueueDataToFile */
+    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_WriteQueueDataToFile), forced_return_CF_WriteQueueDataToFile);
+    UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* Arrange unstubbable: CF_CmdAcc */
     uint16 initial_hk_cmd_counter = Any_uint16();
@@ -3916,7 +3917,7 @@ void Test_CF_CmdWriteQueue_SuccessCall_CF_CmdAcc_type_DownAnd_q_Pend(void)
     CF_CmdWriteQueue(arg_msg);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_WriteQueueDataToFile, 1);
+    UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
@@ -5252,14 +5253,15 @@ void add_CF_CmdWriteQueue_tests(void)
         "Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_queue_Is_q_pend_"
         "SendEventAndRejectCommand");
     UtTest_Add(
-        Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteQueueDataToFile_Fails,
+        Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails,
         cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
         "Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_"
-        "SendEventCloseAndRejectCommandWhen_CF_WriteQueueDataToFile_Fails");
+        "SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails");
     UtTest_Add(
-        Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand,
+        Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand,
         cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
-        "Test_CF_CmdWriteQueue_When_CF_WriteQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_"
+        "Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_"
+        "CF_"
         "WrappedClose_SendEventClosesAndRejectCommand");
     UtTest_Add(
         Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand,

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -532,241 +532,118 @@ void Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size(vo
 
 /*******************************************************************************
 **
-**  CF_TraverseHistory tests
+**  CF_Traverse_WriteHistoryQueueEntryToFile tests
 **
 *******************************************************************************/
 
-void Test_CF_TraverseHistory_AssertsBecause_h_dir_GreaterThan_CF_DIR_NUM(void)
+void Test_CF_Traverse_WriteHistoryQueueEntryToFile(void)
 {
-    // /* Arrange */
-    // CF_History_t       dummy_h;
-    // CF_CListNode_t *      arg_n = &dummy_h.cl_node;
-    // CF_Traverse_WriteFileArg_t      dummy_context;
-    // CF_Traverse_WriteFileArg_t*     arg_context = &dummy_context;
-    //
-    // dummy_h.src_eid = Any_uint8();
-    // dummy_h.seq_num = Any_uint32();
-    // dummy_h.dir = Any_direction_t();
-    // dummy_h.peer_eid = Any_uint8();
-    // dummy_h.cc = Any_condition_code_t();
+    /* Test case for:
+     * int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg);
+     */
+    CF_History_t                      hist;
+    CF_Traverse_WriteHistoryFileArg_t args;
 
-    // /* Act */
-    // CF_TraverseHistory(arg_n, arg_context);
+    memset(&hist, 0, sizeof(hist));
+    memset(&args, 0, sizeof(args));
 
-    // /* Assert */
-    UtAssert_MIR("JIRA: GSFCCFS-1733 CF_Assert - h->dir<CF_Direction_NUM");
+    /* nominal, if everything works, should continue */
+    hist.dir        = CF_Direction_TX;
+    args.filter_dir = CF_Direction_TX;
+    UtAssert_INT32_EQ(CF_Traverse_WriteHistoryQueueEntryToFile(&hist.cl_node, &args), CF_CLIST_CONT);
+    UtAssert_UINT32_EQ(args.counter, 1);
+    UtAssert_BOOL_FALSE(args.error);
 
-} /* end Test_CF_TraverseHistory_AssertsBecause_h_dir_GreaterThan_CF_DIR_NUM */
+    /* filter disabled (anything goes) */
+    hist.dir        = CF_Direction_RX;
+    args.filter_dir = CF_Direction_NUM;
+    UtAssert_INT32_EQ(CF_Traverse_WriteHistoryQueueEntryToFile(&hist.cl_node, &args), CF_CLIST_CONT);
+    UtAssert_UINT32_EQ(args.counter, 2);
+    UtAssert_BOOL_FALSE(args.error);
 
-void Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsFirstCallReturn_CLIST_EXIT(void)
-{
-    /* Arrange */
-    CF_History_t                dummy_h;
-    CF_CListNode_t             *arg_n = &dummy_h.cl_node;
-    CF_Traverse_WriteFileArg_t  dummy_context;
-    CF_Traverse_WriteFileArg_t *arg_context      = &dummy_context;
-    char                        src_colon_str[6] = "SRC: "; /* duplicates function value */
-    uint8                       dummy_len;
-    int                         local_result;
+    /* filter no match (does not write) */
+    hist.dir        = CF_Direction_RX;
+    args.filter_dir = CF_Direction_TX;
+    UtAssert_INT32_EQ(CF_Traverse_WriteHistoryQueueEntryToFile(&hist.cl_node, &args), CF_CLIST_CONT);
+    UtAssert_UINT32_EQ(args.counter, 2); /* no increment */
+    UtAssert_BOOL_FALSE(args.error);
 
-    dummy_h.src_eid  = Any_uint8();
-    dummy_h.seq_num  = Any_uint32();
-    dummy_h.dir      = Any_direction_t();
-    dummy_h.peer_eid = Any_uint8();
-    dummy_h.cc       = Any_condition_code_t();
-
-    /* ensures dummy_context.result change to 1 was done */
-    dummy_context.result = 0;
-
-    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Arrange for CF_WrappedWrite in same file as CF_TraverseHistory */
-    dummy_len = strlen(dummy_h.fnames.src_filename) + strlen(src_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), FIRST_CALL, Any_int_Except(dummy_len));
-
-    /* Act */
-    local_result = CF_TraverseHistory(arg_n, arg_context);
-
-    /* Assert */
-    UT_CF_AssertEventID(CF_EID_ERR_CMD_WHIST_WRITE);
-    UtAssert_True(arg_context->result == 1, "CF_TraverseHistory set context.result to %d and should be 1",
-                  arg_context->result);
-    UtAssert_True(local_result == CF_CLIST_EXIT,
-                  "CF_TraverseHistory returned 0x%08X and should be 0x%08X (CF_CLIST_EXIT)", local_result,
-                  CF_CLIST_EXIT);
-
-} /* end Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsFirstCallReturn_CLIST_EXIT */
-
-void Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsSecondCallReturn_CLIST_EXIT(void)
-{
-    /* Arrange */
-    CF_History_t                dummy_h;
-    CF_CListNode_t             *arg_n = &dummy_h.cl_node;
-    CF_Traverse_WriteFileArg_t  dummy_context;
-    CF_Traverse_WriteFileArg_t *arg_context      = &dummy_context;
-    char                        src_colon_str[6] = "SRC: "; /* duplicates function value */
-    char                        dst_colon_str[6] = "DST: "; /* duplicates function value */
-    uint8                       dummy_len_src;
-    uint8                       dummy_len_dst;
-    int                         local_result;
-
-    dummy_h.src_eid  = Any_uint8();
-    dummy_h.seq_num  = Any_uint32();
-    dummy_h.dir      = Any_direction_t();
-    dummy_h.peer_eid = Any_uint8();
-    dummy_h.cc       = Any_condition_code_t();
-
-    /* ensures dummy_context.result change to 1 was done */
-    dummy_context.result = 0;
-
-    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Arrange for CF_WrappedWrite in same file as CF_TraverseHistory */
-    dummy_len_src = strlen(dummy_h.fnames.src_filename) + strlen(src_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), FIRST_CALL, dummy_len_src);
-    dummy_len_dst = strlen(dummy_h.fnames.dst_filename) + strlen(dst_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), NEXT_CALL, Any_int_Except(dummy_len_dst));
-
-    /* Act */
-    local_result = CF_TraverseHistory(arg_n, arg_context);
-
-    /* Assert */
-    UT_CF_AssertEventID(CF_EID_ERR_CMD_WHIST_WRITE);
-    UtAssert_True(arg_context->result == 1, "CF_TraverseHistory set context.result to %d and should be 1",
-                  arg_context->result);
-    UtAssert_True(local_result == CF_CLIST_EXIT,
-                  "CF_TraverseHistory returned 0x%08X and should be 0x%08X (CF_CLIST_EXIT)", local_result,
-                  CF_CLIST_EXIT);
-
-} /* end Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsSecondCallReturn_CLIST_EXIT */
-
-void Test_CF_TraverseHistory_WhenBothWrappedWritesSuccessfulReturn_CLIST_CONT(void)
-{
-    /* Arrange */
-    CF_History_t                dummy_h;
-    CF_CListNode_t             *arg_n = &dummy_h.cl_node;
-    CF_Traverse_WriteFileArg_t  dummy_context;
-    CF_Traverse_WriteFileArg_t *arg_context      = &dummy_context;
-    char                        src_colon_str[6] = "SRC: "; /* duplicates function value */
-    char                        dst_colon_str[6] = "DST: "; /* duplicates function value */
-    uint8                       dummy_len_src;
-    uint8                       dummy_len_dst;
-    int                         local_result;
-
-    dummy_h.src_eid  = Any_uint8();
-    dummy_h.seq_num  = Any_uint32();
-    dummy_h.dir      = Any_direction_t();
-    dummy_h.peer_eid = Any_uint8();
-    dummy_h.cc       = Any_condition_code_t();
-
-    /* ensures dummy_context.result change to 1 was done */
-    dummy_context.result = 0;
-
-    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Arrange for CF_WrappedWrite in same file as CF_TraverseHistory */
-    dummy_len_src = strlen(dummy_h.fnames.src_filename) + strlen(src_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), FIRST_CALL, dummy_len_src);
-    dummy_len_dst = strlen(dummy_h.fnames.dst_filename) + strlen(dst_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), NEXT_CALL, dummy_len_dst);
-
-    /* Act */
-    local_result = CF_TraverseHistory(arg_n, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(arg_context->result == 0, "CF_TraverseHistory context.result is %d and should be 0",
-                  arg_context->result);
-    UtAssert_True(local_result == CF_CLIST_CONT,
-                  "CF_TraverseHistory returned 0x%08X and should be 0x%08X (CF_CLIST_CONT)", local_result,
-                  CF_CLIST_CONT);
-
-} /* end Test_CF_TraverseHistory_WhenBothWrappedWritesSuccessfulReturn_CLIST_CONT */
-
-/* end CF_TraverseHistory tests */
+    /* Setup for failure */
+    UT_SetDeferredRetcode(UT_KEY(OS_write), 1, -1);
+    hist.dir        = CF_Direction_RX;
+    args.filter_dir = CF_Direction_RX;
+    UtAssert_INT32_EQ(CF_Traverse_WriteHistoryQueueEntryToFile(&hist.cl_node, &args), CF_CLIST_EXIT);
+    UtAssert_UINT32_EQ(args.counter, 2); /* no increment */
+    UtAssert_BOOL_TRUE(args.error);
+}
+/* end CF_Traverse_WriteHistoryQueueEntryToFile tests */
 
 /*******************************************************************************
 **
-**  CF_TraverseTransactions tests
+**  CF_Traverse_WriteTxnQueueEntryToFile tests
 **
 *******************************************************************************/
 
-void Test_CF_TraverseTransactions_When_context_result_Is_1_Return_CLIST_EXIT(void)
+void Test_CF_Traverse_WriteTxnQueueEntryToFile(void)
 {
-    /* Arrange */
-    CF_History_t                dummy_history;
-    CF_Transaction_t            dummy_t;
-    CF_CListNode_t             *arg_n = &dummy_t.cl_node;
-    CF_Traverse_WriteFileArg_t  dummy_context;
-    CF_Traverse_WriteFileArg_t *arg_context = &dummy_context;
-    int                         local_result;
+    /* Test case for:
+     * int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg);
+     */
+    CF_Transaction_t              txn;
+    CF_History_t                  hist;
+    CF_Traverse_WriteTxnFileArg_t args;
 
-    /* Arrange for CF_TraverseHistory in same file as CF_TraverseTransactions */
+    memset(&txn, 0, sizeof(txn));
+    memset(&hist, 0, sizeof(hist));
+    memset(&args, 0, sizeof(args));
+    txn.history = &hist;
 
-    dummy_t.history           = &dummy_history;
-    dummy_t.history->src_eid  = Any_uint8();
-    dummy_t.history->seq_num  = Any_uint32();
-    dummy_t.history->dir      = Any_direction_t();
-    dummy_t.history->peer_eid = Any_uint8();
-    dummy_t.history->cc       = Any_condition_code_t();
+    /* nominal, if everything works, should continue */
+    UtAssert_INT32_EQ(CF_Traverse_WriteTxnQueueEntryToFile(&txn.cl_node, &args), CF_CLIST_CONT);
+    UtAssert_UINT32_EQ(args.counter, 1);
+    UtAssert_BOOL_FALSE(args.error);
 
-    /* Arrange for CF_WrappedWrite in same file as CF_TraverseHistor in same
-     * file as CF_TraverseTransactions */
-    char  src_colon_str[6] = "SRC: "; /* duplicates function value */
-    uint8 dummy_len;
+    /* Setup for failure */
+    UT_SetDeferredRetcode(UT_KEY(OS_write), 1, -1);
+    UtAssert_INT32_EQ(CF_Traverse_WriteTxnQueueEntryToFile(&txn.cl_node, &args), CF_CLIST_EXIT);
+    UtAssert_UINT32_EQ(args.counter, 1); /* no increment */
+    UtAssert_BOOL_TRUE(args.error);
+}
 
-    dummy_len = strlen(dummy_t.history->fnames.src_filename) + strlen(src_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), FIRST_CALL, Any_int_Except(dummy_len));
+/* end CF_Traverse_WriteTxnQueueEntryToFile tests */
 
-    /* Act */
-    local_result = CF_TraverseTransactions(arg_n, arg_context);
+/*******************************************************************************
+**
+**  CF_WriteHistoryEntryToFile tests
+**
+*******************************************************************************/
 
-    /* Assert */
-    UtAssert_True(local_result == CF_CLIST_EXIT, "CF_TraverseTransactions returned %d and should be %d (CF_CLIST_EXIT)",
-                  local_result, CF_CLIST_EXIT);
-} /* end Test_CF_TraverseTransactions_When_context_result_Is_1_Return_CLIST_EXIT */
-
-void Test_CF_TraverseTransactions_When_context_result_Is_0_Return_CLIST_CONT(void)
+void Test_CF_WriteHistoryEntryToFile(void)
 {
-    /* Arrange */
-    CF_History_t                dummy_history;
-    CF_Transaction_t            dummy_t;
-    CF_CListNode_t             *arg_n = &dummy_t.cl_node;
-    CF_Traverse_WriteFileArg_t  dummy_context;
-    CF_Traverse_WriteFileArg_t *arg_context = &dummy_context;
-    int                         local_result;
+    /* Test case for:
+     * int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
+     */
+    osal_id_t    arg_fd = OS_ObjectIdFromInteger(1);
+    CF_History_t h;
 
-    arg_context->result = 0; /* ensures arg_context->result starts at 0 */
+    memset(&h, 0, sizeof(h));
+    strcpy(h.fnames.src_filename, "sf");
+    strcpy(h.fnames.dst_filename, "df");
 
-    /* Arrange for CF_TraverseHistor in same file as CF_TraverseTransactions */
-    dummy_t.history           = &dummy_history;
-    dummy_t.history->src_eid  = Any_uint8();
-    dummy_t.history->seq_num  = Any_uint32();
-    dummy_t.history->dir      = Any_direction_t();
-    dummy_t.history->peer_eid = Any_uint8();
-    dummy_t.history->cc       = Any_condition_code_t();
+    /* Successful write - need to set up for 3 successful calls to OS_write() */
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+    UT_SetDeferredRetcode(UT_KEY(OS_write), 1, 44);
+    UT_SetDeferredRetcode(UT_KEY(OS_write), 1, strlen(h.fnames.src_filename) + 6);
+    UT_SetDeferredRetcode(UT_KEY(OS_write), 1, strlen(h.fnames.dst_filename) + 6);
+    UtAssert_INT32_EQ(CF_WriteHistoryEntryToFile(arg_fd, &h), 0);
+    UT_CF_AssertEventID(0);
 
-    /* Arrange for CF_WrappedWrite in same file as CF_TraverseHistor in same
-     * file as CF_TraverseTransactions */
-    char  src_colon_str[6] = "SRC: "; /* duplicates function value */
-    char  dst_colon_str[6] = "DST: "; /* duplicates function value */
-    uint8 dummy_len_src;
-    uint8 dummy_len_dst;
-
-    dummy_len_src = strlen(dummy_t.history->fnames.src_filename) + strlen(src_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), FIRST_CALL, dummy_len_src);
-    dummy_len_dst = strlen(dummy_t.history->fnames.dst_filename) + strlen(dst_colon_str);
-    UT_SetDeferredRetcode(UT_KEY(OS_write), NEXT_CALL, dummy_len_dst);
-
-    /* Act */
-    local_result = CF_TraverseTransactions(arg_n, arg_context);
-
-    /* Assert */
-    UtAssert_True(local_result == CF_CLIST_CONT, "CF_TraverseTransactions returned %d and should be %d (CF_CLIST_CONT)",
-                  local_result, CF_CLIST_CONT);
-} /* end Test_CF_TraverseTransactions_When_context_result_Is_0_Return_CLIST_CONT */
-
-/* end CF_TraverseTransactions tests */
+    /* Unsuccessful write */
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+    UT_SetDeferredRetcode(UT_KEY(OS_write), 1, -1);
+    UtAssert_INT32_EQ(CF_WriteHistoryEntryToFile(arg_fd, &h), -1);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WHIST_WRITE);
+}
 
 /*******************************************************************************
 **
@@ -774,41 +651,24 @@ void Test_CF_TraverseTransactions_When_context_result_Is_0_Return_CLIST_CONT(voi
 **
 *******************************************************************************/
 
-void Test_CF_WriteQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result(void)
+void Test_CF_WriteTxnQueueDataToFile(void)
 {
     /* Arrange */
-    int32           arg_fd = Any_int32();
-    CF_Channel_t    dummy_c;
-    CF_Channel_t   *arg_c = &dummy_c;
-    CF_QueueIdx_t   arg_q = Any_cf_queue_index_t();
-    CF_CListNode_t  dummy_node;
-    CF_CListNode_t *expected_start = &dummy_node;
-    CF_CListFn_t    expected_fn    = (CF_CListFn_t)CF_TraverseTransactions;
-    int32           result;
+    osal_id_t      arg_fd = OS_ObjectIdFromInteger(1);
+    CF_Channel_t   ch;
+    CF_CListNode_t node;
 
-    CF_CList_Traverse_TRAV_ARG_T_context_t context_clist_traverse;
-
-    dummy_c.qs[arg_q] = expected_start;
-
-    context_clist_traverse.context_result = Any_int32();
-    UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T,
-                          &context_clist_traverse);
+    memset(&node, 0, sizeof(node));
+    memset(&ch, 0, sizeof(ch));
+    ch.qs[CF_QueueIdx_TXA] = &node;
 
     /* Act */
-    result = CF_WriteQueueDataToFile(arg_fd, arg_c, arg_q);
+    /* with no configuration, this should return no error (0) */
+    UtAssert_INT32_EQ(CF_WriteTxnQueueDataToFile(arg_fd, &ch, CF_QueueIdx_TXA), 0);
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_Traverse, 1);
-    UtAssert_ADDRESS_EQ(context_clist_traverse.start, expected_start);
-    UtAssert_True(context_clist_traverse.fn == expected_fn, "context_clist_traverse.fn ==  expected_fn");
-    UtAssert_True(context_clist_traverse.context_fd == arg_fd,
-                  "CF_WriteQueueDataToFile received context fd %d and should be %d (fd)",
-                  context_clist_traverse.context_fd, arg_fd);
-    UtAssert_True(result == context_clist_traverse.context_result,
-                  "CF_WriteQueueDataToFile returned %d and should be %d (CF_CList_Traverse set arg.result)", result,
-                  context_clist_traverse.context_result);
-    /* NOTE: context_clist_traverse.counter is not checked because it is not altered */
-} /* end Test_CF_WriteQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result */
+}
 
 /* end CF_WriteQueueDataToFile tests */
 
@@ -818,43 +678,24 @@ void Test_CF_WriteQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result(vo
 **
 *******************************************************************************/
 
-void Test_CF_WriteHistoryQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result(void)
+void Test_CF_WriteHistoryQueueDataToFile(void)
 {
     /* Arrange */
-    int32           arg_fd = Any_int32();
-    CF_Channel_t    dummy_c;
-    CF_Channel_t   *arg_c   = &dummy_c;
-    CF_Direction_t  arg_dir = Any_direction_t();
-    CF_CListNode_t  dummy_node;
-    CF_CListNode_t *expected_start = &dummy_node;
-    CF_CListFn_t    expected_fn    = (CF_CListFn_t)CF_TraverseHistory;
-    int32           result;
+    osal_id_t      arg_fd = OS_ObjectIdFromInteger(1);
+    CF_Channel_t   ch;
+    CF_CListNode_t node;
 
-    CF_CList_Traverse_TRAV_ARG_T_context_t context_clist_traverse;
-
-    dummy_c.qs[CF_QueueIdx_HIST] = expected_start;
-
-    context_clist_traverse.context_result = Any_int32();
-    UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T,
-                          &context_clist_traverse);
+    memset(&node, 0, sizeof(node));
+    memset(&ch, 0, sizeof(ch));
+    ch.qs[CF_QueueIdx_HIST] = &node;
 
     /* Act */
-    result = CF_WriteHistoryQueueDataToFile(arg_fd, arg_c, arg_dir);
+    /* with no configuration, this should return no error (0) */
+    UtAssert_INT32_EQ(CF_WriteHistoryQueueDataToFile(arg_fd, &ch, CF_QueueIdx_HIST), 0);
 
     /* Assert */
-    /* NOTE: cannot test functions local setup of arg because it is passed as a void*
-    ** Maybe this can be overcome, but need to know what all can be sent to CF_CList_Traverse */
     UtAssert_STUB_COUNT(CF_CList_Traverse, 1);
-    UtAssert_ADDRESS_EQ(context_clist_traverse.start, expected_start);
-    UtAssert_True(context_clist_traverse.fn == expected_fn, "context_clist_traverse.fn ==  expected_fn");
-    UtAssert_True(context_clist_traverse.context_fd == arg_fd,
-                  "CF_WriteQueueDataToFile received context fd %d and should be %d (fd)",
-                  context_clist_traverse.context_fd, arg_fd);
-    UtAssert_True(result == context_clist_traverse.context_result,
-                  "CF_WriteQueueDataToFile returned %d and should be %d (CF_CList_Traverse set arg.result)", result,
-                  context_clist_traverse.context_result);
-    /* NOTE: context_clist_traverse.counter is not checked because it is not altered */
-} /* end Test_CF_WriteHistoryQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result */
+}
 
 /* end CF_WriteHistoryQueueDataToFile tests */
 
@@ -1465,38 +1306,28 @@ void add_cf_utils_h_tests(void)
     /* end CF_CList_InsertBack_Ex tests */
 }
 
-void add_CF_TraverseHistory_tests(void)
+void add_CF_Traverse_WriteHistoryToFile_tests(void)
 {
-    UtTest_Add(Test_CF_TraverseHistory_AssertsBecause_h_dir_GreaterThan_CF_DIR_NUM, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown, "Test_CF_TraverseHistory_AssertsBecause_h_dir_GreaterThan_CF_DIR_NUM");
-    UtTest_Add(Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsFirstCallReturn_CLIST_EXIT, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown, "Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsFirstCallReturn_CLIST_EXIT");
-    UtTest_Add(Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsSecondCallReturn_CLIST_EXIT, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown,
-               "Test_CF_TraverseHistory_When_CF_WrappedWrite_FailsSecondCallReturn_CLIST_EXIT");
-    UtTest_Add(Test_CF_TraverseHistory_WhenBothWrappedWritesSuccessfulReturn_CLIST_CONT, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown, "Test_CF_TraverseHistory_WhenBothWrappedWritesSuccessfulReturn_CLIST_CONT");
+    UtTest_Add(Test_CF_Traverse_WriteHistoryQueueEntryToFile, cf_utils_tests_Setup, cf_utils_tests_Teardown,
+               "CF_Traverse_WriteHistoryQueueEntryToFile");
 }
 
-void add_CF_TraverseTransactions_tests(void)
+void add_CF_Traverse_WriteAllTxnToFile_tests(void)
 {
-    UtTest_Add(Test_CF_TraverseTransactions_When_context_result_Is_1_Return_CLIST_EXIT, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown, "Test_CF_TraverseTransactions_When_context_result_Is_1_Return_CLIST_EXIT");
-    UtTest_Add(Test_CF_TraverseTransactions_When_context_result_Is_0_Return_CLIST_CONT, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown, "Test_CF_TraverseTransactions_When_context_result_Is_0_Return_CLIST_CONT");
+    UtTest_Add(Test_CF_Traverse_WriteTxnQueueEntryToFile, cf_utils_tests_Setup, cf_utils_tests_Teardown,
+               "CF_Traverse_WriteTxnQueueEntryToFile");
 }
 
-void add_CF_WriteQueueDataToFile_tests(void)
+void add_CF_WriteTxnQueueDataToFile_tests(void)
 {
-    UtTest_Add(Test_CF_WriteQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown, "Test_CF_WriteQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result");
+    UtTest_Add(Test_CF_WriteTxnQueueDataToFile, cf_utils_tests_Setup, cf_utils_tests_Teardown,
+               "Test_CF_WriteTxnQueueDataToFile");
 }
 
 void add_CF_WriteHistoryQueueDataToFile_tests(void)
 {
-    UtTest_Add(Test_CF_WriteHistoryQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown,
-               "Test_CF_WriteHistoryQueueDataToFile_Call_CF_CList_Traverse_AndReturn_arg_result");
+    UtTest_Add(Test_CF_WriteHistoryQueueDataToFile, cf_utils_tests_Setup, cf_utils_tests_Teardown,
+               "Test_CF_WriteHistoryQueueDataToFile");
 }
 
 void add_CF_PrioSearch_tests(void)
@@ -1591,11 +1422,11 @@ void UtTest_Setup(void)
 
     add_cf_utils_h_tests();
 
-    add_CF_TraverseHistory_tests();
+    add_CF_Traverse_WriteHistoryToFile_tests();
 
-    add_CF_TraverseTransactions_tests();
+    add_CF_Traverse_WriteAllTxnToFile_tests();
 
-    add_CF_WriteQueueDataToFile_tests();
+    add_CF_WriteTxnQueueDataToFile_tests();
 
     add_CF_WriteHistoryQueueDataToFile_tests();
 

--- a/unit-test/stubs/cf_utils_handlers.c
+++ b/unit-test/stubs/cf_utils_handlers.c
@@ -98,15 +98,15 @@ void UT_DefaultHandler_CF_FindUnusedTransaction(void *UserObj, UT_EntryKey_t Fun
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_WriteQueueDataToFile
+ * Function: UT_DefaultHandler_CF_WriteTxnQueueDataToFile
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
  *-----------------------------------------------------------------*/
-void UT_DefaultHandler_CF_WriteQueueDataToFile(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-    CF_WriteQueueDataToFile_context_t *ctxt = UT_CF_GetContextBuffer(FuncKey, CF_WriteQueueDataToFile_context_t);
+    CF_WriteTxnQueueDataToFile_context_t *ctxt = UT_CF_GetContextBuffer(FuncKey, CF_WriteTxnQueueDataToFile_context_t);
 
     if (ctxt)
     {

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -33,7 +33,7 @@ void UT_DefaultHandler_CF_TraverseAllTransactions(void *, UT_EntryKey_t, const U
 void UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WrappedOpenCreate(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WriteHistoryQueueDataToFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
-void UT_DefaultHandler_CF_WriteQueueDataToFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
 
 /*
  * ----------------------------------------------------
@@ -197,36 +197,36 @@ int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *arg
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_TraverseHistory()
+ * Generated stub function for CF_Traverse_WriteHistoryQueueEntryToFile()
  * ----------------------------------------------------
  */
-int CF_TraverseHistory(CF_CListNode_t *n, CF_Traverse_WriteFileArg_t *context)
+int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseHistory, int);
+    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteHistoryQueueEntryToFile, int);
 
-    UT_GenStub_AddParam(CF_TraverseHistory, CF_CListNode_t *, n);
-    UT_GenStub_AddParam(CF_TraverseHistory, CF_Traverse_WriteFileArg_t *, context);
+    UT_GenStub_AddParam(CF_Traverse_WriteHistoryQueueEntryToFile, CF_CListNode_t *, n);
+    UT_GenStub_AddParam(CF_Traverse_WriteHistoryQueueEntryToFile, void *, arg);
 
-    UT_GenStub_Execute(CF_TraverseHistory, Basic, NULL);
+    UT_GenStub_Execute(CF_Traverse_WriteHistoryQueueEntryToFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseHistory, int);
+    return UT_GenStub_GetReturnValue(CF_Traverse_WriteHistoryQueueEntryToFile, int);
 }
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_TraverseTransactions()
+ * Generated stub function for CF_Traverse_WriteTxnQueueEntryToFile()
  * ----------------------------------------------------
  */
-int CF_TraverseTransactions(CF_CListNode_t *n, CF_Traverse_WriteFileArg_t *context)
+int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseTransactions, int);
+    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteTxnQueueEntryToFile, int);
 
-    UT_GenStub_AddParam(CF_TraverseTransactions, CF_CListNode_t *, n);
-    UT_GenStub_AddParam(CF_TraverseTransactions, CF_Traverse_WriteFileArg_t *, context);
+    UT_GenStub_AddParam(CF_Traverse_WriteTxnQueueEntryToFile, CF_CListNode_t *, n);
+    UT_GenStub_AddParam(CF_Traverse_WriteTxnQueueEntryToFile, void *, arg);
 
-    UT_GenStub_Execute(CF_TraverseTransactions, Basic, NULL);
+    UT_GenStub_Execute(CF_Traverse_WriteTxnQueueEntryToFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseTransactions, int);
+    return UT_GenStub_GetReturnValue(CF_Traverse_WriteTxnQueueEntryToFile, int);
 }
 
 /*
@@ -316,14 +316,31 @@ int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_WriteHistoryEntryToFile()
+ * ----------------------------------------------------
+ */
+int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
+{
+    UT_GenStub_SetupReturnBuffer(CF_WriteHistoryEntryToFile, int);
+
+    UT_GenStub_AddParam(CF_WriteHistoryEntryToFile, osal_id_t, fd);
+    UT_GenStub_AddParam(CF_WriteHistoryEntryToFile, const CF_History_t *, h);
+
+    UT_GenStub_Execute(CF_WriteHistoryEntryToFile, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_WriteHistoryEntryToFile, int);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_WriteHistoryQueueDataToFile()
  * ----------------------------------------------------
  */
-int32 CF_WriteHistoryQueueDataToFile(int32 fd, CF_Channel_t *c, CF_Direction_t dir)
+int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction_t dir)
 {
     UT_GenStub_SetupReturnBuffer(CF_WriteHistoryQueueDataToFile, int32);
 
-    UT_GenStub_AddParam(CF_WriteHistoryQueueDataToFile, int32, fd);
+    UT_GenStub_AddParam(CF_WriteHistoryQueueDataToFile, osal_id_t, fd);
     UT_GenStub_AddParam(CF_WriteHistoryQueueDataToFile, CF_Channel_t *, c);
     UT_GenStub_AddParam(CF_WriteHistoryQueueDataToFile, CF_Direction_t, dir);
 
@@ -334,18 +351,18 @@ int32 CF_WriteHistoryQueueDataToFile(int32 fd, CF_Channel_t *c, CF_Direction_t d
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_WriteQueueDataToFile()
+ * Generated stub function for CF_WriteTxnQueueDataToFile()
  * ----------------------------------------------------
  */
-int32 CF_WriteQueueDataToFile(int32 fd, CF_Channel_t *c, CF_QueueIdx_t q)
+int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WriteQueueDataToFile, int32);
+    UT_GenStub_SetupReturnBuffer(CF_WriteTxnQueueDataToFile, int32);
 
-    UT_GenStub_AddParam(CF_WriteQueueDataToFile, int32, fd);
-    UT_GenStub_AddParam(CF_WriteQueueDataToFile, CF_Channel_t *, c);
-    UT_GenStub_AddParam(CF_WriteQueueDataToFile, CF_QueueIdx_t, q);
+    UT_GenStub_AddParam(CF_WriteTxnQueueDataToFile, osal_id_t, fd);
+    UT_GenStub_AddParam(CF_WriteTxnQueueDataToFile, CF_Channel_t *, c);
+    UT_GenStub_AddParam(CF_WriteTxnQueueDataToFile, CF_QueueIdx_t, q);
 
-    UT_GenStub_Execute(CF_WriteQueueDataToFile, Basic, UT_DefaultHandler_CF_WriteQueueDataToFile);
+    UT_GenStub_Execute(CF_WriteTxnQueueDataToFile, Basic, UT_DefaultHandler_CF_WriteTxnQueueDataToFile);
 
-    return UT_GenStub_GetReturnValue(CF_WriteQueueDataToFile, int32);
+    return UT_GenStub_GetReturnValue(CF_WriteTxnQueueDataToFile, int32);
 }

--- a/unit-test/utilities/cf_test_alt_handler.c
+++ b/unit-test/utilities/cf_test_alt_handler.c
@@ -13,41 +13,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T
- *
- * A handler for CF_CList_Traverse which saves its arguments
- * including the opaque context pointer as a CF_Traverse_WriteFileArg_t object.
- *
- *-----------------------------------------------------------------*/
-void UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
-{
-    CF_CList_Traverse_TRAV_ARG_T_context_t *ctxt;
-    CF_Traverse_WriteFileArg_t *arg = UT_Hook_GetArgValueByName(Context, "context", CF_Traverse_WriteFileArg_t *);
-
-    if (UserObj)
-    {
-        ctxt = UserObj;
-    }
-    else
-    {
-        ctxt = UT_CF_GetContextBuffer(FuncKey, CF_CList_Traverse_TRAV_ARG_T_context_t);
-    }
-
-    if (ctxt)
-    {
-        ctxt->start = UT_Hook_GetArgValueByName(Context, "start", CF_CListNode_t *);
-        ctxt->fn    = UT_Hook_GetArgValueByName(Context, "fn", CF_CListFn_t);
-        if (arg)
-        {
-            ctxt->context_fd      = arg->fd;
-            ctxt->context_counter = arg->counter;
-            ctxt->context_result  = arg->result;
-        }
-    }
-}
-
-/*----------------------------------------------------------------
- *
  * Function: UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T
  *
  * A handler for CF_CList_Traverse which saves its arguments

--- a/unit-test/utilities/cf_test_alt_handler.h
+++ b/unit-test/utilities/cf_test_alt_handler.h
@@ -9,7 +9,6 @@
 
 /* Alternate handlers for CF_CList_Traverse -
  * these differ in the type of context they save */
-void UT_AltHandler_CF_CList_Traverse_TRAV_ARG_T(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context);
 void UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T(void *UserObj, UT_EntryKey_t FuncKey,
                                                          const UT_StubContext_t *Context);
 void UT_AltHandler_CF_CList_Traverse_POINTER(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context);

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -124,7 +124,7 @@ typedef struct
     int32         fd;
     CF_Channel_t *c;
     CF_QueueIdx_t q;
-} CF_WriteQueueDataToFile_context_t;
+} CF_WriteTxnQueueDataToFile_context_t;
 
 typedef struct
 {


### PR DESCRIPTION
**Describe the contribution**

- rename the functions to better indicate what they do
- do not discard the part of the output that has EID/TSN/CC information
- do not pass the return value of snprintf directly to write(), use strlen()
- simplify the code

Fixes #40

**Testing performed**
Build and unit test CF.
Run two instances of CFE+CF, execute transfer in both directions and confirm
Issue CF_WRITE_QUEUE_CC (15) to write the transaction and history queues to the file
Confirm contents of the file are correct.

**Expected behavior changes**
The file contains the information it is intended to contain, mainly the SEQ/DIR/PEER/CC bits are not omitted.  There is also no risk of buffer overruns.

Here is an example file output, after running two transactions between two nodes (one RX, one TX)
```
SEQ (2, 1)      DIR: RX PEER 2  CC: 0   SRC: /cf/testfile2      DST: /cf/testfile2
SEQ (1, 1)      DIR: TX PEER 2  CC: 0   SRC: /cf/testfile1      DST: /cf/testfile1
```

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

