### PR TITLE
Fix #224, support dynamic pdu packets

### DIFF
--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -131,8 +131,8 @@ CF_Logical_PduBuffer_t *CF_CFDP_MsgOutGet(const CF_Transaction_t *t, bool silent
     /* if returning a buffer, then reset the encoder state to point to the beginning of the encapsulation msg */
     if (success && ret != NULL)
     {
-        CF_CFDP_EncodeStart(&CF_AppData.engine.out.encode, CF_AppData.engine.out.msg, ret,
-                            offsetof(CF_PduTlmMsg_t, ph), offsetof(CF_PduTlmMsg_t, ph) + CF_MAX_PDU_SIZE);
+        CF_CFDP_EncodeStart(&CF_AppData.engine.out.encode, CF_AppData.engine.out.msg, ret, offsetof(CF_PduTlmMsg_t, ph),
+                            offsetof(CF_PduTlmMsg_t, ph) + CF_MAX_PDU_SIZE);
     }
 
     return ret;
@@ -177,13 +177,13 @@ void CF_CFDP_Send(uint8 chan_num, const CF_Logical_PduBuffer_t *ph)
  *-----------------------------------------------------------------*/
 void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
 {
-    CF_Transaction_t *      t; /* initialized below */
-    uint32                  count = 0;
-    int32                   status;
-    const int               chan_num = (c - CF_AppData.engine.channels);
-    CFE_SB_Buffer_t *       bufptr;
-    CFE_MSG_Size_t          msg_size;
-    CFE_MSG_Type_t          msg_type = CFE_MSG_Type_Invalid;
+    CF_Transaction_t *t; /* initialized below */
+    uint32            count = 0;
+    int32             status;
+    const int         chan_num = (c - CF_AppData.engine.channels);
+    CFE_SB_Buffer_t * bufptr;
+    CFE_MSG_Size_t    msg_size;
+    CFE_MSG_Type_t    msg_type = CFE_MSG_Type_Invalid;
 
     CF_Logical_PduBuffer_t *ph;
 

--- a/fsw/src/cf_cfdp_sbintf.h
+++ b/fsw/src/cf_cfdp_sbintf.h
@@ -31,6 +31,38 @@
 
 #include "cf_cfdp_types.h"
 
+/**
+ * @brief PDU command encapsulation structure
+ *
+ * This encapsulates a CFDP pdu into a format that is sent or received over the
+ * software bus, adding "command" encapsulation (even though these are not really
+ * commands).
+ *
+ * @note this is only the definition of the header.  In reality all messages are
+ * larger than this, up to CF_MAX_PDU_SIZE.
+ */
+typedef struct CF_PduCmdMsg
+{
+    CFE_MSG_CommandHeader_t hdr; /**< \brief software bus headers, not really used by CF */
+    CF_CFDP_PduHeader_t     ph;  /**< \brief Beginning of CFDP headers */
+} CF_PduCmdMsg_t;
+
+/**
+ * @brief PDU send encapsulation structure
+ *
+ * This encapsulates a CFDP pdu into a format that is sent or received over the
+ * software bus, adding "telemetry" encapsulation (even though these are not really
+ * telemetry items).
+ *
+ * @note this is only the definition of the header.  In reality all messages are
+ * larger than this, up to CF_MAX_PDU_SIZE.
+ */
+typedef struct CF_PduTlmMsg
+{
+    CFE_MSG_TelemetryHeader_t hdr; /**< \brief software bus headers, not really used by CF */
+    CF_CFDP_PduHeader_t       ph;  /**< \brief Beginning of CFDP headers */
+} CF_PduTlmMsg_t;
+
 /************************************************************************/
 /** @brief Obtain a message buffer to construct a PDU inside.
  *

--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -403,36 +403,6 @@ typedef struct CF_Channel
  * of size CF_MAX_PDU_SIZE */
 
 /**
- * @brief PDU receive encapsulation structure
- *
- * This encapsulates a CFDP pdu into a format that is received over the software bus,
- * adding "command" encapsulation (even though these are not really commands).
- *
- * @note this is only the definition of the header.  In reality all messages are
- * larger than this, up to CF_MAX_PDU_SIZE.
- */
-typedef struct CF_PduRecvMsg
-{
-    CFE_MSG_CommandHeader_t hdr; /**< \brief software bus headers, not really used by CF */
-    CF_CFDP_PduHeader_t     ph;  /**< \brief Beginning of CFDP headers */
-} CF_PduRecvMsg_t;
-
-/**
- * @brief PDU send encapsulation structure
- *
- * This encapsulates a CFDP pdu into a format that is sent over the software bus,
- * adding "telemetry" encapsulation (even though these are not really telemetry items).
- *
- * @note this is only the definition of the header.  In reality all messages are
- * larger than this, up to CF_MAX_PDU_SIZE.
- */
-typedef struct CF_PduSendMsg
-{
-    CFE_MSG_TelemetryHeader_t hdr; /**< \brief software bus headers, not really used by CF */
-    CF_CFDP_PduHeader_t       ph;  /**< \brief Beginning of CFDP headers */
-} CF_PduSendMsg_t;
-
-/**
  * @brief CF engine output state
  *
  * Keeps the state of the current output PDU in the CF engine

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -26,14 +26,14 @@
 
 static union
 {
-    CF_PduCmdMsg_t cf_msg;
+    CF_PduCmdMsg_t  cf_msg;
     CFE_SB_Buffer_t sb_buf;
     uint8           bytes[CF_MAX_PDU_SIZE];
 } UT_r_msg;
 
 static union
 {
-    CF_PduTlmMsg_t cf_msg;
+    CF_PduTlmMsg_t  cf_msg;
     CFE_SB_Buffer_t sb_buf;
     uint8           bytes[CF_MAX_PDU_SIZE];
 } UT_s_msg;

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -254,6 +254,7 @@ void Test_CF_CFDP_ReceiveMessage(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, NULL, &c, NULL, &t, &config);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvPh), 1, -1);
     /* Override message type to take the command branch of the if then/else clause */
+    UT_ResetState(UT_KEY(CFE_MSG_GetType)); /* clears the previous cmd type */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &msg_type, sizeof(msg_type), false);
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(c));
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #224
In order to support CF peer to peer transactions, this change will allow incoming PDU packets to be either command or telemetry packets. This is handled in the cf_cfdp_sbintf.c file that handles PDUs wrapped in CCSDS packets.
This change required renaming structures: 

```
CF_PduSendMsg_t to CF_PduTlmMsg_t
CF_PduRecvMsg_t to CF_PduCmdMsg_t
```
This rename makes it less confusing if CF receives a PDU wrapped in a TLM packet, for example. In this case, it would not make sense to receive a "Send" type packet.

In addition to renaming these structures, the typedefs were moved to cf_cfdp_sbint.h as a step toward decoupling the PDU send and receive from the software bus.

By allowing incoming PDU packets to be wrapped in command or telemetry CCSDS packets, CF can receive PDUs from the ground wrapped in a command packet, or PDUs from a CF peer wrapped in a telemetry packet.

**Testing performed**
1. Built and ran (updated) unit tests.
2. Set up a CF peer-to-peer configuration and verified a type 1 TX transaction works from one CF peer to another. Tested that the CF peer can receive the PDUs as telemetry or command packets. 

**Expected behavior changes**
 - No impact to normal behavior, but does enable direct peer to peer PDU transactions CF1(TLM PDU) -> CF2(TLM PDU)

**System(s) tested on**
 - PC Virtual Machine
 - OS: Ubuntu 20.04
 - Versions: cFS main (7/28/2022)

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Cudmore / NASA GSFC / Code 582.0