### PR TITLE
Fix #95, reject PDUs with large bit set

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -632,6 +632,19 @@ int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
 
     CF_CFDP_DecodeHeader(ph->pdec, &ph->pdu_header);
 
+    /*
+     * The "large file" flag is not supported by this implementation yet.
+     * This means file sizes and offsets will be 64 bits, so codec routines
+     * will need to be updated to understand this.  OSAL also doesn't support
+     * 64-bit file access yet.
+     */
+    if (CF_CODEC_IS_OK(ph->pdec) && ph->pdu_header.large_flag)
+    {
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_LARGE_FILE, CFE_EVS_EventType_ERROR,
+                          "CF: pdu with large file bit received (unsupported)");
+        goto err_out;
+    }
+
     if (CF_CODEC_IS_OK(ph->pdec) && ph->pdu_header.pdu_type == 0)
     {
         CF_CFDP_DecodeFileDirectiveHeader(ph->pdec, &ph->fdirective);

--- a/fsw/src/cf_events.h
+++ b/fsw/src/cf_events.h
@@ -64,6 +64,7 @@
 #define CF_EID_ERR_PDU_GET_EID_SIZE    52
 #define CF_EID_ERR_PDU_GET_TSN_SIZE    53
 #define CF_EID_ERR_PDU_FD_UNSUPPORTED  54
+#define CF_EID_ERR_PDU_LARGE_FILE      55
 
 /* CF_CFDP event ids (engine) */
 #define CF_EID_ERR_CFDP_RX_DROPPED      60

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -255,6 +255,12 @@ void Test_CF_CFDP_RecvPh(void)
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvPh(UT_CFDP_CHANNEL, ph), -1);
     UT_CF_AssertEventID(CF_EID_ERR_PDU_SHORT_HEADER);
+
+    /* decode error, large file bit set */
+    UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, NULL, NULL);
+    ph->pdu_header.large_flag = true;
+    UtAssert_INT32_EQ(CF_CFDP_RecvPh(UT_CFDP_CHANNEL, ph), -1);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_LARGE_FILE);
 }
 
 void Test_CF_CFDP_RecvMd(void)


### PR DESCRIPTION
**Describe the contribution**
This bit indicates that the PDU has 64-bit size and offset fields. CF currently does not support large file sizes.  It needs to reject
these packets as they will corrupt the data because they are not decoded properly (decode is fixed at 32 bit sizes).

Fixes #95

**Testing performed**
Build and sanity check CF
Force sending PDU with bit set, confirm CF rejects the PDU.

**Expected behavior changes**
CF informs the user that it received a PDU that it does not understand.

**System(s) tested on**
Ubuntu 21.10

**Additional context**
CF does not and did not support this feature, the only difference here is that it CF will now properly detect and reject a received PDU with this bit set, and inform the user of that event, instead of attempting to ingest it and doing so wrongly (likely corrupting data in the process).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
