### PR TITLE
Fix #313, removes CF_CONFIG_TLM_MID from cf_msgids.h

### DIFF
--- a/fsw/platform_inc/cf_msgids.h
+++ b/fsw/platform_inc/cf_msgids.h
@@ -41,9 +41,8 @@
  * \{
  */
 
-#define CF_HK_TLM_MID     (0x08B0) /**< \brief Message ID for housekeeping telemetry */
-#define CF_CONFIG_TLM_MID (0x08B2) /**< \brief Message ID for configuration telemetry */
-#define CF_EOT_TLM_MID    (0x08B3) /**< \brief Message ID for end of transaction telemetry */
+#define CF_HK_TLM_MID  (0x08B0) /**< \brief Message ID for housekeeping telemetry */
+#define CF_EOT_TLM_MID (0x08B3) /**< \brief Message ID for end of transaction telemetry */
 
 /**\}*/
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
-Fixes #313

**Testing performed**
Searched all cf child directories for `CF_CONFIG_TLM_MID` and found no uses of the variable. 100% unit test coverage.

**Expected behavior changes**
Remove unused `CF_CONFIG_TLM_MID` from cf_msgids.h.

**System(s) tested on**
 - Ubuntu 18.04

**Additional context**
None

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, ASRC Federal
