### PR TITLE
Fix #325, add more concise transaction status code

### DIFF
--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -94,6 +94,20 @@ void CF_CFDP_DecodeStart(CF_DecoderState_t *pdec, const void *msgbuf, CF_Logical
 void CF_CFDP_ResetTransaction(CF_Transaction_t *t, int keep_history);
 
 /************************************************************************/
+/** @brief Helper function to store transaction status code only
+ *
+ * This records the status in the history block but does not set FIN flag
+ * or take any other protocol/state machine actions.
+ *
+ * @par Assumptions, External Events, and Notes:
+ *       t must not be NULL.
+ *
+ * @param t  Pointer to the transaction object
+ * @param cc Status Code value to set within transaction
+ */
+void CF_CFDP_SetTxnStatus(CF_Transaction_t *t, CF_TxnStatus_t txn_stat);
+
+/************************************************************************/
 /** @brief Send an end of transaction packet.
  *
  * @par Assumptions, External Events, and Notes:

--- a/fsw/src/cf_cfdp_dispatch.c
+++ b/fsw/src/cf_cfdp_dispatch.c
@@ -70,7 +70,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
     }
     else
     {
-        if (t->history->cc == CF_CFDP_ConditionCode_NO_ERROR)
+        if (!CF_TxnStatus_IsError(t->history->txn_stat))
         {
             selected_handler = fd_fn;
         }

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -40,15 +40,15 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R2_SetCc
+ * Function: CF_CFDP_R2_SetFinTxnStatus
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CF_CFDP_R2_SetCc(CF_Transaction_t *t, CF_CFDP_ConditionCode_t cc)
+void CF_CFDP_R2_SetFinTxnStatus(CF_Transaction_t *t, CF_TxnStatus_t txn_stat)
 {
-    t->history->cc       = cc;
+    CF_CFDP_SetTxnStatus(t, txn_stat);
     t->flags.rx.send_fin = 1;
 }
 
@@ -76,8 +76,8 @@ void CF_CFDP_R1_Reset(CF_Transaction_t *t)
 void CF_CFDP_R2_Reset(CF_Transaction_t *t)
 {
     if ((t->state_data.r.sub_state == CF_RxSubState_WAIT_FOR_FIN_ACK) ||
-        (t->state_data.r.r2.eof_cc != CF_CFDP_ConditionCode_NO_ERROR) ||
-        (t->history->cc != CF_CFDP_ConditionCode_NO_ERROR) || t->flags.com.canceled)
+        (t->state_data.r.r2.eof_cc != CF_CFDP_ConditionCode_NO_ERROR) || CF_TxnStatus_IsError(t->history->txn_stat) ||
+        t->flags.com.canceled)
     {
         CF_CFDP_R1_Reset(t); /* it's done */
     }
@@ -129,7 +129,7 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *t, int ok_to_send_nak)
     /* checking if r2 is complete. Check nak list, and send NAK if appropriate */
     /* if all data is present, then there will be no gaps in the chunk */
 
-    if (t->history->cc == CF_CFDP_ConditionCode_NO_ERROR)
+    if (!CF_TxnStatus_IsError(t->history->txn_stat))
     {
         /* first, check if md is received. If not, send specialized nak */
         if (!t->flags.rx.md_recv)
@@ -166,9 +166,9 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *t, int ok_to_send_nak)
                                   (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
                 send_fin = 1;
                 ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.nak_limit;
-                t->history->cc = CF_CFDP_ConditionCode_NAK_LIMIT_REACHED; /* don't use CF_CFDP_R2_SetCc because many
-                                                                         places in this function set send_fin */
-                t->state_data.r.r2.acknak_count = 0;                      /* reset for fin/ack */
+                /* don't use CF_CFDP_R2_SetFinTxnStatus because many places in this function set send_fin */
+                CF_CFDP_SetTxnStatus(t, CF_TxnStatus_NAK_LIMIT_REACHED);
+                t->state_data.r.r2.acknak_count = 0; /* reset for fin/ack */
             }
             else
             {
@@ -178,8 +178,11 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *t, int ok_to_send_nak)
 
         if (send_fin)
         {
-            t->flags.rx.send_fin = 1;
             t->flags.rx.complete = 1; /* latch completeness, since send_fin is cleared later */
+
+            /* the transaction is now considered complete, but this will not overwrite an
+             * error status code if there was one set */
+            CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_NO_ERROR);
         }
 
         /* always go to CF_RxSubState_FILEDATA, and let tick change state */
@@ -220,7 +223,7 @@ int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                               "CF R%d(%lu:%lu): failed to seek offset %ld, got %ld", (t->state == CF_TxnState_R2),
                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, (long)fd->offset,
                               (long)fret);
-            t->history->cc = CF_CFDP_ConditionCode_FILE_SIZE_ERROR;
+            CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
             ret = -1; /* connection will reset in caller */
         }
