### PR TITLE
Fix #131, Reset file psn and use OS_mv for out-of-order RX MD processing

### DIFF
--- a/docs/dox_src/cfs_cf.dox
+++ b/docs/dox_src/cfs_cf.dox
@@ -161,6 +161,21 @@
    has a per-channel configuration item for max number of RX messages
    processed per wakeup, and both CF and the ingest app
    need to be able to handle this.
+
+  <H3>Temporary file/directory use</H3>
+
+   Currently the temporary directory is only used to store class 2 RX file data
+   in temporary files on a transaction that has not yet received a metadata PDU.  
+   When/if the metadata is received for that transaction, OS_mv is used to transition
+   the temporary file to the desired destination location.  Note that OS_mv attempts
+   a rename first (faster but does not work across file systems), and if that
+   fails then attempts a copy/delete (slower).  Due to this the most efficent
+   temporary directory configuration is for it to be on the same file system as the
+   destination.  Note that currently this only impacts class 2 RX with an out
+   of order metadata packet, but there's future work being considered to
+   use the temporary location for all receipts with an atomic transfer of the
+   file after successful reception and verification (where applicable) of all the
+   file data.
 **/
 
 

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -1043,7 +1043,12 @@ void Test_CF_CFDP_R2_RecvMd(void)
 
     /* nominal */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
+    t->state_data.r.cached_pos      = 1;
+    t->state_data.r.r2.acknak_count = 1;
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
+    UtAssert_UINT32_EQ(t->state_data.r.cached_pos, 0);
+    UtAssert_UINT32_EQ(t->flags.rx.md_recv, 1);
+    UtAssert_UINT32_EQ(t->state_data.r.r2.acknak_count, 0);
 
     /* md_recv already set */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
@@ -1066,9 +1071,9 @@ void Test_CF_CFDP_R2_RecvMd(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_EOF_MD_SIZE);
     UtAssert_UINT32_EQ(t->history->cc, CF_CFDP_ConditionCode_FILE_SIZE_ERROR);
 
-    /* OS_rename failure */
+    /* OS_mv failure */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(OS_rename), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(OS_mv), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_RENAME);
     UtAssert_UINT32_EQ(t->history->cc, CF_CFDP_ConditionCode_FILESTORE_REJECTION);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #131

Switches from OS_rename to OS_mv which supports "rename" across file systems (via copy/delete)
Resets file cached position (from the file open) so it gets recalculated correctly

**Testing performed**
CI (added unit test asserts)

**Expected behavior changes**
Should now handle an out-of-order MD, and a tmp dir being on a different filesystem than the final location

**System(s) tested on**
CI

**Additional context**
Note the functional/CTF test is the full verification of this capability

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC