### PR TITLE
Fix #172, restore call to CF_CFDP_RecvNak

### DIFF
--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -498,7 +498,7 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     /* this function is only invoked for NAK PDU types */
     nak = &ph->int_header.nak;
 
-    if (nak->segment_list.num_segments > 0)
+    if (CF_CFDP_RecvNak(t, ph) == 0 && nak->segment_list.num_segments > 0)
     {
         for (counter = 0; counter < nak->segment_list.num_segments; ++counter)
         {

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -777,6 +777,15 @@ void Test_CF_CFDP_S2_Nak(void)
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(t, ph));
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.nak_segment_requests, 6);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_INVALID_SR);
+
+    /* bad decode */
+    UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvNak), 1, -1);
+    nak                            = &ph->int_header.nak;
+    nak->segment_list.num_segments = 1;
+    UtAssert_VOIDCALL(CF_CFDP_S2_Nak(t, ph));
+    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error, 2);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_NAK);
 }
 
 void Test_CF_CFDP_S2_Nak_Arm(void)


### PR DESCRIPTION
**Describe the contribution**
This call got inadvertently removed with recent change, caught by regression test.  This puts it back.

Fixes #172

**Testing performed**
Build and sanity check CF
Execute CF file transfers

**Expected behavior changes**
NAK should work properly again

**System(s) tested on**
Ubuntu 21.10

**Additional context**
In my test environment it is difficult to recreate a NAK situation...

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