@@ -235,9 +238,9 @@ int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                               "CF R%d(%lu:%lu): OS_write expected %ld, got %ld", (t->state == CF_TxnState_R2),
                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
                               (long)fd->data_len, (long)fret);
+            CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_write;
-            t->history->cc = CF_CFDP_ConditionCode_FILESTORE_REJECTION;
-            ret            = -1; /* connection will reset in caller */
+            ret = -1; /* connection will reset in caller */
         }
         else
         {
@@ -363,6 +366,7 @@ void CF_CFDP_R2_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
             }
             else
             {
+                CF_CFDP_SetTxnStatus(t, CF_TxnStatus_From_ConditionCode(t->state_data.r.r2.eof_cc));
                 CF_CFDP_R2_Reset(t);
             }
         }
@@ -371,7 +375,7 @@ void CF_CFDP_R2_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
             /* bad eof sent? */
             if (ret == CF_RxEofRet_FSIZE_MISMATCH)
             {
-                CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILE_SIZE_ERROR);
+                CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
             }
             else
             {
@@ -621,7 +625,7 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
         t->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
         if (t->state == CF_TxnState_R2)
         {
-            CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILESTORE_REJECTION);
+            CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
         }
         else
         {
@@ -685,7 +689,7 @@ int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
                                   "CF R%d(%lu:%lu): failed to seek offset %lu, got %ld", (t->state == CF_TxnState_R2),
                                   (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
                                   (unsigned long)t->state_data.r.r2.rx_crc_calc_bytes, (long)fret);
-                t->history->cc = CF_CFDP_ConditionCode_FILE_SIZE_ERROR; /* should be ok to use this one */
+                CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
                 ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
                 success = false;
                 break;
@@ -699,7 +703,7 @@ int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
                               "CF R%d(%lu:%lu): failed to read file expected %lu, got %ld",
                               (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                               (unsigned long)t->history->seq_num, (unsigned long)read_size, (long)fret);
-            t->history->cc = CF_CFDP_ConditionCode_FILE_SIZE_ERROR; /* should be ok to use this one */
+            CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_read;
             success = false;
             break;
@@ -725,7 +729,7 @@ int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
         }
         else
         {
-            CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILE_CHECKSUM_FAILURE);
+            CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILE_CHECKSUM_FAILURE);
         }
 
         t->flags.com.crc_calc = 1;
@@ -749,7 +753,7 @@ int CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t)
     CF_SendRet_t sret;
     int          ret = 0;
 
-    if (t->history->cc == CF_CFDP_ConditionCode_NO_ERROR && !t->flags.com.crc_calc)
+    if (!CF_TxnStatus_IsError(t->history->txn_stat) && !t->flags.com.crc_calc)
     {
         /* no error, and haven't checked crc -- so start checking it */
         if (CF_CFDP_R2_CalcCrcChunk(t))
@@ -760,7 +764,8 @@ int CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t)
 
     if (ret != -1)
     {
-        sret = CF_CFDP_SendFin(t, t->state_data.r.r2.dc, t->state_data.r.r2.fs, t->history->cc);
+        sret = CF_CFDP_SendFin(t, t->state_data.r.r2.dc, t->state_data.r.r2.fs,
+                               CF_TxnStatus_To_ConditionCode(t->history->txn_stat));
         CF_Assert(sret != CF_SendRet_ERROR); /* CF_CFDP_SendFin does not return CF_SendRet_ERROR */
         t->state_data.r.sub_state =
             CF_RxSubState_WAIT_FOR_FIN_ACK; /* whether or not fin send successful, ok to transition state */
@@ -838,7 +843,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                                       (unsigned long)t->history->seq_num, (unsigned long)t->fsize,
                                       (unsigned long)t->state_data.r.r2.eof_size);
                     ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_size_mismatch;
-                    CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILE_SIZE_ERROR);
+                    CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
                     success = false;
                 }
             }
@@ -860,7 +865,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                                       (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                                       (unsigned long)t->history->seq_num, (long)status);
                     t->fd = OS_OBJECT_ID_UNDEFINED;
-                    CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILESTORE_REJECTION);
+                    CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
                     ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_rename;
                     success = false;
                 }
@@ -874,7 +879,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                                           "CF R%d(%lu:%lu): failed to open renamed file in R2, error=%ld",
                                           (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                                           (unsigned long)t->history->seq_num, (long)ret);
-                        CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_FILESTORE_REJECTION);
+                        CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
                         ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
                         t->fd   = OS_OBJECT_ID_UNDEFINED; /* just in case */
                         success = false;
@@ -1012,7 +1017,7 @@ void CF_CFDP_R_Tick(CF_Transaction_t *t, int *cont /* unused */)
             {
                 CF_CFDP_R_SendInactivityEvent(t);
 
-                CF_CFDP_R2_SetCc(t, CF_CFDP_ConditionCode_INACTIVITY_DETECTED);
+                CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_INACTIVITY_DETECTED);
                 t->flags.rx.inactivity_fired = 1;
             }
             else
