### PR TITLE
Fix #30, Correct 2 aberrant instances of CF_Transaction_t argument name

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -139,10 +139,10 @@ void CF_CFDP_ArmAckTimer(CF_Transaction_t *t)
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
-static inline CF_CFDP_Class_t CF_CFDP_GetClass(const CF_Transaction_t *ti)
+static inline CF_CFDP_Class_t CF_CFDP_GetClass(const CF_Transaction_t *t)
 {
-    CF_Assert(ti->flags.com.q_index != CF_QueueIdx_FREE);
-    return !!((ti->state == CF_TxnState_S2) || (ti->state == CF_TxnState_R2));
+    CF_Assert(t->flags.com.q_index != CF_QueueIdx_FREE);
+    return !!((t->state == CF_TxnState_S2) || (t->state == CF_TxnState_R2));
 }
 
 /*----------------------------------------------------------------
@@ -152,12 +152,12 @@ static inline CF_CFDP_Class_t CF_CFDP_GetClass(const CF_Transaction_t *ti)
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
-static inline int CF_CFDP_IsSender(CF_Transaction_t *ti)
+static inline int CF_CFDP_IsSender(CF_Transaction_t *t)
 {
-    CF_Assert(ti->flags.com.q_index != CF_QueueIdx_FREE);
+    CF_Assert(t->flags.com.q_index != CF_QueueIdx_FREE);
     /* the state could actually be CF_TxnState_IDLE, which is still not a sender. This would
      * be an unused transaction in the RX (CF_CFDP_ReceiveMessage) path. */
-    return !!((ti->state == CF_TxnState_S1) || (ti->state == CF_TxnState_S2));
+    return !!((t->state == CF_TxnState_S1) || (t->state == CF_TxnState_S2));
 }
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #30
Amended the only 2 aberrant instances of CF_Transaction_t objects named 'ti', to align them with the other (several hundred) instances named 't'.

**Testing performed**
None, prior to submission of pull request.

**Expected behavior changes**
No impact on behavior.

**System(s) tested on**
n/a

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt