### PR TITLE
Fix #166, improve coverage on CF_CmdGetSetParam

### DIFF
--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -979,14 +979,10 @@ void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
             {
                 *((uint16 *)item.ptr) = value;
             }
-            else if (item.size == sizeof(uint8))
-            {
-                *((uint8 *)item.ptr) = value;
-            }
             else
             {
-                /* unimplemented store; this is a SW configuration error! */
-                acc = 1;
+                /* uint8 is the only other option */
+                *((uint8 *)item.ptr) = value;
             }
         }
     }
@@ -1003,13 +999,10 @@ void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
         {
             value = *((const uint16 *)item.ptr);
         }
-        else if (item.size == sizeof(uint8))
-        {
-            value = *((const uint8 *)item.ptr);
-        }
         else
         {
-            acc = 1;
+            /* uint8 is the only other option */
+            value = *((const uint8 *)item.ptr);
         }
 
         CFE_EVS_SendEvent(CF_EID_INF_CMD_GETSET2, CFE_EVS_EventType_INFORMATION, "CF: parameter id %d = %lu", param_id,


### PR DESCRIPTION
**Describe the contribution**
Rewrites the unit test on this function in order to get full line coverage.
This needs to call the routine with every defined param ID to get each case.

Fixes #166

**Testing performed**
Build and run all unit tests, confirm coverage

**Expected behavior changes**
None for FSW, unit test coverage improvement

**System(s) tested on**
Ubuntu 21.10

**Additional context**
This also removes a bit of code from FSW that did a no-op for a size that wasn't uint32/uint16/uint8.  This was unreachable because there are no cases that have such a size, and it would be a software bug if there was.  

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
