### PR TITLE
Fix #229, Add doc build/deploy workflow

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,15 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-documentation:
+    name: Build and deploy cFS documents
+    uses: nasa/cFS/.github/workflows/build-deploy-doc.yml@main
+    with:
+      target: "[\"cf-usersguide\"]"
+      app-name: cf
+      buildpdf: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+      deploy: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}

--- a/docs/dox_src/cf-usersguide.doxyfile.in
+++ b/docs/dox_src/cf-usersguide.doxyfile.in
@@ -16,4 +16,4 @@
 INPUT                 += @MISSION_SOURCE_DIR@/cfe/cmake/sample_defs
 
 PROJECT_NAME           = "CF User's Guide"
-WARN_LOGFILE           = cf_usersguide_warnings.log
+WARN_LOGFILE           = cf-usersguide-warnings.log


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #229

**Testing performed**
CI with forced fork/branch for reuse workflow and forced deploy: https://github.com/skliper/CF/runs/6009379924

**Expected behavior changes**
Doc build with enforcement of no warnings, will deploy to gh-pages on push to main

**System(s) tested on**
CI

**Additional context**
Depends on nasa/cFS#451

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC