### PR TITLE
Fixes #212, Add unit test workflow

### DIFF
--- a/.github/workflows/build-cfs.yml
+++ b/.github/workflows/build-cfs.yml
@@ -8,12 +8,15 @@ on:
 env:
   SIMULATION: native
   OMIT_DEPRECATED: true
-  ENABLE_UNIT_TESTS: false
+  ENABLE_UNIT_TESTS: true
+  CTEST_OUTPUT_ON_FAILURE: true
+  REPO_NAME: ${{ github.event.repository.name }}
 
 jobs:
   #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
   check-for-duplicates:
     runs-on: ubuntu-latest
+    
     # Map a step output to a job output
     outputs:
         should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -25,13 +28,31 @@ jobs:
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
     
-  build-run:
+  build-run-test:
+    name: Build, Run, Test
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        buildtype: [debug, release]
+
+    # Set the type of machine to run on
+    env:
+      BUILDTYPE: ${{ matrix.buildtype }}
+    
     steps:
+      - name: Cache Source and Build
+        id: cache-src-bld
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/work/${{ env.REPO_NAME }}/${{ env.REPO_NAME }}/*
+          key: build-${{ github.run_number }}-${{ matrix.buildtype }}-${{ matrix.os }}
+      
       - name: Checkout bundle
         uses: actions/checkout@v2
         with:
@@ -84,3 +105,12 @@ jobs:
           fi
         working-directory: ./build/exe/cpu1/
 
+      - name: Install Dependencies
+        run: sudo apt-get install lcov -y        
+      
+      - name: Run Tests
+        run: make test
+
+      - name: Check Coverage
+        run: make lcov
+  


### PR DESCRIPTION
Changes enable_unit_test to true, changes ctest_output_on_failure to true,
Adds repo_name, changes ubuntu-latest to ubuntu-18.04, splits build-run
Copied and pasted this file from a successful run
Adds matrix method to ubuntu-18.04 and ubuntu-20.04

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #212

**Testing performed**
Testing performed on fork: https://github.com/chillfig/CF/actions/runs/2054990660

**Expected behavior changes**
Passing workflow

**System(s) tested on**
Ubuntu 18.04
Ubuntu 20.04

**Additional context**
The build release tested on Ubuntu 20.04 catches a format truncation warning in nasa/osal. [#1241](https://github.com/nasa/osal/issues/1241) documents this issue. Passing workflow requires truncation suppression, depends on https://github.com/nasa/cFE/pull/2078.

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, ASRC Federal
