### PR TITLE
Fix #171, use osal_id_t for OSAL ID, not int32

### DIFF
--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -171,7 +171,7 @@ typedef struct CF_ChunkWrapper
  */
 typedef struct CF_Playback
 {
-    uint32            dir_id;
+    osal_id_t         dir_id;
     CF_CFDP_Class_t   cfdp_class;
     CF_TxnFilenames_t fnames;
     uint16            num_ts; /* number of transactions -- 16 bit should be enough */
@@ -387,7 +387,7 @@ typedef struct CF_Channel
     /* For polling directories, the configuration data is in a table. */
     CF_Poll_t poll[CF_MAX_POLLING_DIR_PER_CHAN];
 
-    uint32 sem_id; /* semaphore id for output pipe */
+    osal_id_t sem_id; /* semaphore id for output pipe */
 
     const CF_Transaction_t *cur; /* current transaction during channel cycle */
 

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -179,7 +179,7 @@ typedef struct
 {
     CF_CListNode_t *start;
     CF_CListFn_t    fn;
-    int32           context_fd;
+    osal_id_t       context_fd;
     int32           context_result;
     int32           context_counter;
 } CF_CList_Traverse_TRAV_ARG_T_context_t;


### PR DESCRIPTION
**Describe the contribution**
Use the correct typedef for OSAL ID.  This also necessitates using the correct conversion macro where use as an integer is intended.

Fixes #171

**Testing performed**
Build with OSAL bleeding edge code, confirm no type conversion errors.

**Expected behavior changes**
None w/Caelum OSAL, as osal_id_t is equivalent to uint32.

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

