### PR TITLE
Fix #146, set revision number to 99

### DIFF
--- a/fsw/src/cf_version.h
+++ b/fsw/src/cf_version.h
@@ -28,6 +28,6 @@
 
 #define CF_MAJOR_VERSION 3
 #define CF_MINOR_VERSION 0
-#define CF_REVISION      0
+#define CF_REVISION      99 /* indicates a development version */
 
 #endif /* CF_VERSION_H */


### PR DESCRIPTION
**Describe the contribution**
Per CFE/CFS versioning patterns, development software should report itself as revision 99 to avoid confusion with released versions.

Fixes #146

**Testing performed**
Build and sanity check CF

**Expected behavior changes**
Revision reported as 99 now, example boot event:

    EVS Port1 66/1/CF_APP 20: CF Initialized. Version 3.0.99

**System(s) tested on**
Ubuntu 21.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
