### PR TITLE
Fix #254, Fix #220, Updates CLA information for Apache 2.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 **Checklist (Please check before submitting)**
 
 * [ ] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
-* [ ] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.
+* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.
 
 **Describe the contribution**
 A clear and concise description of what the contribution is.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
 # Contributing Guide
 
-Please see our [top-level contributing guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md) for more information on how to contribute. 
+Please see our [top-level contributing guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md) for more information on how to contribute to cFS components.
+
+## Contributor License Agreement (CLA)
+
+Before we can accept your code contributions we need a signed Contributor License Agreement (CLA). See the [instructions](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) for more information.


### PR DESCRIPTION
Adds link to new CLAs in pull_request_template and contributing.md

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #254
- Fixes #220
- Fixes https://github.com/nasa/cFS/issues/495

**Testing performed**
Visually inspected links in fork and in PR template.

**Expected behavior changes**
All references to CLAs should be updated to the cFS app CLA.

**System(s) tested on**
Google Chrome browser

**Additional context**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, ASRC Federal
