### PR TITLE
Fix #186, CF table name and default polling disabled

### DIFF
--- a/fsw/tables/cf_def_config.c
+++ b/fsw/tables/cf_def_config.c
@@ -38,7 +38,7 @@ CF_ConfigTable_t CF_config_table = {
          0x18c8,
          0x08c2,
          16,
-         {{5, 25, CF_CFDP_CLASS_2, 23, "/cf/poll_dir", "./poll_dir", 0}, {0}, {0}, {0}, {0}},
+         {{5, 25, CF_CFDP_CLASS_2, 23, "/cf/poll_dir", "./poll_dir", 1}, {0}, {0}, {0}, {0}},
          "", /* throttle sem for channel 1, empty string means no throttle */
          1,
      },
@@ -58,4 +58,4 @@ CF_ConfigTable_t CF_config_table = {
     480, /* outgoing_file_chunk_size */
     "/cf/tmp",
 };
-CFE_TBL_FILEDEF(CF_config_table, CF_APP.config_table, CF config table, cf_def_config.tbl)
+CFE_TBL_FILEDEF(CF_config_table, CF.config_table, CF config table, cf_def_config.tbl)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [ x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #186 

**Testing performed**
Built and default startup, confirmed table loaded w/ no errors (with CF app name in startup config)

**Expected behavior changes**
No polling errors reported, works with GSFC app naming patterns

**System(s) tested on**
 - Hardware: i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC
