### PR TITLE
Fix #102, Clean up remaining commented-out code

### DIFF
--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -182,11 +182,11 @@ CF_ConfigTable_t dummy_table;
 /* CF_ValidateConfigTable tests specific functions */
 void cf_config_table_tests_set_dummy_table_to_nominal(void)
 {
-    // all values for dummy_table.ticks_per_second nominal except 0
+    /* all values for dummy_table.ticks_per_second nominal except 0 */
     dummy_table.ticks_per_second = Any_uint32_Except(0);
-    // all values (except 0) & 3ff == 0 are nominal (1024 byte aligned)
+    /* all values (except 0) & 3ff == 0 are nominal (1024 byte aligned) */
     dummy_table.rx_crc_calc_bytes_per_wakeup = Any_uint32_Except(0) << 10;
-    // all values less than sizeof(CF_CFDP_PduFileDataContent_t) are nominal
+    /* all values less than sizeof(CF_CFDP_PduFileDataContent_t) are nominal */
     dummy_table.outgoing_file_chunk_size = Any_uint16_LessThan(sizeof(CF_CFDP_PduFileDataContent_t));
 } /* end cf_config_table_tests_set_dummy_table_to_nominal */
 
@@ -254,7 +254,7 @@ void Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArra
     CF_ConfigTable_t *arg_table = &dummy_table;
     int32             result;
 
-    // outgoing_file_chunk_size set to greater than sizeof(CF_CFDP_PduFileDataContent_t)
+    /* outgoing_file_chunk_size set to greater than sizeof(CF_CFDP_PduFileDataContent_t) */
     arg_table->ticks_per_second             = 1;
     arg_table->rx_crc_calc_bytes_per_wakeup = 0x0400; /* 1024 aligned */
     arg_table->outgoing_file_chunk_size     = sizeof(CF_CFDP_PduFileDataContent_t) + 1;
@@ -482,7 +482,6 @@ void Test_CF_Init_CallTo_CFE_EVS_SendEvent_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_Wr
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
     UtAssert_STUB_COUNT(CFE_SB_Subscribe, 3);
-    // UtAssert_STUB_COUNT(CF_TableInit, 1);
     UtAssert_STUB_COUNT(CF_CFDP_InitEngine, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 } /* end Test_CF_Init_CallTo_CFE_EVS_SendEvent_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus */

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -859,7 +859,7 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     int catastrophe_count = 0;
     while (arg_cmd->data.byte[0] == CF_ALL_CHANNELS)
     {
-        if (catastrophe_count == 10) // 10 is arbitrary
+        if (catastrophe_count == 10) /* 10 is arbitrary */
         {
             UtAssert_Message(UTASSERT_CASETYPE_ABORT, __FILE__, __LINE__,
                              "CANNOT make arg_cmd->data.byte[0] != CF_ALL_CHANNELS in 10 tries");
@@ -3603,9 +3603,6 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_IsNot_0_Return_0_Success(void)
     uint32 arg_val      = Any_uint32_Except(0);
     uint8  arg_chan_num = Any_uint8(); /* Any_uint8() used here because it shows value does not matter in this test */
     int    local_result;
-
-    // CF_AppData.config_table = &dummy_config_table;
-    //  memcpy(CF_AppData.config_table->chan[arg_chan_num].sem_name, dummy_sem_name, 20);
 
     /* Act */
     local_result = CF_CmdValidateMaxOutgoing(arg_val, arg_chan_num);

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -1007,7 +1007,7 @@ void Test_CF_WrappedOpen_Call_OS_OpenCreate_WithGivenArgumentsAndReturnItsReturn
     /* Act */
     UtAssert_INT32_EQ(CF_WrappedOpenCreate(arg_fd, arg_fname, arg_flags, arg_access), forced_return_OS_OpenCreate);
 
-    // /* Assert */
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_PerfLogAdd, 2);
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
 } /* end Test_CF_WrappedOpen_Call_OS_OpenCreate_WithGivenArgumentsAndReturnItsReturnValue */
@@ -1060,8 +1060,8 @@ void Test_CF_WrappedClose_Receive_OS_SUCCESS_From_OS_close_NoEventSent(void)
 void Test_CF_WrappedRead_CallsOS_read_WithGivenArgumentsAndReturnItsReturnValue(void)
 {
     /* Arrange */
-    uint32 arg_read_size = Any_uint32_LessThan_or_EqualTo(10); // 10 is arbitrary to make test fast
-    uint8  dummy_buf[10] = {0};                                // 10 to match max read size of 10 (arbitrary)
+    uint32 arg_read_size = Any_uint32_LessThan_or_EqualTo(10); /* 10 is arbitrary to make test fast */
+    uint8  dummy_buf[10] = {0};                                /* 10 to match max read size of 10 (arbitrary) */
     void * arg_buf       = &dummy_buf;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), arg_read_size);

--- a/unit-test/utilities/cf_test_utils.c
+++ b/unit-test/utilities/cf_test_utils.c
@@ -167,9 +167,11 @@ unsigned int Any_unsigned_int(void)
     return random_val;
 }
 
-// AnyBufferOf_uint8_WithSize works, but name/design could use overhaul
-// should it return a pointer? or should it be named different because it alters
-// the buffer given?
+/*
+ * AnyBufferOf_uint8_WithSize works, but name/design could use overhaul
+ * should it return a pointer? or should it be named different because it alters
+ * the buffer given?
+ */
 void AnyBufferOf_uint8_WithSize(uint8 *buffer, size_t size)
 {
     int i;
@@ -260,7 +262,7 @@ uint8 Any_uint8_BetweenExcludeMax(uint8 floor, uint8 ceiling)
 uint8 Any_uint8_BetweenInclusive(uint8 floor, uint8 ceiling)
 {
     uint8 random_val;
-    uint8 diff = ceiling - floor + 1; // +1 for inclusive
+    uint8 diff = ceiling - floor + 1; /* +1 for inclusive */
 
     random_val = (rand() % diff) + floor;
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #102.
Remaining stray 'C++ style' comments (single line // comments) in CF were removed to changed to 'C-style' comments ( /* ).
A few remaining lines of commented out (unused) code were also removed.

**Testing performed**
None (comment changes only - no code was modified).

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 