### PR TITLE
Fix #285, flatten logic in CF_CFDP_InitEngine() to fix bug

### DIFF
--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -850,6 +850,7 @@ void Test_CF_CFDP_InitEngine(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, NULL, &config);
     UtAssert_INT32_EQ(CF_CFDP_InitEngine(), 0);
     UtAssert_BOOL_TRUE(CF_AppData.engine.enabled);
+    UtAssert_STUB_COUNT(CF_FreeTransaction, CF_NUM_TRANSACTIONS_PER_CHANNEL);
 
     /* nominal call, with sem */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, NULL, &config);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #285, fixed error in code where semaphore name being blank would skip to the end of `CF_CFDP_InitEngine()`

**Testing performed**
Ran unit tests

**Expected behavior changes**
If the semaphore name is blank, continue with function instead of exiting.

**System(s) tested on**
 - OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Haven Carlson - NASA