@@ -1074,6 +1079,7 @@ void CF_CFDP_R_Tick(CF_Transaction_t *t, int *cont /* unused */)
                         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_ACK_LIMIT, CFE_EVS_EventType_ERROR,
                                           "CF R2(%lu:%lu): ack limit reached, no fin-ack",
                                           (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
+                        CF_CFDP_SetTxnStatus(t, CF_TxnStatus_ACK_LIMIT_NO_FIN);
                         ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit;
                         CF_CFDP_R2_Reset(t);
                         success = false;

--- a/fsw/src/cf_cfdp_r.h
+++ b/fsw/src/cf_cfdp_r.h
@@ -104,15 +104,15 @@ void CF_CFDP_R_Cancel(CF_Transaction_t *t);
 void CF_CFDP_R_Init(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Helper function to store condition code set send_fin flag.
+/** @brief Helper function to store transaction status code and set send_fin flag.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
  *
  * @param t  Pointer to the transaction object
- * @param cc Condition Code value to set within transaction
+ * @param cc Status Code value to set within transaction
  */
-void CF_CFDP_R2_SetCc(CF_Transaction_t *t, CF_CFDP_ConditionCode_t cc);
+void CF_CFDP_R2_SetFinTxnStatus(CF_Transaction_t *t, CF_TxnStatus_t txn_stat);
 
 /************************************************************************/
 /** @brief CFDP R1 transaction reset function.

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -257,7 +257,7 @@ void CF_CFDP_S_SubstateSendFileData(CF_Transaction_t *t)
     else if (bytes_processed < 0)
     {
         /* IO error -- change state and send EOF */
-        t->history->cc            = CF_CFDP_ConditionCode_FILESTORE_REJECTION;
+        CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
         t->state_data.s.sub_state = CF_TxSubState_EOF;
     }
     else
@@ -340,6 +340,7 @@ void CF_CFDP_S2_SubstateSendFileData(CF_Transaction_t *t)
     }
     else if (ret < 0)
     {
+        CF_CFDP_SetTxnStatus(t, CF_TxnStatus_NAK_RESPONSE_ERROR);
         CF_CFDP_S_Reset(t);
     }
     else
@@ -443,7 +444,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
 
     if (!success)
     {
-        t->history->cc = CF_CFDP_ConditionCode_FILESTORE_REJECTION;
+        CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
         CF_CFDP_S_Reset(t);
     }
 
@@ -465,6 +466,7 @@ void CF_CFDP_S_SubstateSendFinAck(CF_Transaction_t *t)
     if (CF_CFDP_SendAck(t, CF_CFDP_AckTxnStatus_ACTIVE, CF_CFDP_FileDirective_FIN, t->state_data.s.s2.fin_cc,
                         t->history->peer_eid, t->history->seq_num) != CF_SendRet_NO_MSG)
     {
+        CF_CFDP_SetTxnStatus(t, CF_TxnStatus_NO_ERROR);
         CF_CFDP_S_Reset(t);
     }
 }
@@ -483,6 +485,7 @@ void CF_CFDP_S2_EarlyFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_EARLY_FIN, CFE_EVS_EventType_ERROR,
                       "CF S%d(%lu:%lu): got early fin -- cancelling", (t->state == CF_TxnState_S2),
                       (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
+    CF_CFDP_SetTxnStatus(t, CF_TxnStatus_EARLY_FIN);
     CF_CFDP_S_Reset(t);
 }
 
@@ -596,7 +599,7 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     {
         /* don't send fin if error. Don't check the eof CC, just go with
          * the stored one we sent before */
-        if (t->history->cc != CF_CFDP_ConditionCode_NO_ERROR)
+        if (CF_TxnStatus_IsError(t->history->txn_stat))
         {
             CF_CFDP_S_Reset(t);
         }
@@ -749,6 +752,8 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INACT_TIMER, CFE_EVS_EventType_ERROR,
                               "CF S2(%lu:%lu): inactivity timer expired", (unsigned long)t->history->src_eid,
                               (unsigned long)t->history->seq_num);
+            CF_CFDP_SetTxnStatus(t, CF_TxnStatus_INACTIVITY_DETECTED);
+
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.inactivity_timer;
             CF_CFDP_S_Reset(t);
         }
@@ -771,6 +776,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
                             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_ACK_LIMIT, CFE_EVS_EventType_ERROR,
                                               "CF S2(%lu:%lu), ack limit reached, no eof-ack",
                                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
+                            CF_CFDP_SetTxnStatus(t, CF_TxnStatus_ACK_LIMIT_NO_EOF);
                             ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit;
 
                             /* no reason to reset this timer, as it isn't used again */
@@ -786,6 +792,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
                             }
                             else if (sret == CF_SendRet_ERROR)
                             {
+                                CF_CFDP_SetTxnStatus(t, CF_TxnStatus_SEND_EOF_FAILURE);
                                 CF_CFDP_S_Reset(t); /* can't go on, error occurred */
                                 early_exit = true;
                             }

