### PR TITLE
Fix #178, remove throttle sem from default/example config

### DIFF
--- a/fsw/tables/cf_def_config.c
+++ b/fsw/tables/cf_def_config.c
@@ -39,7 +39,7 @@ CF_ConfigTable_t CF_config_table = {
          0x08c2,
          16,
          {{5, 25, CF_CFDP_CLASS_2, 23, "/cf/poll_dir", "./poll_dir", 0}, {0}, {0}, {0}, {0}},
-         "cf_1_sem",
+         "", /* throttle sem for channel 1, empty string means no throttle */
          1,
      },
      {5, /* max number of outgoing messages per wakeup */
@@ -48,7 +48,7 @@ CF_ConfigTable_t CF_config_table = {
       0x08c3,
       16,
       {{0}, {0}, {0}, {0}, {0}},
-      "cf_2_sem",
+      "", /* throttle sem for channel 2, empty string means no throttle */
       1}},
     3,   /* ack timer */
     3,   /* nak timer */


### PR DESCRIPTION
**Describe the contribution**
Removes the throttle sem name from the example configuration table.  Unless the user provides another app/library to create this sem, this configuration will not load.  With this sem removed then CF should at least be able to start up.

Fixes #178

**Testing performed**
Build CF

**Expected behavior changes**
Example config will not attempt to use a throttle sem.

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
