### PR TITLE
Fix #173, Truncate files when created to avoid stale data

### DIFF
--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -613,7 +613,8 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
         CF_CFDP_ArmAckTimer(t);
     }
 
-    ret = CF_WrappedOpenCreate(&t->fd, t->history->fnames.dst_filename, OS_FILE_FLAG_CREATE, OS_READ_WRITE);
+    ret = CF_WrappedOpenCreate(&t->fd, t->history->fnames.dst_filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE,
+                               OS_READ_WRITE);
     if (ret < 0)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_CREAT, CFE_EVS_EventType_ERROR,

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -743,7 +743,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
 
     /* PTFO: queues can be large. may want to split this work up across the state machine and take several wakeups to
      * complete */
-    ret = CF_WrappedOpenCreate(&fd, wq->filename, OS_FILE_FLAG_CREATE, OS_WRITE_ONLY);
+    ret = CF_WrappedOpenCreate(&fd, wq->filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
     if (ret < 0)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_OPEN, CFE_EVS_EventType_ERROR, "CF: write queue failed to open file %s",


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #173

**Testing performed**
CI

**Expected behavior changes**
Truncates when creating files (avoids stale data if previous file was larger)

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC