### PR TITLE
Fix #217, Add mission rev and print in startup and noop events

### DIFF
--- a/fsw/platform_inc/cf_platform_cfg.h
+++ b/fsw/platform_inc/cf_platform_cfg.h
@@ -323,11 +323,24 @@ typedef uint32 CF_TransactionSeq_t;
 
 /**
  *  @brief Number of milliseconds to wait for a SB message
- *
- *  @par Limits:
- *
  */
 #define CF_RCVMSG_TIMEOUT (100)
+
+/**
+ * \brief Mission specific version number
+ *
+ *  \par Description:
+ *       An application version number consists of four parts:
+ *       major version number, minor version number, revision
+ *       number and mission specific revision number. The mission
+ *       specific revision number is defined here such
+ *       that missions can manage as a configuration definition
+ *
+ *  \par Limits:
+ *       Must be defined as a numeric value that is greater than
+ *       or equal to zero.
+ */
+#define CF_MISSION_REV 0
 
 /**\}*/
 

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -368,8 +368,8 @@ int32 CF_Init(void)
         goto err_out;
     }
 
-    status = CFE_EVS_SendEvent(CF_EID_INF_INIT, CFE_EVS_EventType_INFORMATION, "CF Initialized. Version %d.%d.%d",
-                               CF_MAJOR_VERSION, CF_MINOR_VERSION, CF_REVISION);
+    status = CFE_EVS_SendEvent(CF_EID_INF_INIT, CFE_EVS_EventType_INFORMATION, "CF Initialized. Version %d.%d.%d.%d",
+                               CF_MAJOR_VERSION, CF_MINOR_VERSION, CF_REVISION, CF_MISSION_REV);
 
     if (status != CFE_SUCCESS)
     {

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -52,8 +52,8 @@
  *-----------------------------------------------------------------*/
 void CF_CmdNoop(CFE_SB_Buffer_t *msg)
 {
-    CFE_EVS_SendEvent(CF_EID_INF_CMD_NOOP, CFE_EVS_EventType_INFORMATION, "CF: No-Op received, Version %d.%d.%d",
-                      CF_MAJOR_VERSION, CF_MINOR_VERSION, CF_REVISION);
+    CFE_EVS_SendEvent(CF_EID_INF_CMD_NOOP, CFE_EVS_EventType_INFORMATION, "CF: No-Op received, Version %d.%d.%d.%d",
+                      CF_MAJOR_VERSION, CF_MINOR_VERSION, CF_REVISION, CF_MISSION_REV);
     CF_CmdAcc();
 }
 

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -4241,7 +4241,7 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_m
     CFE_MSG_FcnCode_t forced_return_CFE_MSG_GetFcnCode = 0x00; /* 0x00 forces fns[0] which is CF_CmdNoop */
     CFE_MSG_Size_t    forced_return_CFE_MSG_GetSize =
         sizeof(CF_NoArgsCmd_t); /* sizeof(CF_NoArgsCmd_t) is expected size of CF_CmdNoop */
-    const char *                 expected_Spec = "CF: No-Op received, Version %d.%d.%d";
+    const char *                 expected_Spec = "CF: No-Op received, Version %d.%d.%d.%d";
     CFE_MSG_GetFcnCode_context_t context_CFE_MSG_GetFcnCode;
     CFE_MSG_GetSize_context_t    context_CFE_MSG_GetSize;
     CFE_EVS_SendEvent_context_t  context_CFE_EVS_SendEvent;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #217

**Testing performed**
CI

**Expected behavior changes**
Adds mission rev in startup and noop events

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC