### PR TITLE
Fix #36, add CF_PURGE_QUEUE_CC

### DIFF
--- a/fsw/src/cf_msg.h
+++ b/fsw/src/cf_msg.h
@@ -152,6 +152,7 @@ typedef enum
     CF_ENABLE_DIR_POLLING_CC  = 18,
     CF_DISABLE_DIR_POLLING_CC = 19,
     CF_DELETE_QUEUE_NODE_CC   = 20,
+    CF_PURGE_QUEUE_CC         = 21,
     CF_ENABLE_ENGINE_CC       = 22,
     CF_DISABLE_ENGINE_CC      = 23,
     CF_NUM_COMMANDS           = 24,


### PR DESCRIPTION
**Describe the contribution**
Adds missing enum label to CF_CMDS.

Fixes #36

**Testing performed**
Issued the command (code 21) from cmdutil and confirmed CF did something ....

**Expected behavior changes**
None, this command code was already in the dispatch table, so it worked before if CC 21 was manually sent using cmdutil.

**System(s) tested on**
Ubuntu 21.10

**Additional context**
This is just for completeness/correctness of the enum.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

