### PR TITLE
Fix #118, failed commands send error event message

### DIFF
--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -168,6 +168,7 @@ void CF_CmdTxFile(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_TX_FILE, CFE_EVS_EventType_ERROR, "CF: file transfer failed");
         CF_CmdRej();
     }
 }
@@ -211,6 +212,7 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_PLAYBACK_DIR, CFE_EVS_EventType_ERROR, "CF: directory playback cmd failed");
         CF_CmdRej();
     }
 }
@@ -286,6 +288,7 @@ void CF_CmdFreeze(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_FREEZE, CFE_EVS_EventType_ERROR, "CF: freeze cmd failed");
         CF_CmdRej();
     }
 }
@@ -309,6 +312,7 @@ void CF_CmdThaw(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_THAW, CFE_EVS_EventType_ERROR, "CF: thaw cmd failed");
         CF_CmdRej();
     }
 }
@@ -511,6 +515,8 @@ void CF_CmdCancel(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        /* No transaction was matched for the given combination of chan + eid + ts  */
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_CANCEL_CHAN, CFE_EVS_EventType_ERROR, "CF: cancel cmd: no transaction found");
         CF_CmdRej();
     }
 }
@@ -545,6 +551,9 @@ void CF_CmdAbandon(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        /* No transaction was matched for the given combination of chan + eid + ts  */
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ABANDON_CHAN, CFE_EVS_EventType_ERROR,
+                          "CF: abandon cmd: no transaction found");
         CF_CmdRej();
     }
 }
@@ -584,6 +593,7 @@ void CF_CmdEnableDequeue(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_DEQUEUE, CFE_EVS_EventType_ERROR, "CF: enable dequeue cmd failed");
         CF_CmdRej();
     }
 }
@@ -608,6 +618,7 @@ void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_DISABLE_DEQUEUE, CFE_EVS_EventType_ERROR, "CF: disable dequeue cmd failed");
         CF_CmdRej();
     }
 }
@@ -667,6 +678,8 @@ void CF_CmdEnablePolldir(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_POLLDIR, CFE_EVS_EventType_ERROR,
+                          "CF: enable polling directory cmd failed");
         CF_CmdRej();
     }
 }
@@ -692,6 +705,8 @@ void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_DISABLE_POLLDIR, CFE_EVS_EventType_ERROR,
+                          "CF: disable polling directory cmd failed");
         CF_CmdRej();
     }
 }
@@ -796,6 +811,7 @@ void CF_CmdPurgeQueue(CFE_SB_Buffer_t *msg)
     }
     else
     {
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_PURGE_QUEUE, CFE_EVS_EventType_ERROR, "CF: purge queue cmd failed");
         CF_CmdRej();
     }
 }

--- a/fsw/src/cf_events.h
+++ b/fsw/src/cf_events.h
@@ -1372,6 +1372,127 @@
  */
 #define CF_EID_ERR_CMD_BAD_PARAM (154)
 
+/**
+ * \brief CF Cancel Command No Matching Transaction Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Cancel command received without a matching transaction
+ */
+#define CF_EID_ERR_CMD_CANCEL_CHAN (155)
+
+/**
+ * \brief CF Abandon Command No Matching Transaction Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Abandon command received without a matching transaction
+ */
+#define CF_EID_ERR_CMD_ABANDON_CHAN (156)
+
+/**
+ * \brief CF Transfer File Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Transfer file command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_TX_FILE (157)
+
+/**
+ * \brief CF Playback Directory Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Playback directory command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_PLAYBACK_DIR (158)
+
+/**
+ * \brief CF Freeze Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Freeze command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_FREEZE (159)
+
+/**
+ * \brief CF Thaw Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Thaw command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_THAW (160)
+
+/**
+ * \brief CF Enable Dequeue Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Enable Dequeue command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_ENABLE_DEQUEUE (161)
+
+/**
+ * \brief CF Disable Dequeue Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Disable dequeue command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_DISABLE_DEQUEUE (162)
+
+/**
+ * \brief CF Enable Polldir Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Enable polldir command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_ENABLE_POLLDIR (163)
+
+/**
+ * \brief CF Disable Polldir Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Disable polldir command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_DISABLE_POLLDIR (164)
+
+/**
+ * \brief CF Purge Queue Command Failed Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Purge queue command was unsuccessful
+ */
+#define CF_EID_ERR_CMD_PURGE_QUEUE (165)
+
 /**\}*/
 
 #endif /* !CF_EVENTS_H */

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -627,9 +627,11 @@ void Test_CF_CmdTxFile(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
 
     /* CF_CFDP_TxFile fails*/
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_TxFile), -1);
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_TX_FILE);
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 4);
 }
 