--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -138,19 +138,69 @@ typedef enum
 } CF_Direction_t;
 
 /**
+ * @brief Values for Transaction Status code
+ *
+ * This enum defines the possible values representing the
+ * result of a transaction.  This is a superset of the condition codes
+ * defined in CCSDS book 727 (condition codes) but with additional
+ * values for local conditions that the blue book does not have,
+ * such as protocol/state machine or decoding errors.
+ *
+ * The values here are designed to not overlap with the condition
+ * codes defined in the blue book, but can be translated to one
+ * of those codes for the purposes of FIN/ACK/EOF PDUs.
+ */
+typedef enum
+{
+    /**
+     * The undefined status is a placeholder for new transactions before a value is set.
+     */
+    CF_TxnStatus_UNDEFINED = -1,
+
+    /* Status codes 0-15 share the same values/meanings as the CFDP condition code (CC) */
+    CF_TxnStatus_NO_ERROR                  = CF_CFDP_ConditionCode_NO_ERROR,
+    CF_TxnStatus_POS_ACK_LIMIT_REACHED     = CF_CFDP_ConditionCode_POS_ACK_LIMIT_REACHED,
+    CF_TxnStatus_KEEP_ALIVE_LIMIT_REACHED  = CF_CFDP_ConditionCode_KEEP_ALIVE_LIMIT_REACHED,
+    CF_TxnStatus_INVALID_TRANSMISSION_MODE = CF_CFDP_ConditionCode_INVALID_TRANSMISSION_MODE,
+    CF_TxnStatus_FILESTORE_REJECTION       = CF_CFDP_ConditionCode_FILESTORE_REJECTION,
+    CF_TxnStatus_FILE_CHECKSUM_FAILURE     = CF_CFDP_ConditionCode_FILE_CHECKSUM_FAILURE,
+    CF_TxnStatus_FILE_SIZE_ERROR           = CF_CFDP_ConditionCode_FILE_SIZE_ERROR,
+    CF_TxnStatus_NAK_LIMIT_REACHED         = CF_CFDP_ConditionCode_NAK_LIMIT_REACHED,
+    CF_TxnStatus_INACTIVITY_DETECTED       = CF_CFDP_ConditionCode_INACTIVITY_DETECTED,
+    CF_TxnStatus_INVALID_FILE_STRUCTURE    = CF_CFDP_ConditionCode_INVALID_FILE_STRUCTURE,
+    CF_TxnStatus_CHECK_LIMIT_REACHED       = CF_CFDP_ConditionCode_CHECK_LIMIT_REACHED,
+    CF_TxnStatus_UNSUPPORTED_CHECKSUM_TYPE = CF_CFDP_ConditionCode_UNSUPPORTED_CHECKSUM_TYPE,
+    CF_TxnStatus_SUSPEND_REQUEST_RECEIVED  = CF_CFDP_ConditionCode_SUSPEND_REQUEST_RECEIVED,
+    CF_TxnStatus_CANCEL_REQUEST_RECEIVED   = CF_CFDP_ConditionCode_CANCEL_REQUEST_RECEIVED,
+
+    /* Additional status codes for items not representable in a CFDP CC, these can be set in
+     * transactions that did not make it to the point of sending FIN/EOF. */
+    CF_TxnStatus_PROTOCOL_ERROR     = 16,
+    CF_TxnStatus_ACK_LIMIT_NO_FIN   = 17,
+    CF_TxnStatus_ACK_LIMIT_NO_EOF   = 18,
+    CF_TxnStatus_NAK_RESPONSE_ERROR = 19,
+    CF_TxnStatus_SEND_EOF_FAILURE   = 20,
+    CF_TxnStatus_EARLY_FIN          = 21,
+
+    /* keep last */
+    CF_TxnStatus_MAX = 22
+
+} CF_TxnStatus_t;
+
+/**
  * @brief CF History entry
  *
  * Records CF app operations for future reference
  */
 typedef struct CF_History
 {
-    CF_TxnFilenames_t       fnames;   /**< \brief file names associated with this history entry */
-    CF_CListNode_t          cl_node;  /**< \brief for connection to a CList */
-    CF_Direction_t          dir;      /**< \brief direction of this history entry */
-    CF_CFDP_ConditionCode_t cc;       /**< \brief final condition code of operation */
-    CF_EntityId_t           src_eid;  /**< \brief the source eid of the transaction */
-    CF_EntityId_t           peer_eid; /**< \brief peer_eid is always the "other guy", same src_eid for RX */
-    CF_TransactionSeq_t     seq_num;  /**< \brief transaction identifier, stays constant for entire transfer */
+    CF_TxnFilenames_t   fnames;   /**< \brief file names associated with this history entry */
+    CF_CListNode_t      cl_node;  /**< \brief for connection to a CList */
+    CF_Direction_t      dir;      /**< \brief direction of this history entry */
+    CF_TxnStatus_t      txn_stat; /**< \brief final status of operation */
+    CF_EntityId_t       src_eid;  /**< \brief the source eid of the transaction */
+    CF_EntityId_t       peer_eid; /**< \brief peer_eid is always the "other guy", same src_eid for RX */
+    CF_TransactionSeq_t seq_num;  /**< \brief transaction identifier, stays constant for entire transfer */
 } CF_History_t;
 
 /**

--- a/fsw/src/cf_msg.h
+++ b/fsw/src/cf_msg.h
@@ -135,7 +135,7 @@ typedef struct CF_EotPacket
     uint32                    channel;    /**< \brief Channel number */
     uint32                    direction;  /**< \brief direction of this transaction */
     uint32                    state;      /**< \brief Transaction state */
