### PR TITLE
Fix #297, base offsets for CF msgids

### DIFF
--- a/fsw/platform_inc/cf_msgids.h
+++ b/fsw/platform_inc/cf_msgids.h
@@ -25,14 +25,45 @@
 #ifndef CF_MSGIDS_H
 #define CF_MSGIDS_H
 
+#include "cfe_msgids.h"
+#include "cfe_mission_cfg.h"
+
+/*
+ * Define a set of backup msg offsets, in case the user has not added these
+ * to the global mission config header.  This also facilitates the bundle build.
+ * However normally one should set a value for these in cfe_mission_cfg.h.
+ */
+#ifndef CFE_MISSION_CF_CMD_MSG
+#define CFE_MISSION_CF_CMD_MSG 0xB3
+#endif
+
+#ifndef CFE_MISSION_CF_SEND_HK_MSG
+#define CFE_MISSION_CF_SEND_HK_MSG 0xB4
+#endif
+
+#ifndef CFE_MISSION_CF_WAKE_UP_MSG
+#define CFE_MISSION_CF_WAKE_UP_MSG 0xB5
+#endif
+
+#ifndef CFE_MISSION_CF_HK_TLM_MSG
+#define CFE_MISSION_CF_HK_TLM_MSG 0xB0
+#endif
+
+#ifndef CFE_MISSION_CF_CONFIG_TLM_MSG
+#define CFE_MISSION_CF_CONFIG_TLM_MSG 0xB2
+#endif
+
 /**
  * \defgroup cfscfcmdmid CFS CFDP Command Message IDs
  * \{
  */
 
-#define CF_CMD_MID     (0x18B3) /**< \brief Message ID for commands */
-#define CF_SEND_HK_MID (0x18B4) /**< \brief Message ID to request housekeeping telemetry */
-#define CF_WAKE_UP_MID (0x18B5) /**< \brief Message ID for waking up the processing cycle */
+#define CF_CMD_MID CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_CF_CMD_MSG /**< \brief Message ID for commands */
+#define CF_SEND_HK_MID \
+    CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_CF_SEND_HK_MSG /**< \brief Message ID to request housekeeping telemetry */
+#define CF_WAKE_UP_MID                                                                                               \
+    CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_CF_WAKE_UP_MSG /**< \brief Message ID for waking up the processing cycle \
+                                                            */
 
 /**\}*/
 
@@ -41,8 +72,10 @@
  * \{
  */
 
-#define CF_HK_TLM_MID     (0x08B0) /**< \brief Message ID for housekeeping telemetry */
-#define CF_CONFIG_TLM_MID (0x08B2) /**< \brief Message ID for configuration telemetry */
+#define CF_HK_TLM_MID \
+    CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_CF_HK_TLM_MSG /**< \brief Message ID for housekeeping telemetry */
+#define CF_CONFIG_TLM_MID \
+    CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_CF_CONFIG_TLM_MSG /**< \brief Message ID for configuration telemetry */
 
 /**\}*/
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Define the CF msgids as an offset from the CFE_PLATFORM_CMD_MID_BASE or CFE_PLATFORM_TLM_MID_BASE, which helps simplify configuration.

Users should add MSG offsets to the global mission config header.

Fixes #297

**Testing performed**
Build and run CF app

**Expected behavior changes**
MsgIds for CF can be more easily customized by setting MSG offsets in the global cfe_mission_cfg.h header file, the same way other CFE framework module msgids are set.  User does not need to modify this file in place to do so.

**System(s) tested on**
Ubuntu 22.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