@@ -681,9 +683,11 @@ void Test_CF_CmdPlaybackDir(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
 
     /* CF_CFDP_PlaybackDir fails*/
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_PlaybackDir), -1);
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_PLAYBACK_DIR);
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 4);
 }
 
@@ -1030,6 +1034,7 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
     /* Assert */
     /* Assert for CF-CmdRej */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_FREEZE);
 } /* end Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand */
 
 /*******************************************************************************
@@ -1100,6 +1105,7 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
     /* Assert */
     /* Assert for CF-CmdRej */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_THAW);
 } /* end Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand */
 
 /*******************************************************************************
@@ -1603,6 +1609,8 @@ void Test_CF_CmdCancel_Call_CF_CmdRej(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+
     /* Nominally returns number of transactions affected, cause failure */
     UT_SetDefaultReturnValue(UT_KEY(CF_TraverseAllTransactions), 0);
 
@@ -1612,6 +1620,7 @@ void Test_CF_CmdCancel_Call_CF_CmdRej(void)
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_CANCEL_CHAN);
 } /* end Test_CF_CmdCancel_Call_CF_CmdRej */
 
 /*******************************************************************************
@@ -1677,6 +1686,8 @@ void Test_CF_CmdAbandon_Call_CF_CmdRej(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+
     /* Nominally returns number of transactions acted on, force failure */
     UT_SetDefaultReturnValue(UT_KEY(CF_TraverseAllTransactions), 0);
 
@@ -1686,6 +1697,7 @@ void Test_CF_CmdAbandon_Call_CF_CmdRej(void)
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ABANDON_CHAN);
 } /* end Test_CF_CmdAbandon_Call_CF_CmdRej */
 
 /*******************************************************************************
@@ -1779,6 +1791,8 @@ void Test_CF_CmdEnableDequeue_CmdRej(void)
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&dummy_config_table, 0, sizeof(dummy_config_table));
 
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+
     CF_AppData.config_table = &dummy_config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
@@ -1793,6 +1807,7 @@ void Test_CF_CmdEnableDequeue_CmdRej(void)
     /* Assert */
     /* Assert for CF-CmdAcc */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_DEQUEUE);
 } /* end Test_CF_CmdEnableDequeue_CmdRej */
 
 /*******************************************************************************
@@ -1858,6 +1873,8 @@ void Test_CF_CmdDisableDequeue_CmdRej(void)
 
     CF_AppData.config_table = &dummy_config_table;
 
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = CF_NUM_CHANNELS + 1;
 
@@ -1870,6 +1887,7 @@ void Test_CF_CmdDisableDequeue_CmdRej(void)
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_DEQUEUE);
 } /* end Test_CF_CmdDisableDequeue_CmdRej */
 
 /*******************************************************************************
@@ -2035,6 +2053,8 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
 
     CF_AppData.config_table = &dummy_config_table;
 
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_channel;
 
@@ -2058,6 +2078,7 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
                   initial_hk_cmd_counter);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_POLLDIR);
 } /* end Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess */
 
 void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
@@ -2070,6 +2091,8 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
 
     memset(&utbuf, 0, sizeof(utbuf));
+
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
 
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_channel;
@@ -2091,6 +2114,7 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_POLLDIR);
 } /* end Test_CF_CmdEnablePolldir_FailWhenActionFail */
 
 /* end */
@@ -2116,6 +2140,8 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
 
     CF_AppData.config_table = &dummy_config_table;
 
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_channel;
 
@@ -2139,6 +2165,7 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
                   initial_hk_cmd_counter);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_POLLDIR);
 } /* end Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess */
 
 void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
@@ -2151,6 +2178,8 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
 
     memset(&utbuf, 0, sizeof(utbuf));
+
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
 
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_channel;
@@ -2172,6 +2201,7 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_POLLDIR);
 } /* end Test_CF_CmdDisablePolldir_FailWhenActionFail */
 
 /*******************************************************************************
@@ -2428,6 +2458,8 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
+    UT_CF_ResetEventCapture(UT_KEY(CFE_EVS_SendEvent));
+
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_channel;
 
@@ -2448,6 +2480,7 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_QUEUE);
 }
 
 void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #118 , an error event message is sent if a command is not successful

**Testing performed**
Ran unit tests

**Expected behavior changes**
Behavior Change: All commands now send an error event message if unsuccessful

**System(s) tested on**
OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Haven Carlson - NASA