-    uint32                    cc;         /**< \brief final condition code of operation */
+    uint32                    txn_stat;   /**< \brief final status code of transaction (extended CFDP CC) */
     CF_EntityId_t             src_eid;    /**< \brief the source eid of the transaction */
     CF_EntityId_t             peer_eid;   /**< \brief peer_eid is always the "other guy", same src_eid for RX */
     uint32                    fsize;      /**< \brief File size */

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -473,4 +473,48 @@ int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size);
  */
 int32 CF_WrappedLseek(osal_id_t fd, off_t offset, int mode);
 
+/************************************************************************/
+/** @brief Converts the internal transaction status to a CFDP condition code
+ *
+ * Transaction status is a superset of condition codes, and includes
+ * other error conditions for which CFDP will not send FIN/ACK/EOF
+ * and thus there is no corresponding condition code.
+ *
+ * @par Assumptions, External Events, and Notes:
+ *        Not all transaction status codes directly correlate to a CFDP CC
+ *
+ * @param txn_stat   Transaction status
+ *
+ * @returns CFDP protocol condition code
+ */
+CF_CFDP_ConditionCode_t CF_TxnStatus_To_ConditionCode(CF_TxnStatus_t txn_stat);
+
+/************************************************************************/
+/** @brief Converts a CFDP condition code to an internal transaction status
+ *
+ * @par Assumptions, External Events, and Notes:
+ *       None
+ *
+ * @param txn_stat   Transaction status
+ *
+ * @returns CFDP protocol condition code
+ */
+CF_TxnStatus_t CF_TxnStatus_From_ConditionCode(CF_CFDP_ConditionCode_t cc);
+
+/************************************************************************/
+/** @brief Check if the internal transaction status represents an error
+ *
+ * @par Assumptions, External Events, and Notes:
+ *       Transaction status is a superset of condition codes, and includes
+ *       other error conditions for which CFDP will not send FIN/ACK/EOF
+ *       and thus there is no corresponding condition code.
+ *
+ * @param txn_stat   Transaction status
+ *
+ * @returns Boolean value indicating if the transaction is in an errorred state
+ * @retval true if the an error has occurred during the transaction
+ * @retval false if no error has occurred during the transaction yet
+ */
+bool CF_TxnStatus_IsError(CF_TxnStatus_t txn_stat);
+
 #endif /* !CF_UTILS_H */

--- a/unit-test/cf_cfdp_dispatch_tests.c
+++ b/unit-test/cf_cfdp_dispatch_tests.c
@@ -163,7 +163,7 @@ void Test_CF_CFDP_R_DispatchRecv(void)
     /* file data with error */
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     ph->pdu_header.pdu_type = 1;
-    t->history->cc          = CF_CFDP_ConditionCode_FILESTORE_REJECTION;
+    UT_SetDeferredRetcode(UT_KEY(CF_TxnStatus_IsError), 1, true);
     UtAssert_VOIDCALL(CF_CFDP_R_DispatchRecv(t, ph, &dispatch, NULL));
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.dropped, 1);
 

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -1118,6 +1118,77 @@ void Test_CF_WrappedLseek_Call_OS_lseek_WithGivenArgumentsAndReturnItsReturnValu
 
 /* end CF_WrappedLseek tests */
 
+void Test_CF_TxnStatus_IsError(void)
+{
+    /* Test function for:
+     * bool CF_TxnStatus_IsError(CF_TxnStatus_t txn_stat)
+     */
+    UtAssert_BOOL_FALSE(CF_TxnStatus_IsError(CF_TxnStatus_UNDEFINED));
+    UtAssert_BOOL_FALSE(CF_TxnStatus_IsError(CF_TxnStatus_NO_ERROR));
+    UtAssert_BOOL_TRUE(CF_TxnStatus_IsError(CF_TxnStatus_INACTIVITY_DETECTED));
+    UtAssert_BOOL_TRUE(CF_TxnStatus_IsError(CF_TxnStatus_MAX));
+}
+
+void Test_CF_TxnStatus_To_ConditionCode(void)
+{
+    /* Test function for:
+     * CF_CFDP_ConditionCode_t CF_TxnStatus_To_ConditionCode(CF_TxnStatus_t txn_stat)
+     */
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_UNDEFINED), CF_CFDP_ConditionCode_NO_ERROR);
+
+    /* for the 4-bit condition codes these should be numerically equivalent to status codes */
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_NO_ERROR), CF_CFDP_ConditionCode_NO_ERROR);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_POS_ACK_LIMIT_REACHED),
+                      CF_CFDP_ConditionCode_POS_ACK_LIMIT_REACHED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_KEEP_ALIVE_LIMIT_REACHED),
+                      CF_CFDP_ConditionCode_KEEP_ALIVE_LIMIT_REACHED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_INVALID_TRANSMISSION_MODE),
+                      CF_CFDP_ConditionCode_INVALID_TRANSMISSION_MODE);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_FILESTORE_REJECTION),
+                      CF_CFDP_ConditionCode_FILESTORE_REJECTION);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_FILE_CHECKSUM_FAILURE),
+                      CF_CFDP_ConditionCode_FILE_CHECKSUM_FAILURE);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_FILE_SIZE_ERROR),
+                      CF_CFDP_ConditionCode_FILE_SIZE_ERROR);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_NAK_LIMIT_REACHED),
+                      CF_CFDP_ConditionCode_NAK_LIMIT_REACHED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_INACTIVITY_DETECTED),
+                      CF_CFDP_ConditionCode_INACTIVITY_DETECTED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_INVALID_FILE_STRUCTURE),
+                      CF_CFDP_ConditionCode_INVALID_FILE_STRUCTURE);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_CHECK_LIMIT_REACHED),
+                      CF_CFDP_ConditionCode_CHECK_LIMIT_REACHED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_UNSUPPORTED_CHECKSUM_TYPE),
+                      CF_CFDP_ConditionCode_UNSUPPORTED_CHECKSUM_TYPE);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_SUSPEND_REQUEST_RECEIVED),
+                      CF_CFDP_ConditionCode_SUSPEND_REQUEST_RECEIVED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_CANCEL_REQUEST_RECEIVED),
+                      CF_CFDP_ConditionCode_CANCEL_REQUEST_RECEIVED);
+
+    /* Other extended translations */
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_ACK_LIMIT_NO_FIN),
+                      CF_CFDP_ConditionCode_INACTIVITY_DETECTED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_ACK_LIMIT_NO_EOF),
+                      CF_CFDP_ConditionCode_INACTIVITY_DETECTED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_PROTOCOL_ERROR),
+                      CF_CFDP_ConditionCode_CANCEL_REQUEST_RECEIVED);
+    UtAssert_INT32_EQ(CF_TxnStatus_To_ConditionCode(CF_TxnStatus_MAX), CF_CFDP_ConditionCode_CANCEL_REQUEST_RECEIVED);
+}
+
+void Test_CF_TxnStatus_From_ConditionCode(void)
+{
+    /* Test function for:
+     * CF_TxnStatus_t CF_TxnStatus_From_ConditionCode(CF_CFDP_ConditionCode_t cc)
+     */
+    int32 i;
+
+    /* for the 4-bit condition codes these should be numerically equivalent to status codes */
+    for (i = 0; i <= 15; ++i)
+    {
+        UtAssert_INT32_EQ(CF_TxnStatus_From_ConditionCode(i), i);
+    }
+}
+
 /*******************************************************************************
 **
 **  cf_utils_tests UtTest_Add groups
@@ -1159,6 +1230,12 @@ void add_cf_utils_h_tests(void)
     UtTest_Add(Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size, cf_utils_tests_Setup,
                cf_utils_tests_Teardown, "Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size");
     /* end CF_CList_InsertBack_Ex tests */
+
+    UtTest_Add(Test_CF_TxnStatus_IsError, cf_utils_tests_Setup, cf_utils_tests_Teardown, "CF_TxnStatus_IsError");
+    UtTest_Add(Test_CF_TxnStatus_To_ConditionCode, cf_utils_tests_Setup, cf_utils_tests_Teardown,
+               "CF_TxnStatus_To_ConditionCode");
+    UtTest_Add(Test_CF_TxnStatus_From_ConditionCode, cf_utils_tests_Setup, cf_utils_tests_Teardown,
+               "CF_TxnStatus_From_ConditionCode");
 }
 
 void add_CF_Traverse_WriteHistoryToFile_tests(void)

--- a/unit-test/stubs/cf_cfdp_r_stubs.c
+++ b/unit-test/stubs/cf_cfdp_r_stubs.c
@@ -173,15 +173,15 @@ void CF_CFDP_R2_Reset(CF_Transaction_t *t)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CFDP_R2_SetCc()
+ * Generated stub function for CF_CFDP_R2_SetFinTxnStatus()
  * ----------------------------------------------------
  */
-void CF_CFDP_R2_SetCc(CF_Transaction_t *t, CF_CFDP_ConditionCode_t cc)
+void CF_CFDP_R2_SetFinTxnStatus(CF_Transaction_t *t, CF_TxnStatus_t txn_stat)
 {
-    UT_GenStub_AddParam(CF_CFDP_R2_SetCc, CF_Transaction_t *, t);
-    UT_GenStub_AddParam(CF_CFDP_R2_SetCc, CF_CFDP_ConditionCode_t, cc);
+    UT_GenStub_AddParam(CF_CFDP_R2_SetFinTxnStatus, CF_Transaction_t *, t);
+    UT_GenStub_AddParam(CF_CFDP_R2_SetFinTxnStatus, CF_TxnStatus_t, txn_stat);
 
-    UT_GenStub_Execute(CF_CFDP_R2_SetCc, Basic, NULL);
+    UT_GenStub_Execute(CF_CFDP_R2_SetFinTxnStatus, Basic, NULL);
 }
 
 /*

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -519,6 +519,18 @@ CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_SendEotPkt()
+ * ----------------------------------------------------
+ */
+void CF_CFDP_SendEotPkt(CF_Transaction_t *t)
+{
+    UT_GenStub_AddParam(CF_CFDP_SendEotPkt, CF_Transaction_t *, t);
+
+    UT_GenStub_Execute(CF_CFDP_SendEotPkt, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_CFDP_SendFd()
  * ----------------------------------------------------
  */
@@ -585,6 +597,19 @@ CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     UT_GenStub_Execute(CF_CFDP_SendNak, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_CFDP_SendNak, CF_SendRet_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_SetTxnStatus()
+ * ----------------------------------------------------
+ */
+void CF_CFDP_SetTxnStatus(CF_Transaction_t *t, CF_TxnStatus_t txn_stat)
+{
+    UT_GenStub_AddParam(CF_CFDP_SetTxnStatus, CF_Transaction_t *, t);
+    UT_GenStub_AddParam(CF_CFDP_SetTxnStatus, CF_TxnStatus_t, txn_stat);
+
+    UT_GenStub_Execute(CF_CFDP_SetTxnStatus, Basic, NULL);
 }
 
 /*

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -251,18 +251,6 @@ void CF_CmdResume(CFE_SB_Buffer_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CmdSendCfgParams()
- * ----------------------------------------------------
- */
-void CF_CmdSendCfgParams(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdSendCfgParams, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdSendCfgParams, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_CmdSetParam()
  * ----------------------------------------------------
  */

--- a/unit-test/stubs/cf_codec_stubs.c
+++ b/unit-test/stubs/cf_codec_stubs.c
@@ -95,10 +95,10 @@ void CF_CFDP_DecodeAllTlv(CF_DecoderState_t *state, CF_Logical_TlvList_t *pltlv,
  * Generated stub function for CF_CFDP_DecodeCrc()
  * ----------------------------------------------------
  */
-void CF_CFDP_DecodeCrc(CF_DecoderState_t *state, uint32 *pcrc)
+void CF_CFDP_DecodeCrc(CF_DecoderState_t *state, uint32 *plcrc)
 {
     UT_GenStub_AddParam(CF_CFDP_DecodeCrc, CF_DecoderState_t *, state);
-    UT_GenStub_AddParam(CF_CFDP_DecodeCrc, uint32 *, pcrc);
+    UT_GenStub_AddParam(CF_CFDP_DecodeCrc, uint32 *, plcrc);
 
     UT_GenStub_Execute(CF_CFDP_DecodeCrc, Basic, NULL);
 }
@@ -164,6 +164,7 @@ void CF_CFDP_DecodeFin(CF_DecoderState_t *state, CF_Logical_PduFin_t *plfin)
 int32 CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh)
 {
     UT_GenStub_SetupReturnBuffer(CF_CFDP_DecodeHeader, int32);
+
     UT_GenStub_AddParam(CF_CFDP_DecodeHeader, CF_DecoderState_t *, state);
     UT_GenStub_AddParam(CF_CFDP_DecodeHeader, CF_Logical_PduHeader_t *, plh);
 

--- a/unit-test/stubs/cf_utils_handlers.c
+++ b/unit-test/stubs/cf_utils_handlers.c
@@ -214,3 +214,19 @@ void UT_DefaultHandler_CF_WrappedOpenCreate(void *UserObj, UT_EntryKey_t FuncKey
         UT_Stub_SetReturnValue(FuncKey, ctxt->forced_return);
     }
 }
+
+/*----------------------------------------------------------------
+ *
+ * Function: UT_DefaultHandler_CF_TxnStatus_IsError
+ *
+ * Translate the return value to a "bool"
+ *
+ *-----------------------------------------------------------------*/
+void UT_DefaultHandler_CF_TxnStatus_IsError(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    bool result;
+
+    result = (bool)Context->Int32StatusCode;
+
+    UT_Stub_SetReturnValue(FuncKey, result);
+}

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -31,6 +31,7 @@ void UT_DefaultHandler_CF_FindUnusedTransaction(void *, UT_EntryKey_t, const UT_
 void UT_DefaultHandler_CF_ResetHistory(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_TraverseAllTransactions(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CF_TxnStatus_IsError(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WrappedOpenCreate(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WriteHistoryQueueDataToFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
@@ -227,6 +228,54 @@ int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
     UT_GenStub_Execute(CF_Traverse_WriteTxnQueueEntryToFile, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_Traverse_WriteTxnQueueEntryToFile, int);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_TxnStatus_From_ConditionCode()
+ * ----------------------------------------------------
+ */
+CF_TxnStatus_t CF_TxnStatus_From_ConditionCode(CF_CFDP_ConditionCode_t cc)
+{
+    UT_GenStub_SetupReturnBuffer(CF_TxnStatus_From_ConditionCode, CF_TxnStatus_t);
+
+    UT_GenStub_AddParam(CF_TxnStatus_From_ConditionCode, CF_CFDP_ConditionCode_t, cc);
+
+    UT_GenStub_Execute(CF_TxnStatus_From_ConditionCode, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_TxnStatus_From_ConditionCode, CF_TxnStatus_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_TxnStatus_IsError()
+ * ----------------------------------------------------
+ */
+bool CF_TxnStatus_IsError(CF_TxnStatus_t txn_stat)
+{
+    UT_GenStub_SetupReturnBuffer(CF_TxnStatus_IsError, bool);
+
+    UT_GenStub_AddParam(CF_TxnStatus_IsError, CF_TxnStatus_t, txn_stat);
+
+    UT_GenStub_Execute(CF_TxnStatus_IsError, Basic, UT_DefaultHandler_CF_TxnStatus_IsError);
+
+    return UT_GenStub_GetReturnValue(CF_TxnStatus_IsError, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_TxnStatus_To_ConditionCode()
+ * ----------------------------------------------------
+ */
+CF_CFDP_ConditionCode_t CF_TxnStatus_To_ConditionCode(CF_TxnStatus_t txn_stat)
+{
+    UT_GenStub_SetupReturnBuffer(CF_TxnStatus_To_ConditionCode, CF_CFDP_ConditionCode_t);
+
+    UT_GenStub_AddParam(CF_TxnStatus_To_ConditionCode, CF_TxnStatus_t, txn_stat);
+
+    UT_GenStub_Execute(CF_TxnStatus_To_ConditionCode, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_TxnStatus_To_ConditionCode, CF_CFDP_ConditionCode_t);
 }
 
 /*

--- a/unit-test/utilities/cf_test_alt_handler.c
+++ b/unit-test/utilities/cf_test_alt_handler.c
@@ -169,3 +169,19 @@ void UT_AltHandler_GenericPointerReturn(void *UserObj, UT_EntryKey_t FuncKey, co
 {
     UT_Stub_SetReturnValue(FuncKey, UserObj);
 }
+
+/*----------------------------------------------------------------
+ *
+ * Function: UT_AltHandler_CaptureTransactionStatus
+ *
+ * A handler for CF_CFDP_SetTxnStatus() and similar that captures the CF_TxnStatus_t
+ * value to the supplied storage location.
+ *
+ *-----------------------------------------------------------------*/
+void UT_AltHandler_CaptureTransactionStatus(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    CF_TxnStatus_t *p_txn_stat = UserObj;
+    CF_TxnStatus_t  in_stat    = UT_Hook_GetArgValueByName(Context, "txn_stat", CF_TxnStatus_t);
+
+    *p_txn_stat = in_stat;
+}

--- a/unit-test/utilities/cf_test_alt_handler.h
+++ b/unit-test/utilities/cf_test_alt_handler.h
@@ -39,4 +39,6 @@ void UT_AltHandler_CF_TraverseAllTransactions_All_Channels_Set_Context(void *Use
 
 void UT_AltHandler_GenericPointerReturn(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context);
 
+void UT_AltHandler_CaptureTransactionStatus(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context);
+
 #endif /* CF_TEST_ALT_HANDLER_H */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a new concept of "transaction status" to replace use of CFDP condition code to indicate the result of a transaction.  To aid in transition this is equivalent in numeric value to the defined CFDP CC values but is extended with additional values for other conditions that can occur in the implementation but do not necessarily result in sending a FIN/EOF PDU.

This also adds setting of Transaction Status for some off-nominal cases where no CFDP CC was set.

Fixes #325 

**Testing performed**
Build and run all tests, confirm 100% coverage in unit tests for all new/modified functions
Run two instances of CFS running CF and perform file transfer between them, both nominal/successful and also intentionally create an error (filesystem rejection).  Confirm that the generated "EOT" telemetry message contains the expected code in both cases.

**Expected behavior changes**
For successful file transfers both sender and receiver send "0" (`NO_ERROR`) in the new `txn_stat` field of the EOT TLM message.  For non success both send an appropriate error code in the field.

**System(s) tested on**
Ubuntu 22.04 64-bit

**Additional context**
The `txn_stat` value overlaps with the previous CFDP condition code value, but it is extended with additional values.  Where overlapping, numeric values for CFDP CCs are kept the same, and the value is the same integer width at the same place, such that the EOT message format is not changed and software interpreting the message should not break.  

However, the software interpreting the EOT TLM will need to accept the wider range of possible code values.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
