### PR TITLE
Fix #330, Clean up redundant comments and empty lines

### DIFF
--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -40,8 +40,6 @@ CF_AppData_t CF_AppData;
 
 /*----------------------------------------------------------------
  *
- * Function: CF_HkCmd
- *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
  *
@@ -53,8 +51,6 @@ void CF_HkCmd(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CheckTables
  *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
@@ -109,8 +105,6 @@ void CF_CheckTables(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_ValidateConfigTable
- *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
  *
@@ -149,8 +143,6 @@ int32 CF_ValidateConfigTable(void *tbl_ptr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_TableInit
  *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
@@ -206,8 +198,6 @@ int32 CF_TableInit(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Init
  *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
@@ -278,8 +268,6 @@ int32 CF_Init(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_WakeUp
- *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
  *
@@ -292,8 +280,6 @@ void CF_WakeUp(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_ProcessMsg
  *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
@@ -329,8 +315,6 @@ void CF_ProcessMsg(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_AppMain
  *
  * Entry point function
  * See description in cf_app.h for argument/return detail

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -48,8 +48,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeStart
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -83,8 +81,6 @@ void CF_CFDP_EncodeStart(CF_EncoderState_t *penc, void *msgbuf, CF_Logical_PduBu
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeStart
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -120,8 +116,6 @@ void CF_CFDP_DecodeStart(CF_DecoderState_t *pdec, const void *msgbuf, CF_Logical
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_ArmAckTimer
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -134,8 +128,6 @@ void CF_CFDP_ArmAckTimer(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_GetClass
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -146,8 +138,6 @@ static inline CF_CFDP_Class_t CF_CFDP_GetClass(const CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_IsSender
  *
  * Internal helper routine only, not part of API.
  *
@@ -162,8 +152,6 @@ static inline int CF_CFDP_IsSender(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_ArmInactTimer
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -173,8 +161,6 @@ static inline void CF_CFDP_ArmInactTimer(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DispatchRecv
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -195,8 +181,6 @@ void CF_CFDP_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DispatchTx
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -209,8 +193,6 @@ static void CF_CFDP_DispatchTx(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_FindUnusedChunks
  *
  * Internal helper routine only, not part of API.
  *
@@ -227,8 +209,6 @@ static CF_ChunkWrapper_t *CF_CFDP_FindUnusedChunks(CF_Channel_t *c, CF_Direction
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_SetPduLength
  *
  * Internal helper routine only, not part of API.
  *
@@ -250,8 +230,6 @@ static void CF_CFDP_SetPduLength(CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_ConstructPduHeader
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -323,8 +301,6 @@ CF_Logical_PduBuffer_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *t, CF
 
 /*----------------------------------------------------------------
  *
- * Function: CF_strnlen
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -340,8 +316,6 @@ static inline size_t CF_strnlen(const char *s, size_t maxlen)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_SendMd
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -363,7 +337,6 @@ CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t)
     }
     else
     {
-
         md = &ph->int_header.md;
 
         CF_Assert((t->state == CF_TxnState_S1) || (t->state == CF_TxnState_S2));
@@ -388,8 +361,6 @@ CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_SendFd
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -409,8 +380,6 @@ CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_AppendTlv
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -448,8 +417,6 @@ void CF_CFDP_AppendTlv(CF_Logical_TlvList_t *ptlv_list, CF_CFDP_TlvType_t tlv_ty
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_SendEof
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -489,8 +456,6 @@ CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_SendAck
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -543,8 +508,6 @@ CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_SendFin
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -585,8 +548,6 @@ CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, 
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_SendNak
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -602,7 +563,6 @@ CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-
         CF_Assert(CF_CFDP_GetClass(t) == CF_CFDP_CLASS_2);
 
         nak = &ph->int_header.nak;
@@ -621,8 +581,6 @@ CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_RecvPh
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -684,8 +642,6 @@ int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_RecvMd
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -708,7 +664,6 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-
         /* store the expected file size in transaction */
         t->fsize = md->size;
 
@@ -758,8 +713,6 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_RecvFd
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -804,8 +757,6 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_RecvEof
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -827,8 +778,6 @@ int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_RecvAck
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -852,8 +801,6 @@ int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_RecvFin
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -879,8 +826,6 @@ int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_RecvNak
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -903,8 +848,6 @@ int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_RecvDrop
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -915,8 +858,6 @@ void CF_CFDP_RecvDrop(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_RecvIdle
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -1001,8 +942,6 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_InitEngine
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -1095,8 +1034,6 @@ int32 CF_CFDP_InitEngine(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_CycleTxFirstActive
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1132,8 +1069,6 @@ int CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_CycleTx
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -1178,8 +1113,6 @@ void CF_CFDP_CycleTx(CF_Channel_t *c)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DoTick
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1212,8 +1145,6 @@ int CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_TickTransactions
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -1278,8 +1209,6 @@ void CF_CFDP_TickTransactions(CF_Channel_t *c)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_InitTxnTxFile
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1293,8 +1222,6 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_TxFile_Initiate
  *
  * Internal helper routine only, not part of API.
  *
@@ -1328,8 +1255,6 @@ static void CF_CFDP_TxFile_Initiate(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_cl
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_TxFile
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1351,7 +1276,6 @@ int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP
     }
     else
     {
-
         t = CF_FindUnusedTransaction(&CF_AppData.engine.channels[chan]);
         CF_Assert(t); /* should always have a free transaction at this point */
 
@@ -1372,8 +1296,6 @@ int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_PlaybackDir_Initiate
  *
  * Internal helper routine only, not part of API.
  *
@@ -1414,8 +1336,6 @@ static int32 CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *p, const char *src_file
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_PlaybackDir
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1445,8 +1365,6 @@ int32 CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_ProcessPlaybackDirectory
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -1514,8 +1432,6 @@ void CF_CFDP_ProcessPlaybackDirectory(CF_Channel_t *c, CF_Playback_t *p)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_UpdatePollPbCounted
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -1540,8 +1456,6 @@ static void CF_CFDP_UpdatePollPbCounted(CF_Playback_t *pb, int up, uint8 *counte
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_ProcessPlaybackDirectories
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -1559,8 +1473,6 @@ static void CF_CFDP_ProcessPlaybackDirectories(CF_Channel_t *c)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_ProcessPollingDirectories
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -1624,8 +1536,6 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_CycleEngine
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1664,8 +1574,6 @@ void CF_CFDP_CycleEngine(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_ResetTransaction
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
@@ -1735,8 +1643,6 @@ void CF_CFDP_ResetTransaction(CF_Transaction_t *t, int keep_history)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_SendEotPkt
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1775,8 +1681,6 @@ void CF_CFDP_SendEotPkt(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_CopyStringFromLV
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1797,8 +1701,6 @@ int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t 
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_CancelTransaction
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1816,8 +1718,6 @@ void CF_CFDP_CancelTransaction(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_CloseFiles
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -1833,8 +1733,6 @@ int CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DisableEngine
  *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail

--- a/fsw/src/cf_cfdp_dispatch.c
+++ b/fsw/src/cf_cfdp_dispatch.c
@@ -33,8 +33,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R_DispatchRecv
- *
  * Application-scope internal function
  * See description in cf_cfdp_dispatch.h for argument/return detail
  *
@@ -92,8 +90,6 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S_DispatchRecv
- *
  * Application-scope internal function
  * See description in cf_cfdp_dispatch.h for argument/return detail
  *
@@ -150,8 +146,6 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S_DispatchTransmit
- *
  * Application-scope internal function
  * See description in cf_cfdp_dispatch.h for argument/return detail
  *
@@ -168,8 +162,6 @@ void CF_CFDP_S_DispatchTransmit(CF_Transaction_t *t, const CF_CFDP_S_SubstateSen
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_TxStateDispatch
  *
  * Application-scope internal function
  * See description in cf_cfdp_dispatch.h for argument/return detail
@@ -188,8 +180,6 @@ void CF_CFDP_TxStateDispatch(CF_Transaction_t *t, const CF_CFDP_TxnSendDispatchT
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_RxStateDispatch
  *
  * Application-scope internal function
  * See description in cf_cfdp_dispatch.h for argument/return detail

--- a/fsw/src/cf_cfdp_pdu.h
+++ b/fsw/src/cf_cfdp_pdu.h
@@ -142,7 +142,6 @@ typedef struct CF_CFDP_PduHeader
     CF_CFDP_uint8_t  eid_tsn_lengths; /**< \brief Lengths of the EID+TSN data (bitfields) */
 
     /* variable-length data goes here - it is at least 3 additional bytes */
-
 } CF_CFDP_PduHeader_t;
 
 /**
@@ -316,7 +315,6 @@ typedef struct CF_CFDP_PduEof
     CF_CFDP_uint8_t  cc;
     CF_CFDP_uint32_t crc;
     CF_CFDP_uint32_t size;
-
 } CF_CFDP_PduEof_t;
 
 /**
@@ -327,7 +325,6 @@ typedef struct CF_CFDP_PduEof
 typedef struct CF_CFDP_PduFin
 {
     CF_CFDP_uint8_t flags;
-
 } CF_CFDP_PduFin_t;
 
 /**
@@ -361,7 +358,6 @@ typedef struct CF_CFDP_PduNak
 {
     CF_CFDP_uint32_t scope_start;
     CF_CFDP_uint32_t scope_end;
-
 } CF_CFDP_PduNak_t;
 
 /**
@@ -373,7 +369,6 @@ typedef struct CF_CFDP_PduMd
 {
     CF_CFDP_uint8_t  segmentation_control;
     CF_CFDP_uint32_t size;
-
 } CF_CFDP_PduMd_t;
 
 /**

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -40,8 +40,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R2_SetCc
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -54,8 +52,6 @@ void CF_CFDP_R2_SetCc(CF_Transaction_t *t, CF_CFDP_ConditionCode_t cc)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R1_Reset
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -66,8 +62,6 @@ void CF_CFDP_R1_Reset(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R2_Reset
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -89,8 +83,6 @@ void CF_CFDP_R2_Reset(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R_CheckCrc
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -115,8 +107,6 @@ int CF_CFDP_R_CheckCrc(CF_Transaction_t *t, uint32 expected_crc)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R2_Complete
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -189,8 +179,6 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *t, int ok_to_send_nak)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R_ProcessFd
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -251,8 +239,6 @@ int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R_SubstateRecvEof
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -292,8 +278,6 @@ int CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R1_SubstateRecvEof
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -325,8 +309,6 @@ void CF_CFDP_R1_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R2_SubstateRecvEof
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -384,8 +366,6 @@ void CF_CFDP_R2_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R1_SubstateRecvFileData
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -414,8 +394,6 @@ void CF_CFDP_R1_SubstateRecvFileData(CF_Transaction_t *t, CF_Logical_PduBuffer_t
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R2_SubstateRecvFileData
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -462,8 +440,6 @@ void CF_CFDP_R2_SubstateRecvFileData(CF_Transaction_t *t, CF_Logical_PduBuffer_t
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R2_GapCompute
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -495,8 +471,6 @@ void CF_CFDP_R2_GapCompute(const CF_ChunkList_t *chunks, const CF_Chunk_t *c, vo
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R_SubstateSendNak
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -580,8 +554,6 @@ int CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R_Init
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -635,8 +607,6 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R2_CalcCrcChunk
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -738,8 +708,6 @@ int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R2_SubstateSendFin
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -776,8 +744,6 @@ int CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R2_Recv_fin_ack
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -799,8 +765,6 @@ void CF_CFDP_R2_Recv_fin_ack(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R2_RecvMd
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -903,8 +867,6 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R1_Recv
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -922,8 +884,6 @@ void CF_CFDP_R1_Recv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R2_Recv
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
@@ -951,8 +911,6 @@ void CF_CFDP_R2_Recv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R_Cancel
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -972,8 +930,6 @@ void CF_CFDP_R_Cancel(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_R_SendInactivityEvent
- *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail
  *
@@ -987,8 +943,6 @@ void CF_CFDP_R_SendInactivityEvent(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_R_Tick
  *
  * Application-scope internal function
  * See description in cf_cfdp_r.h for argument/return detail

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -42,8 +42,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S_Reset
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -54,8 +52,6 @@ static inline void CF_CFDP_S_Reset(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S_SendEof
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -72,8 +68,6 @@ CF_SendRet_t CF_CFDP_S_SendEof(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S1_SubstateSendEof
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -92,8 +86,6 @@ void CF_CFDP_S1_SubstateSendEof(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S2_SubstateSendEof
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -111,8 +103,6 @@ void CF_CFDP_S2_SubstateSendEof(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S_SendFileData
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -235,8 +225,6 @@ int32 CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S_SubstateSendFileData
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -267,8 +255,6 @@ void CF_CFDP_S_SubstateSendFileData(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S_CheckAndRespondNak
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -324,8 +310,6 @@ int CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S2_SubstateSendFileData
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -349,8 +333,6 @@ void CF_CFDP_S2_SubstateSendFileData(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S_SubstateSendMetadata
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -453,8 +435,6 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S_SubstateSendFinAck
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -471,8 +451,6 @@ void CF_CFDP_S_SubstateSendFinAck(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S2_EarlyFin
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -488,8 +466,6 @@ void CF_CFDP_S2_EarlyFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S2_Fin
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -501,8 +477,6 @@ void CF_CFDP_S2_Fin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S2_Nak
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -570,8 +544,6 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S2_Nak_Arm
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -583,8 +555,6 @@ void CF_CFDP_S2_Nak_Arm(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S2_WaitForEofAck
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -617,8 +587,6 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S1_Recv
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -631,8 +599,6 @@ void CF_CFDP_S1_Recv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S2_Recv
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -670,8 +636,6 @@ void CF_CFDP_S2_Recv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S1_Tx
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -689,8 +653,6 @@ void CF_CFDP_S1_Tx(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S2_Tx
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -710,8 +672,6 @@ void CF_CFDP_S2_Tx(CF_Transaction_t *t)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_S_Cancel
- *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
  *
@@ -726,8 +686,6 @@ void CF_CFDP_S_Cancel(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S_Tick
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail
@@ -812,8 +770,6 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_S_Tick_Nak
  *
  * Application-scope internal function
  * See description in cf_cfdp_s.h for argument/return detail

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -54,8 +54,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_MsgOutGet
- *
  * Application-scope internal function
  * See description in cf_cfdp_sbintf.h for argument/return detail
  *
@@ -140,8 +138,6 @@ CF_Logical_PduBuffer_t *CF_CFDP_MsgOutGet(const CF_Transaction_t *t, bool silent
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_Send
- *
  * Application-scope internal function
  * See description in cf_cfdp_sbintf.h for argument/return detail
  *
@@ -168,8 +164,6 @@ void CF_CFDP_Send(uint8 chan_num, const CF_Logical_PduBuffer_t *ph)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_ReceiveMessage
  *
  * Application-scope internal function
  * See description in cf_cfdp_sbintf.h for argument/return detail

--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -339,7 +339,6 @@ typedef struct CF_Transaction
      * Please ignore the duplicate declarations of the "all" flags.
      */
     CF_StateFlags_t flags;
-
 } CF_Transaction_t;
 
 /**

--- a/fsw/src/cf_chunk.c
+++ b/fsw/src/cf_chunk.c
@@ -38,8 +38,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Chunks_EraseRange
- *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
  *
@@ -58,8 +56,6 @@ void CF_Chunks_EraseRange(CF_ChunkList_t *chunks, CF_ChunkIdx_t start, CF_ChunkI
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Chunks_EraseChunk
- *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
  *
@@ -76,8 +72,6 @@ void CF_Chunks_EraseChunk(CF_ChunkList_t *chunks, CF_ChunkIdx_t erase_index)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Chunks_InsertChunk
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
@@ -99,8 +93,6 @@ void CF_Chunks_InsertChunk(CF_ChunkList_t *chunks, CF_ChunkIdx_t index_before, c
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Chunks_FindInsertPosition
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
@@ -133,8 +125,6 @@ CF_ChunkIdx_t CF_Chunks_FindInsertPosition(CF_ChunkList_t *chunks, const CF_Chun
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Chunks_CombinePrevious
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
@@ -173,8 +163,6 @@ int CF_Chunks_CombinePrevious(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Chunks_CombineNext
- *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
  *
@@ -201,7 +189,6 @@ int CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chun
     /* If index advanced the range of chunks can be combined */
     if (i != combined_i)
     {
-
         /* End is the max of last combined chunk end or new chunk end */
         chunk_end =
             CF_Chunk_MAX(chunks->chunks[combined_i - 1].offset + chunks->chunks[combined_i - 1].size, chunk_end);
@@ -219,8 +206,6 @@ int CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chun
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Chunks_FindSmallestSize
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
@@ -243,8 +228,6 @@ CF_ChunkIdx_t CF_Chunks_FindSmallestSize(const CF_ChunkList_t *chunks)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Chunks_Insert
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
@@ -286,8 +269,6 @@ void CF_Chunks_Insert(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t 
 
 /*----------------------------------------------------------------
  *
- * Function: CF_ChunkListAdd
- *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
  *
@@ -306,8 +287,6 @@ void CF_ChunkListAdd(CF_ChunkList_t *chunks, CF_ChunkOffset_t offset, CF_ChunkSi
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_ChunkList_RemoveFromFirst
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
@@ -335,8 +314,6 @@ void CF_ChunkList_RemoveFromFirst(CF_ChunkList_t *chunks, CF_ChunkSize_t size)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_ChunkList_GetFirstChunk
- *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
  *
@@ -347,8 +324,6 @@ const CF_Chunk_t *CF_ChunkList_GetFirstChunk(const CF_ChunkList_t *chunks)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_ChunkListInit
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
@@ -364,8 +339,6 @@ void CF_ChunkListInit(CF_ChunkList_t *chunks, CF_ChunkIdx_t max_chunks, CF_Chunk
 
 /*----------------------------------------------------------------
  *
- * Function: CF_ChunkListReset
- *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail
  *
@@ -377,8 +350,6 @@ void CF_ChunkListReset(CF_ChunkList_t *chunks)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_ChunkList_ComputeGaps
  *
  * Application-scope internal function
  * See description in cf_chunk.h for argument/return detail

--- a/fsw/src/cf_clist.c
+++ b/fsw/src/cf_clist.c
@@ -34,8 +34,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CList_InitNode
- *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail
  *
@@ -47,8 +45,6 @@ void CF_CList_InitNode(CF_CListNode_t *node)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CList_InsertFront
  *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail
@@ -76,8 +72,6 @@ void CF_CList_InsertFront(CF_CListNode_t **head, CF_CListNode_t *node)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CList_InsertBack
  *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail
@@ -107,8 +101,6 @@ void CF_CList_InsertBack(CF_CListNode_t **head, CF_CListNode_t *node)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CList_Pop
- *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail
  *
@@ -129,8 +121,6 @@ CF_CListNode_t *CF_CList_Pop(CF_CListNode_t **head)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CList_Remove
  *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail
@@ -167,8 +157,6 @@ void CF_CList_Remove(CF_CListNode_t **head, CF_CListNode_t *node)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CList_InsertAfter
- *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail
  *
@@ -189,8 +177,6 @@ void CF_CList_InsertAfter(CF_CListNode_t **head, CF_CListNode_t *start, CF_CList
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CList_Traverse
  *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail
@@ -230,8 +216,6 @@ void CF_CList_Traverse(CF_CListNode_t *start, CF_CListFn_t fn, void *context)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CList_Traverse_R
  *
  * Application-scope internal function
  * See description in cf_clist.h for argument/return detail

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -40,8 +40,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdNoop
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -54,8 +52,6 @@ void CF_CmdNoop(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdReset
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -125,8 +121,6 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdTxFile
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -169,8 +163,6 @@ void CF_CmdTxFile(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdPlaybackDir
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -216,8 +208,6 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_DoChanAction
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -253,8 +243,6 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_
 
 /*----------------------------------------------------------------
  *
- * Function: CF_DoFreezeThaw
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -267,8 +255,6 @@ int CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdFreeze
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -292,8 +278,6 @@ void CF_CmdFreeze(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdThaw
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -315,8 +299,6 @@ void CF_CmdThaw(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_FindTransactionBySequenceNumberAllChannels
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -345,8 +327,6 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSe
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_TsnChanAction
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -394,8 +374,6 @@ int CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAct
 
 /*----------------------------------------------------------------
  *
- * Function: CF_DoSuspRes_Txn
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -414,8 +392,6 @@ void CF_DoSuspRes_Txn(CF_Transaction_t *t, CF_ChanAction_SuspResArg_t *context)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_DoSuspRes
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -458,8 +434,6 @@ void CF_DoSuspRes(CF_TransactionCmd_t *cmd, uint8 action)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdSuspend
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -470,8 +444,6 @@ void CF_CmdSuspend(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdResume
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -484,8 +456,6 @@ void CF_CmdResume(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdCancel_Txn
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -496,8 +466,6 @@ void CF_CmdCancel_Txn(CF_Transaction_t *t, void *ignored)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdCancel
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -521,8 +489,6 @@ void CF_CmdCancel(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdAbandon_Txn
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -533,8 +499,6 @@ void CF_CmdAbandon_Txn(CF_Transaction_t *t, void *ignored)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdAbandon
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -558,8 +522,6 @@ void CF_CmdAbandon(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_DoEnableDisableDequeue
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -572,8 +534,6 @@ int CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *con
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdEnableDequeue
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -598,8 +558,6 @@ void CF_CmdEnableDequeue(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdDisableDequeue
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -622,8 +580,6 @@ void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_DoEnableDisablePolldir
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -657,8 +613,6 @@ int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdEnablePolldir
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -683,8 +637,6 @@ void CF_CmdEnablePolldir(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdDisablePolldir
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -711,8 +663,6 @@ void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_PurgeHistory
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -726,8 +676,6 @@ int CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_PurgeTransaction
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -740,8 +688,6 @@ int CF_PurgeTransaction(CF_CListNode_t *n, void *ignored)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_DoPurgeQueue
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -793,8 +739,6 @@ int CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdPurgeQueue
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -815,8 +759,6 @@ void CF_CmdPurgeQueue(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdWriteQueue
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -951,8 +893,6 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdValidateChunkSize
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -968,8 +908,6 @@ int CF_CmdValidateChunkSize(uint32 val, uint8 chan_num /* ignored */)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdValidateMaxOutgoing
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -989,8 +927,6 @@ int CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdGetSetParam
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -1148,8 +1084,6 @@ void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdSetParam
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -1162,8 +1096,6 @@ void CF_CmdSetParam(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdGetParam
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -1175,8 +1107,6 @@ void CF_CmdGetParam(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CmdEnableEngine
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
@@ -1208,8 +1138,6 @@ void CF_CmdEnableEngine(CFE_SB_Buffer_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CmdDisableEngine
- *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
  *
@@ -1231,8 +1159,6 @@ void CF_CmdDisableEngine(CFE_SB_Buffer_t *msg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_ProcessGroundCommand
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail

--- a/fsw/src/cf_codec.c
+++ b/fsw/src/cf_codec.c
@@ -125,8 +125,6 @@ static const CF_Codec_BitField_t CF_CFDP_PduFileData_SEGMENT_METADATA_LENGTH   =
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Codec_Store_uint8
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -136,8 +134,6 @@ static inline void CF_Codec_Store_uint8(CF_CFDP_uint8_t *pdst, uint8 val)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Codec_Store_uint16
  *
  * Internal helper routine only, not part of API.
  *
@@ -150,8 +146,6 @@ static inline void CF_Codec_Store_uint16(CF_CFDP_uint16_t *pdst, uint16 val)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Codec_Store_uint32
  *
  * Internal helper routine only, not part of API.
  *
@@ -168,8 +162,6 @@ static inline void CF_Codec_Store_uint32(CF_CFDP_uint32_t *pdst, uint32 val)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Codec_Store_uint64
  *
  * Internal helper routine only, not part of API.
  *
@@ -195,8 +187,6 @@ static inline void CF_Codec_Store_uint64(CF_CFDP_uint64_t *pdst, uint64 val)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Codec_Load_uint8
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -206,8 +196,6 @@ static inline void CF_Codec_Load_uint8(uint8 *pdst, const CF_CFDP_uint8_t *psrc)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Codec_Load_uint16
  *
  * Internal helper routine only, not part of API.
  *
@@ -224,8 +212,6 @@ static inline void CF_Codec_Load_uint16(uint16 *pdst, const CF_CFDP_uint16_t *ps
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Codec_Load_uint32
  *
  * Internal helper routine only, not part of API.
  *
@@ -246,8 +232,6 @@ static inline void CF_Codec_Load_uint32(uint32 *pdst, const CF_CFDP_uint32_t *ps
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Codec_Load_uint64
  *
  * Internal helper routine only, not part of API.
  *
@@ -277,8 +261,6 @@ static inline void CF_Codec_Load_uint64(uint64 *pdst, const CF_CFDP_uint64_t *ps
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_CodecCheckSize
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -301,8 +283,6 @@ bool CF_CFDP_CodecCheckSize(CF_CodecState_t *state, size_t chunksize)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DoEncodeChunk
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -320,8 +300,6 @@ void *CF_CFDP_DoEncodeChunk(CF_EncoderState_t *state, size_t chunksize)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DoDecodeChunk
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -341,8 +319,6 @@ const void *CF_CFDP_DoDecodeChunk(CF_DecoderState_t *state, size_t chunksize)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_GetValueEncodedSize
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -361,8 +337,6 @@ uint8 CF_CFDP_GetValueEncodedSize(uint64 Value)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_EncodeIntegerInSize
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -388,8 +362,6 @@ void CF_EncodeIntegerInSize(CF_EncoderState_t *state, uint64 value, uint8 encode
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_EncodeHeaderWithoutSize
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -427,8 +399,6 @@ void CF_CFDP_EncodeHeaderWithoutSize(CF_EncoderState_t *state, CF_Logical_PduHea
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeHeaderFinalSize
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -459,8 +429,6 @@ void CF_CFDP_EncodeHeaderFinalSize(CF_EncoderState_t *state, CF_Logical_PduHeade
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeFileDirectiveHeader
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -478,8 +446,6 @@ void CF_CFDP_EncodeFileDirectiveHeader(CF_EncoderState_t *state, CF_Logical_PduF
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_EncodeLV
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -510,8 +476,6 @@ void CF_CFDP_EncodeLV(CF_EncoderState_t *state, CF_Logical_Lv_t *pllv)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_EncodeTLV
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -551,8 +515,6 @@ void CF_CFDP_EncodeTLV(CF_EncoderState_t *state, CF_Logical_Tlv_t *pltlv)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeSegmentRequest
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -571,8 +533,6 @@ void CF_CFDP_EncodeSegmentRequest(CF_EncoderState_t *state, CF_Logical_SegmentRe
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeAllTlv
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -589,8 +549,6 @@ void CF_CFDP_EncodeAllTlv(CF_EncoderState_t *state, CF_Logical_TlvList_t *pltlv)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeAllSegments
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -606,8 +564,6 @@ void CF_CFDP_EncodeAllSegments(CF_EncoderState_t *state, CF_Logical_SegmentList_
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_EncodeMd
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -632,8 +588,6 @@ void CF_CFDP_EncodeMd(CF_EncoderState_t *state, CF_Logical_PduMd_t *plmd)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_EncodeFileDataHeader
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -672,8 +626,6 @@ void CF_CFDP_EncodeFileDataHeader(CF_EncoderState_t *state, bool with_meta, CF_L
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeEof
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -696,8 +648,6 @@ void CF_CFDP_EncodeEof(CF_EncoderState_t *state, CF_Logical_PduEof_t *pleof)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeFin
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -719,8 +669,6 @@ void CF_CFDP_EncodeFin(CF_EncoderState_t *state, CF_Logical_PduFin_t *plfin)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_EncodeAck
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -745,8 +693,6 @@ void CF_CFDP_EncodeAck(CF_EncoderState_t *state, CF_Logical_PduAck_t *plack)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeNak
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -767,8 +713,6 @@ void CF_CFDP_EncodeNak(CF_EncoderState_t *state, CF_Logical_PduNak_t *plnak)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_EncodeCrc
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -785,8 +729,6 @@ void CF_CFDP_EncodeCrc(CF_EncoderState_t *state, uint32 *plcrc)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_DecodeIntegerInSize
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -815,8 +757,6 @@ uint64 CF_DecodeIntegerInSize(CF_DecoderState_t *state, uint8 decode_size)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeHeader
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -864,8 +804,6 @@ int32 CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DecodeFileDirectiveHeader
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -886,8 +824,6 @@ void CF_CFDP_DecodeFileDirectiveHeader(CF_DecoderState_t *state, CF_Logical_PduF
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DecodeLV
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -905,8 +841,6 @@ void CF_CFDP_DecodeLV(CF_DecoderState_t *state, CF_Logical_Lv_t *pllv)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeTLV
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -939,8 +873,6 @@ void CF_CFDP_DecodeTLV(CF_DecoderState_t *state, CF_Logical_Tlv_t *pltlv)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DecodeSegmentRequest
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -958,8 +890,6 @@ void CF_CFDP_DecodeSegmentRequest(CF_DecoderState_t *state, CF_Logical_SegmentRe
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeMd
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -983,8 +913,6 @@ void CF_CFDP_DecodeMd(CF_DecoderState_t *state, CF_Logical_PduMd_t *plmd)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeFileDataHeader
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -1048,8 +976,6 @@ void CF_CFDP_DecodeFileDataHeader(CF_DecoderState_t *state, bool with_meta, CF_L
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DecodeCrc
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -1066,8 +992,6 @@ void CF_CFDP_DecodeCrc(CF_DecoderState_t *state, uint32 *plcrc)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeEof
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -1090,8 +1014,6 @@ void CF_CFDP_DecodeEof(CF_DecoderState_t *state, CF_Logical_PduEof_t *pleof)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DecodeFin
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -1112,8 +1034,6 @@ void CF_CFDP_DecodeFin(CF_DecoderState_t *state, CF_Logical_PduFin_t *plfin)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeAck
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -1136,8 +1056,6 @@ void CF_CFDP_DecodeAck(CF_DecoderState_t *state, CF_Logical_PduAck_t *plack)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CFDP_DecodeNak
- *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
  *
@@ -1157,8 +1075,6 @@ void CF_CFDP_DecodeNak(CF_DecoderState_t *state, CF_Logical_PduNak_t *plnak)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeAllTlv
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail
@@ -1194,8 +1110,6 @@ void CF_CFDP_DecodeAllTlv(CF_DecoderState_t *state, CF_Logical_TlvList_t *pltlv,
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CFDP_DecodeAllSegments
  *
  * Application-scope internal function
  * See description in cf_codec.h for argument/return detail

--- a/fsw/src/cf_crc.c
+++ b/fsw/src/cf_crc.c
@@ -35,8 +35,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_CRC_Start
- *
  * Application-scope internal function
  * See description in cf_crc.h for argument/return detail
  *
@@ -47,8 +45,6 @@ void CF_CRC_Start(CF_Crc_t *c)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CRC_Digest
  *
  * Application-scope internal function
  * See description in cf_crc.h for argument/return detail
@@ -74,8 +70,6 @@ void CF_CRC_Digest(CF_Crc_t *c, const uint8 *data, int len)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_CRC_Finalize
  *
  * Application-scope internal function
  * See description in cf_crc.h for argument/return detail

--- a/fsw/src/cf_logical_pdu.h
+++ b/fsw/src/cf_logical_pdu.h
@@ -117,7 +117,6 @@ typedef struct CF_Logical_PduHeader
     CF_EntityId_t       source_eid;      /**< \brief Source entity ID (normalized) */
     CF_EntityId_t       destination_eid; /**< \brief Destination entity ID (normalized) */
     CF_TransactionSeq_t sequence_num;    /**< \brief Sequence number (normalized) */
-
 } CF_Logical_PduHeader_t;
 
 /**
@@ -164,7 +163,6 @@ typedef union CF_Logical_TlvData
 {
     CF_EntityId_t eid;      /**< \brief Valid when type=ENTITY_ID (6) */
     const void *  data_ptr; /**< \brief Source of actual data in original location (other string/binary types) */
-
 } CF_Logical_TlvData_t;
 
 /**
@@ -203,7 +201,6 @@ typedef struct CF_Logical_SegmentList
      * and may be 0 if the PDU does not contain any such fields.
      */
     CF_Logical_SegmentRequest_t segments[CF_PDU_MAX_SEGMENTS];
-
 } CF_Logical_SegmentList_t;
 
 typedef struct CF_Logical_TlvList
@@ -211,7 +208,6 @@ typedef struct CF_Logical_TlvList
     uint8 num_tlv; /**< \brief number of valid entries in the TLV list */
 
     CF_Logical_Tlv_t tlv[CF_PDU_MAX_TLV];
-
 } CF_Logical_TlvList_t;
 
 /**
@@ -229,7 +225,6 @@ typedef struct CF_Logical_PduEof
      * \brief Set of all TLV blobs in this PDU.
      */
     CF_Logical_TlvList_t tlv_list;
-
 } CF_Logical_PduEof_t;
 
 /**
@@ -260,7 +255,6 @@ typedef struct CF_Logical_PduAck
     uint8                   ack_subtype_code;   /**< \brief depends on ack_directive_code  */
     CF_CFDP_ConditionCode_t cc;
     CF_CFDP_AckTxnStatus_t  txn_status;
-
 } CF_Logical_PduAck_t;
 
 /**
@@ -277,7 +271,6 @@ typedef struct CF_Logical_PduMd
 
     CF_Logical_Lv_t source_filename;
     CF_Logical_Lv_t dest_filename;
-
 } CF_Logical_PduMd_t;
 
 /**
@@ -292,7 +285,6 @@ typedef struct CF_Logical_PduNak
      * \brief Set of all segments in this PDU.
      */
     CF_Logical_SegmentList_t segment_list;
-
 } CF_Logical_PduNak_t;
 
 typedef struct CF_Logical_PduFileDataHeader
@@ -309,7 +301,6 @@ typedef struct CF_Logical_PduFileDataHeader
 
     const void *data_ptr; /**< \brief pointer to read-only data blob within encoded PDU */
     size_t      data_len; /**< \brief Length of data blob within encoded PDU (derived field) */
-
 } CF_Logical_PduFileDataHeader_t;
 
 /**
@@ -326,7 +317,6 @@ typedef union CF_Logical_IntHeader
     CF_Logical_PduMd_t             md;  /**< \brief valid when pdu_type=0 + directive_code=METADATA (7) */
     CF_Logical_PduNak_t            nak; /**< \brief valid when pdu_type=0 + directive_code=NAK (8) */
     CF_Logical_PduFileDataHeader_t fd;  /**< \brief valid when pdu_type=1 (directive_code is not applicable) */
-
 } CF_Logical_IntHeader_t;
 
 /**
@@ -373,7 +363,6 @@ typedef struct CF_Logical_PduBuffer
      * does not permit for any other size.
      */
     uint32 content_crc;
-
 } CF_Logical_PduBuffer_t;
 
 #endif /* !CF_LOGICAL_PDU_H */

--- a/fsw/src/cf_msg.h
+++ b/fsw/src/cf_msg.h
@@ -167,7 +167,6 @@ typedef union
  */
 typedef enum
 {
-
     /**
      * \brief No-op
      *

--- a/fsw/src/cf_timer.c
+++ b/fsw/src/cf_timer.c
@@ -36,8 +36,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Timer_Sec2Ticks
- *
  * Application-scope internal function
  * See description in cf_timer.h for argument/return detail
  *
@@ -48,8 +46,6 @@ uint32 CF_Timer_Sec2Ticks(CF_Timer_Seconds_t sec)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Timer_InitRelSec
  *
  * Application-scope internal function
  * See description in cf_timer.h for argument/return detail
@@ -62,8 +58,6 @@ void CF_Timer_InitRelSec(CF_Timer_t *t, uint32 rel_sec)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Timer_Expired
- *
  * Application-scope internal function
  * See description in cf_timer.h for argument/return detail
  *
@@ -74,8 +68,6 @@ int CF_Timer_Expired(const CF_Timer_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_Timer_Tick
  *
  * Application-scope internal function
  * See description in cf_timer.h for argument/return detail

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -36,8 +36,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CF_FindUnusedTransaction
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -82,8 +80,6 @@ CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *c)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_ResetHistory
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -95,8 +91,6 @@ void CF_ResetHistory(CF_Channel_t *c, CF_History_t *h)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_FreeTransaction
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -115,8 +109,6 @@ void CF_FreeTransaction(CF_Transaction_t *t)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_FindTransactionBySequenceNumber_Impl
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -137,8 +129,6 @@ int CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_Trans
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_FindTransactionBySequenceNumber
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -171,8 +161,6 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *c, CF_Transac
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_WriteHistoryEntryToFile
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -221,8 +209,6 @@ int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Traverse_WriteHistoryQueueEntryToFile
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -250,8 +236,6 @@ int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_Traverse_WriteTxnQueueEntryToFile
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -274,8 +258,6 @@ int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_WriteTxnQueueDataToFile
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -293,8 +275,6 @@ int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_WriteHistoryQueueDataToFile
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -314,8 +294,6 @@ int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_PrioSearch
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -340,8 +318,6 @@ int CF_PrioSearch(CF_CListNode_t *node, void *context)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_InsertSortPrio
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -385,8 +361,6 @@ void CF_InsertSortPrio(CF_Transaction_t *t, CF_QueueIdx_t q)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_TraverseAllTransactions_Impl
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -400,8 +374,6 @@ int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *arg
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_TraverseAllTransactions
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -419,8 +391,6 @@ int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t 
 
 /*----------------------------------------------------------------
  *
- * Function: CF_TraverseAllTransactions_All_Channels
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -435,8 +405,6 @@ int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, 
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_WrappedOpenCreate
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -453,8 +421,6 @@ int32 CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_WrappedClose
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
@@ -477,8 +443,6 @@ void CF_WrappedClose(osal_id_t fd)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_WrappedRead
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -495,8 +459,6 @@ int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
 
 /*----------------------------------------------------------------
  *
- * Function: CF_WrappedWrite
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -512,8 +474,6 @@ int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CF_WrappedLseek
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -32,14 +32,12 @@
 void cf_app_tests_Setup(void)
 {
     cf_tests_Setup();
-} /* end cf_app_tests_Setup */
+}
 
 void CF_App_Tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end CF_App_Tests_Teardown */
-
-/* end cf_app_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -61,8 +59,6 @@ void UT_UpdatedDefaultHandler_CFE_SB_ReceiveBuffer(void *UserObj, UT_EntryKey_t 
     UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ReceiveBuffer), BufPtr, sizeof(*BufPtr));
 }
 
-/* end cf_app_tests helpers */
-
 /*******************************************************************************
 **
 **  CF_HkCmd tests - full coverage
@@ -71,7 +67,6 @@ void UT_UpdatedDefaultHandler_CFE_SB_ReceiveBuffer(void *UserObj, UT_EntryKey_t 
 
 void Test_CF_HkCmd(void)
 {
-
     /* Act */
     CF_HkCmd();
 
@@ -80,8 +75,6 @@ void Test_CF_HkCmd(void)
     UtAssert_STUB_COUNT(CFE_SB_TransmitMsg, 1);
     UtAssert_STUB_COUNT(CFE_TIME_GetTime, 1);
 }
-
-/* end CF_HkCmd tests */
 
 /*******************************************************************************
 **
@@ -99,7 +92,7 @@ void Test_CF_CheckTables_DoNotReleaseAddressBecauseEngineIsEnabled(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_TBL_ReleaseAddress, 0);
-} /* end Test_CF_CheckTables_DoNotReleaseAddressBecauseEngineIsEnabled */
+}
 
 void Test_CF_CheckTables_CallTo_CFE_TBL_ReleaseAddress_ReturnsNot_CFE_SUCCESS_SendEvent(void)
 {
@@ -111,7 +104,7 @@ void Test_CF_CheckTables_CallTo_CFE_TBL_ReleaseAddress_ReturnsNot_CFE_SUCCESS_Se
     /* Assert */
     UtAssert_STUB_COUNT(CFE_TBL_ReleaseAddress, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end Test_CF_CheckTables_CallTo_CFE_TBL_ReleaseAddress_ReturnsNot_CFE_SUCCESS_SendEvent */
+}
 
 void Test_CF_CheckTables_CallTo_CFE_TBL_Manage_ReturnsNot_CFE_SUCCESS_SendEvent(void)
 {
@@ -124,7 +117,7 @@ void Test_CF_CheckTables_CallTo_CFE_TBL_Manage_ReturnsNot_CFE_SUCCESS_SendEvent(
     UtAssert_STUB_COUNT(CFE_TBL_ReleaseAddress, 1);
     UtAssert_STUB_COUNT(CFE_TBL_Manage, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end Test_CF_CheckTables_CallTo_CFE_TBL_Manage_ReturnsNot_CFE_SUCCESS_SendEvent */
+}
 
 void Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_ReturnsNot_CFE_SUCCESS_Or_CFE_TBL_INFO_UPDATED_SendEvent(void)
 {
@@ -138,7 +131,7 @@ void Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_ReturnsNot_CFE_SUCCESS_Or_CFE
     UtAssert_STUB_COUNT(CFE_TBL_Manage, 1);
     UtAssert_STUB_COUNT(CFE_TBL_GetAddress, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_ReturnsNot_CFE_SUCCESS_Or_CFE_TBL_INFO_UPDATED_SendEvent */
+}
 
 void Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_SUCCESS(void)
 {
@@ -150,7 +143,7 @@ void Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_SUCCESS(void)
     UtAssert_STUB_COUNT(CFE_TBL_Manage, 1);
     UtAssert_STUB_COUNT(CFE_TBL_GetAddress, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_SUCCESS */
+}
 
 void Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED(void)
 {
@@ -164,9 +157,7 @@ void Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED(
     UtAssert_STUB_COUNT(CFE_TBL_Manage, 1);
     UtAssert_STUB_COUNT(CFE_TBL_GetAddress, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED */
-
-/* end CF_CheckTables tests */
+}
 
 /*******************************************************************************
 **
@@ -188,13 +179,13 @@ void cf_config_table_tests_set_dummy_table_to_nominal(void)
     dummy_table.rx_crc_calc_bytes_per_wakeup = Any_uint32_Except(0) << 10;
     // all values less than sizeof(CF_CFDP_PduFileDataContent_t) are nominal
     dummy_table.outgoing_file_chunk_size = Any_uint16_LessThan(sizeof(CF_CFDP_PduFileDataContent_t));
-} /* end cf_config_table_tests_set_dummy_table_to_nominal */
+}
 
 void Setup_cf_config_table_tests(void)
 {
     cf_app_tests_Setup();
     cf_config_table_tests_set_dummy_table_to_nominal();
-} /* end Setup_cf_config_table_tests */
+}
 
 /* end CF_ValidateConfigTable tests specific items */
 
@@ -211,7 +202,7 @@ void Test_CF_ValidateConfigTable_FailBecauseTableTicksPerSecondIs0(void)
 
     /* Assert */
     UtAssert_INT32_EQ(result, -1);
-} /* end Test_CF_ValidateConfigTable_FailBecauseTableTicksPerSecondIs0 */
+}
 
 void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIs0(void)
 {
@@ -227,7 +218,7 @@ void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIs0(void)
 
     /* Assert */
     UtAssert_INT32_EQ(result, -2);
-} /* end Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIs0 */
+}
 
 void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIsNot1024ByteAligned(void)
 {
@@ -246,7 +237,7 @@ void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIsNot1024ByteAlign
 
     /* Assert */
     UtAssert_INT32_EQ(result, -2);
-} /* end Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIsNot1024ByteAligned */
+}
 
 void Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArray(void)
 {
@@ -264,7 +255,7 @@ void Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArra
 
     /* Assert */
     UtAssert_INT32_EQ(result, -3);
-} /* end Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArray */
+}
 
 void Test_CF_ValidateConfigTable_Success(void)
 {
@@ -281,9 +272,7 @@ void Test_CF_ValidateConfigTable_Success(void)
 
     /* Assert */
     UtAssert_INT32_EQ(result, CFE_SUCCESS);
-} /* end Test_CF_ValidateConfigTable_Success */
-
-/* end CF_ValidateConfigTable tests */
+}
 
 /*******************************************************************************
 **
@@ -303,7 +292,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Register_DidNotReturnSuccess(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_REG);
-} /* end Test_CF_TableInit_FailBecause_CFE_TBL_Register_DidNotReturnSuccess */
+}
 
 void Test_CF_TableInit_FailBecause_CFE_TBL_Load_DidNotReturnSuccess(void)
 {
@@ -317,7 +306,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Load_DidNotReturnSuccess(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_LOAD);
-} /* end Test_CF_TableInit_FailBecause_CFE_TBL_Load_DidNotReturnSuccess */
+}
 
 void Test_CF_TableInit_FailBecause_CFE_TBL_Manage_DidNotReturnSuccess(void)
 {
@@ -332,7 +321,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Manage_DidNotReturnSuccess(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_MANAGE);
-} /* end Test_CF_TableInit_FailBecause_CFE_TBL_Manage_DidNotReturnSuccess */
+}
 
 void Test_CF_TableInit_FailBecause_CFE_TBL_GetAddress_DidNotReturnSuccess(void)
 {
@@ -347,7 +336,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_GetAddress_DidNotReturnSuccess(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_GETADDR);
-} /* end Test_CF_TableInit_FailBecause_CFE_TBL_GetAddress_DidNotReturnSuccess */
+}
 
 void Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_SUCCESS_SuccessAndDoNotSendEvent(void)
 {
@@ -356,7 +345,7 @@ void Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_SUCCESS_SuccessAndDoN
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_SUCCESS_SuccessAndDoNotSendEvent */
+}
 
 void Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED_SuccessAndDoNotSendEvent(void)
 {
@@ -368,9 +357,7 @@ void Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED_Succ
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED_SuccessAndDoNotSendEvent */
-
-/* end CF_TableInit tests */
+}
 
 /*******************************************************************************
 **
@@ -391,7 +378,7 @@ void Test_CF_Init_CallTo_CFE_EVS_Register_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_Wri
     UtAssert_STUB_COUNT(CFE_MSG_Init, 1);
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 1);
-} /* end Test_CF_Init_CallTo_CFE_EVS_Register_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus */
+}
 
 void Test_CF_Init_CallTo_CFE_SB_CreatePipe_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus(void)
 {
@@ -408,7 +395,7 @@ void Test_CF_Init_CallTo_CFE_SB_CreatePipe_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_Wr
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
     UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 1);
-} /* end Test_CF_Init_CallTo_CFE_SB_CreatePipe_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus */
+}
 
 void Test_CF_Init_FirstCallTo_CFE_SB_Subscribe_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus(void)
 {
@@ -426,7 +413,7 @@ void Test_CF_Init_FirstCallTo_CFE_SB_Subscribe_ReturnsNot_CFE_SUCCESS_Call_CFE_E
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
     UtAssert_STUB_COUNT(CFE_SB_Subscribe, 1);
     UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 1);
-} /* end Test_CF_Init_FirstCallTo_CFE_SB_Subscribe_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus */
+}
 
 /* NOTE: multi call test for CFE_SB_Subscribe would be helpful but not necessary for coverage */
 
@@ -447,7 +434,7 @@ void Test_CF_Init_CallTo_CF_TableInit_ReturnsNot_CFE_SUCCESS_ReturnErrorStatus(v
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
     UtAssert_STUB_COUNT(CFE_SB_Subscribe, 3);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end Test_CF_Init_CallTo_CF_TableInit_ReturnsNot_CFE_SUCCESS_ReturnErrorStatus */
+}
 
 void Test_CF_Init_CallTo_CF_CFDP_InitEngine_ReturnsNot_CFE_SUCCESS_ReturnErrorStatus(void)
 {
@@ -465,7 +452,7 @@ void Test_CF_Init_CallTo_CF_CFDP_InitEngine_ReturnsNot_CFE_SUCCESS_ReturnErrorSt
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
     UtAssert_STUB_COUNT(CFE_SB_Subscribe, 3);
     UtAssert_STUB_COUNT(CF_CFDP_InitEngine, 1);
-} /* end Test_CF_Init_CallTo_CF_CFDP_InitEngine_ReturnsNot_CFE_SUCCESS_ReturnErrorStatus */
+}
 
 void Test_CF_Init_CallTo_CFE_EVS_SendEvent_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus(void)
 {
@@ -485,7 +472,7 @@ void Test_CF_Init_CallTo_CFE_EVS_SendEvent_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_Wr
     // UtAssert_STUB_COUNT(CF_TableInit, 1);
     UtAssert_STUB_COUNT(CF_CFDP_InitEngine, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end Test_CF_Init_CallTo_CFE_EVS_SendEvent_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus */
+}
 
 void Test_CF_Init_Success(void)
 {
@@ -494,9 +481,7 @@ void Test_CF_Init_Success(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_MSG_Init, 1);
-} /* end Test_CF_Init_Success */
-
-/* end CF_Init tests */
+}
 
 /*******************************************************************************
 **
@@ -514,7 +499,7 @@ void Test_CF_WakeUp(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CFDP_CycleEngine, 1);
-} /* end Test_CF_WakeUp */
+}
 
 /*******************************************************************************
 **
@@ -539,7 +524,7 @@ void Test_CF_ProcessMsg_ProcessGroundCommand(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_MSG_GetMsgId, 1);
     UtAssert_STUB_COUNT(CF_ProcessGroundCommand, 1);
-} /* end Test_CF_ProcessMsg_ProcessGroundCommand */
+}
 
 void Test_CF_ProcessMsg_WakeUp(void)
 {
@@ -558,8 +543,7 @@ void Test_CF_ProcessMsg_WakeUp(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_MSG_GetMsgId, 1);
     UtAssert_STUB_COUNT(CF_CFDP_CycleEngine, 1);
-
-} /* end Test_CF_ProcessMsg_WakeUp */
+}
 
 void Test_CF_ProcessMsg_SendHk(void)
 {
@@ -578,7 +562,7 @@ void Test_CF_ProcessMsg_SendHk(void)
     UtAssert_STUB_COUNT(CFE_MSG_GetMsgId, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_MSG_SetMsgTime, 1); /* Confirms CF_HkCmd path was taken */
-} /* end Test_CF_ProcessMsg_SendHk */
+}
 
 void Test_CF_ProcessMsg_UnrecognizedCommandEnterDefaultPath(void)
 {
@@ -595,10 +579,7 @@ void Test_CF_ProcessMsg_UnrecognizedCommandEnterDefaultPath(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_CMD_LENGTH);
-
-} /* end Test_CF_ProcessMsg_UnrecognizedCommandEnterDefaultPath */
-
-/* end CF_ProcessMsg tests */
+}
 
 /*******************************************************************************
 **
@@ -622,8 +603,7 @@ void Test_CF_AppMain_CallTo_CF_Init_DoNotReturn_CFE_SUCCESS_Set_CF_AppData_run_s
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_UINT32_EQ(CF_AppData.run_status, CFE_ES_RunStatus_APP_ERROR);
-} /* end Test_CF_AppMain_CallTo_CF_Init_DoNotReturn_CFE_SUCCESS_Set_CF_AppData_run_status_To_CFE_ES_RunStatus_APP_ERROR
-   */
+}
 
 void Test_CF_AppMain_CFE_SB_ReceiveBuffer_Cases(void)
 {
@@ -711,9 +691,7 @@ void Test_CF_AppMain_RunLoopCallTo_CFE_SB_ReceiveBuffer_Returns_CFE_SUCCESS_AndV
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     /* Assert for CF_ProcessMsg */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
-} /* end Test_CF_AppMain_RunLoopCallTo_CFE_SB_ReceiveBuffer_Returns_CFE_SUCCESS_AndValid_msg_Call_CF_ProcessMsg */
-
-/* end CF_AppMain tests */
+}
 
 /*******************************************************************************
 **
@@ -743,7 +721,7 @@ void add_CF_CheckTables_tests(void)
                CF_App_Tests_Teardown, "Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_SUCCESS");
     UtTest_Add(Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED, Setup_cf_config_table_tests,
                CF_App_Tests_Teardown, "Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED");
-} /* end add_CF_CheckTables_tests */
+}
 
 void add_CF_ValidateConfigTable_tests(void)
 {
@@ -759,7 +737,7 @@ void add_CF_ValidateConfigTable_tests(void)
                "Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArray");
     UtTest_Add(Test_CF_ValidateConfigTable_Success, Setup_cf_config_table_tests, CF_App_Tests_Teardown,
                "Test_CF_ValidateConfigTable_Success");
-} /* end add_CF_ValidateConfigTable_tests */
+}
 
 void add_CF_TableInit_tests(void)
 {
@@ -777,7 +755,7 @@ void add_CF_TableInit_tests(void)
     UtTest_Add(Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED_SuccessAndDoNotSendEvent,
                cf_app_tests_Setup, CF_App_Tests_Teardown,
                "Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED_SuccessAndDoNotSendEvent");
-} /* end add_CF_TableInit_tests */
+}
 
 void add_CF_Init_tests(void)
 {
@@ -803,12 +781,12 @@ void add_CF_Init_tests(void)
         cf_app_tests_Setup, CF_App_Tests_Teardown,
         "Test_CF_Init_CallTo_CFE_EVS_SendEvent_ReturnsNot_CFE_SUCCESS_Call_CFE_ES_WriteToSysLog_ReturnErrorStatus");
     UtTest_Add(Test_CF_Init_Success, cf_app_tests_Setup, CF_App_Tests_Teardown, "Test_CF_Init_Success");
-} /* end add_CF_Init_tests */
+}
 
 void add_CF_WakeUp_tests(void)
 {
     UtTest_Add(Test_CF_WakeUp, cf_app_tests_Setup, CF_App_Tests_Teardown, "Test_CF_WakeUp");
-} /* end add_CF_WakeUp_tests */
+}
 
 void add_CF_ProcessMsg_tests(void)
 {
@@ -818,7 +796,7 @@ void add_CF_ProcessMsg_tests(void)
     UtTest_Add(Test_CF_ProcessMsg_SendHk, cf_app_tests_Setup, CF_App_Tests_Teardown, "Test_CF_ProcessMsg_SendHk");
     UtTest_Add(Test_CF_ProcessMsg_UnrecognizedCommandEnterDefaultPath, cf_app_tests_Setup, CF_App_Tests_Teardown,
                "Test_CF_ProcessMsg_UnrecognizedCommandEnterDefaultPath");
-} /* end add_CF_ProcessMsg_tests */
+}
 
 void add_CF_AppMain_tests(void)
 {
@@ -833,9 +811,7 @@ void add_CF_AppMain_tests(void)
         Test_CF_AppMain_RunLoopCallTo_CFE_SB_ReceiveBuffer_Returns_CFE_SUCCESS_AndValid_msg_Call_CF_ProcessMsg,
         cf_app_tests_Setup, CF_App_Tests_Teardown,
         "Test_CF_AppMain_RunLoopCallTo_CFE_SB_ReceiveBuffer_Returns_CFE_SUCCESS_AndValid_msg_Call_CF_ProcessMsg");
-} /* end add_CF_AppMain_tests */
-
-/* end cf_app_tests UtTest_Add groups */
+}
 
 /*******************************************************************************
 **
@@ -863,4 +839,3 @@ void UtTest_Setup(void)
 
     add_CF_AppMain_tests();
 }
-/* end cf_app_tests.c */

--- a/unit-test/cf_cfdp_dispatch_tests.c
+++ b/unit-test/cf_cfdp_dispatch_tests.c
@@ -109,15 +109,12 @@ void cf_cfdp_dispatch_tests_Setup(void)
 
     /* make sure global data is wiped between tests */
     memset(&CF_AppData, 0, sizeof(CF_AppData));
-
-} /* end cf_cfdp_dispatch_tests_Setup */
+}
 
 void cf_cfdp_dispatch_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_cfdp_dispatch_tests_Teardown */
-
-/* end cf_cfdp_dispatch_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -316,7 +313,4 @@ void UtTest_Setup(void)
                "CF_CFDP_TxStateDispatch");
     UtTest_Add(Test_CF_CFDP_RxStateDispatch, cf_cfdp_dispatch_tests_Setup, cf_cfdp_dispatch_tests_Teardown,
                "CF_CFDP_RxStateDispatch");
-
-} /* end UtTest_Setup for cf_cfdp_dispatch_tests.c */
-
-/* end cf_cfdp_dispatch_tests.c */
+}

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -128,15 +128,12 @@ void cf_cfdp_r_tests_Setup(void)
 
     /* make sure global data is wiped between tests */
     memset(&CF_AppData, 0, sizeof(CF_AppData));
-
-} /* end cf_cfdp_r_tests_Setup */
+}
 
 void cf_cfdp_r_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_cfdp_r_tests_Teardown */
-
-/* end cf_cfdp_r_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -1148,7 +1145,4 @@ void UtTest_Setup(void)
     UtTest_Add(Test_CF_CFDP_R2_RecvMd, cf_cfdp_r_tests_Setup, cf_cfdp_r_tests_Teardown, "CF_CFDP_R2_RecvMd");
     UtTest_Add(Test_CF_CFDP_R_SendInactivityEvent, cf_cfdp_r_tests_Setup, cf_cfdp_r_tests_Teardown,
                "CF_CFDP_R_SendInactivityEvent");
-
-} /* end UtTest_Setup for cf_cfdp_r_tests.c */
-
-/* end cf_cfdp_r_tests.c */
+}

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -151,15 +151,12 @@ void cf_cfdp_s_tests_Setup(void)
 
     /* make sure global data is wiped between tests */
     memset(&CF_AppData, 0, sizeof(CF_AppData));
-
-} /* end cf_cfdp_s_tests_Setup */
+}
 
 void cf_cfdp_s_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_cfdp_s_tests_Teardown */
-
-/* end cf_cfdp_s_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -893,7 +890,4 @@ void UtTest_Setup(void)
     UtTest_Add(Test_CF_CFDP_S2_Nak_Arm, cf_cfdp_s_tests_Setup, cf_cfdp_s_tests_Teardown, "CF_CFDP_S2_Nak_Arm");
     UtTest_Add(Test_CF_CFDP_S2_WaitForEofAck, cf_cfdp_s_tests_Setup, cf_cfdp_s_tests_Teardown,
                "CF_CFDP_S2_WaitForEofAck");
-
-} /* end UtTest_Setup for cf_cfdp_s_tests.c */
-
-/* end cf_cfdp_s_tests.c */
+}

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -180,8 +180,6 @@ static void UT_CFDP_SetupBasicTestState(UT_CF_Setup_t setup, CF_Logical_PduBuffe
     UT_CF_ResetEventCapture();
 }
 
-/* end cf_cfdp_tests local utility functions */
-
 /*******************************************************************************
 **
 **  cf_cfdp_tests Setup and Teardown
@@ -197,13 +195,12 @@ void cf_cfdp_tests_Setup(void)
      * previously left in here.
      */
     memset(&CF_AppData, 0, sizeof(CF_AppData));
-
-} /* end cf_cfdp_tests_Setup */
+}
 
 void cf_cfdp_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_cfdp_tests_Teardown */
+}
 
 /*******************************************************************************
 **
@@ -404,7 +401,4 @@ void UtTest_Setup(void)
 
     UtTest_Add(Test_CF_CFDP_MsgOutGet, cf_cfdp_tests_Setup, cf_cfdp_tests_Teardown, "CF_CFDP_MsgOutGet");
     UtTest_Add(Test_CF_CFDP_Send, cf_cfdp_tests_Setup, cf_cfdp_tests_Teardown, "CF_CFDP_Send");
-
-} /* end UtTest_Setup for cf_cfdp_tests.c */
-
-/* end cf_cfdp_tests.c */
+}

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -144,8 +144,6 @@ static void UT_CFDP_SetupBasicTestState(UT_CF_Setup_t setup, CF_Logical_PduBuffe
     UT_CF_ResetEventCapture();
 }
 
-/* end cf_cfdp_tests local utility functions */
-
 /*******************************************************************************
 **
 **  cf_cfdp_tests Setup and Teardown
@@ -161,15 +159,12 @@ void cf_cfdp_tests_Setup(void)
      * previously left in here.
      */
     memset(&CF_AppData, 0, sizeof(CF_AppData));
-
-} /* end cf_cfdp_tests_Setup */
+}
 
 void cf_cfdp_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_cfdp_tests_Teardown */
-
-/* end cf_cfdp_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -468,6 +463,7 @@ void Test_CF_CFDP_RecvDrop(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     UtAssert_VOIDCALL(CF_CFDP_RecvDrop(t, ph));
 }
+
 void Test_CF_CFDP_RecvIdle(void)
 {
     /* Test case for:
@@ -633,6 +629,7 @@ void Test_CF_CFDP_SendMd(void)
     UtAssert_STRINGBUF_EQ(md->source_filename.data_ptr, md->source_filename.length, h->fnames.src_filename,
                           sizeof(h->fnames.src_filename));
 }
+
 void Test_CF_CFDP_SendFd(void)
 {
     /* Test case for:
@@ -1538,7 +1535,4 @@ void UtTest_Setup(void)
     UtTest_Add(Test_CF_CFDP_SendFin, cf_cfdp_tests_Setup, cf_cfdp_tests_Teardown, "CF_CFDP_SendFin");
     UtTest_Add(Test_CF_CFDP_SendNak, cf_cfdp_tests_Setup, cf_cfdp_tests_Teardown, "CF_CFDP_SendNak");
     UtTest_Add(Test_CF_CFDP_AppendTlv, cf_cfdp_tests_Setup, cf_cfdp_tests_Teardown, "CF_CFDP_AppendTlv");
-
-} /* end UtTest_Setup for cf_cfdp_tests.c */
-
-/* end cf_cfdp_tests.c */
+}

--- a/unit-test/cf_chunk_tests.c
+++ b/unit-test/cf_chunk_tests.c
@@ -74,7 +74,6 @@ void UT_CF_Chunk_SetupFull(CF_ChunkList_t *CList)
 /* Print the chunk list to the UT log (test debug helper) */
 void UT_CF_Chunk_Print(CF_ChunkList_t *CList)
 {
-
     CF_ChunkIdx_t cidx;
 
     UtPrintf("Chunk list: index{offset, size}");

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -80,14 +80,12 @@ typedef union
 void cf_cmd_tests_Setup(void)
 {
     cf_tests_Setup();
-} /* end cf_cmd_tests_Setup */
+}
 
 void cf_cmd_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_cmd_tests_Teardown */
-
-/* end cf_cmd_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -133,8 +131,6 @@ CF_TransactionSeq_t Any_CF_TransactionSeq_t(void)
 {
     return (CF_TransactionSeq_t)Any_uint32();
 }
-
-/* end cf_cmd_tests specific Any functions */
 
 /*******************************************************************************
 **
@@ -191,10 +187,7 @@ void Test_CF_CmdNoop_SendNoopEventAndAcceptCommand(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
     /* Assert to show counter incremented */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* Test_CF_CmdNoop_SendNoopEventAndAcceptCommand */
-
-/* end CF_CmdNoop tests */
+}
 
 /*******************************************************************************
 **
@@ -225,7 +218,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand */
+}
 
 void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCommand(void)
 {
@@ -250,7 +243,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCommand */
+}
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSendEvent(void)
 {
@@ -274,7 +267,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
     UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
     UtAssert_ZERO(CF_AppData.hk.counters.cmd);
     UtAssert_ZERO(CF_AppData.hk.counters.err);
-} /* end Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSendEvent */
+}
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEventAndAcceptCommand(void)
 {
@@ -335,8 +328,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
     }
     /* Assert to show counter incremented */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEventAndAcceptCommand */
+}
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEventAndAcceptCommand(void)
 {
@@ -385,8 +377,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
     }
     /* Assert to show counter incremented */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEventAndAcceptCommand */
+}
 
 void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEventAcceptCommand(void)
 {
@@ -429,8 +420,7 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
     }
     /* Assert to show counter incremented */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEventAcceptCommand */
+}
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(void)
 {
@@ -507,9 +497,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
                              sizeof(&CF_AppData.hk.channel_hk[i].counters.sent),
                              "sent channel %d was completely cleared to 0", i);
     }
-} /* end Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent */
-
-/* end CF_CmdReset tests */
+}
 
 /*******************************************************************************
 **
@@ -583,8 +571,6 @@ void Test_CF_CmdTxFile(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 5);
 }
 
-/* end CF_CmdTxFile tests */
-
 /*******************************************************************************
 **
 **  CF_CmdPlaybackDir tests
@@ -651,8 +637,6 @@ void Test_CF_CmdPlaybackDir(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 5);
 }
 
-/* end CF_CmdPlaybackDir tests */
-
 /*******************************************************************************
 **
 **  CF_DoChanAction tests
@@ -687,8 +671,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
     UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (an fn returned 1)", local_result);
-
-} /* end Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1 */
+}
 
 void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
 {
@@ -717,8 +700,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
     UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (an fn returned 1)", local_result);
-
-} /* end Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1 */
+}
 
 void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
 {
@@ -747,8 +729,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
     UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 0, "CF_DoChanAction returned %d and should be 0 (all fn returned 0)", local_result);
-
-} /* end Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0 */
+}
 
 void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
 {
@@ -777,8 +758,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
     UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (fn returned 1)", local_result);
-
-} /* end Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1 */
+}
 
 void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
 {
@@ -807,8 +787,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
     UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 0, "CF_DoChanAction returned %d and should be 0 (fn returned 0)", local_result);
-
-} /* end Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1 */
+}
 
 void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendEvent_(void)
 {
@@ -838,8 +817,7 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
 
     UtAssert_True(local_result == -1,
                   "CF_DoChanAction returned %d and should be -1 (cmd->data.byte[0] >= CF_NUM_CHANNELS)", local_result);
-
-} /* end Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendEvent_ */
+}
 
 void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
 {
@@ -882,10 +860,7 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
 
     UtAssert_True(local_result == -1,
                   "CF_DoChanAction returned %d and should be -1 (cmd->data.byte[0] >= CF_NUM_CHANNELS)", local_result);
-
-} /* end Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent */
-
-/* end CF_DoChanAction tests */
+}
 
 /*******************************************************************************
 **
@@ -917,10 +892,7 @@ void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
                   "CF_DoFreezeThaw set frozen to %d and should be %d (context->barg))",
                   CF_AppData.hk.channel_hk[arg_chan_num].frozen, dummy_context.barg);
     UtAssert_True(local_result == 0, "CF_DoFreezeThaw returned %d and should be 0 (only returns 0)", local_result);
-
-} /* end Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0 */
-
-/* end CF_DoFreezeThaw tests */
+}
 
 /**************************************************************************
 **
@@ -960,7 +932,7 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
                   initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_FREEZE);
-} /* end Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand */
+}
 
 void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
 {
@@ -984,7 +956,7 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_FREEZE);
-} /* end Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand */
+}
 
 /*******************************************************************************
 **
@@ -1024,7 +996,7 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
                   initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_THAW);
-} /* end Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand */
+}
 
 void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
 {
@@ -1048,7 +1020,7 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_THAW);
-} /* end Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand */
+}
 
 /*******************************************************************************
 **
@@ -1082,8 +1054,7 @@ void Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundRe
     UtAssert_UINT32_EQ(context_CF_CFDP_FTBSN.transaction_sequence_number, arg_ts);
     UtAssert_UINT32_EQ(context_CF_CFDP_FTBSN.src_eid, arg_eid);
     UtAssert_ADDRESS_EQ(local_result, expected_result);
-
-} /* end Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundReturn_NULL */
+}
 
 void Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound(void)
 {
@@ -1126,8 +1097,7 @@ void Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound(
     UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].transaction_sequence_number, arg_ts);
     UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].src_eid, arg_eid);
     UtAssert_ADDRESS_EQ(local_result, expected_result);
-
-} /* end Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound */
+}
 
 /*******************************************************************************
 **
@@ -1175,7 +1145,7 @@ void Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotF
     UT_CF_AssertEventID(CF_EID_ERR_CMD_TRANS_NOT_FOUND);
 
     UtAssert_STUB_COUNT(Dummy_CF_TsnChanAction_fn_t, 0);
-} /* end Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotFoundAndReturn_neg1_Fail */
+}
 
 void Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_AndReturn_CFE_SUCCESS(void)
 {
@@ -1218,7 +1188,7 @@ void Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_An
     UtAssert_STUB_COUNT(Dummy_CF_TsnChanAction_fn_t, 1);
     UtAssert_ADDRESS_EQ(context_Dummy_CF_TsnChanAction_fn_t.t, &dummy_t);
     UtAssert_ADDRESS_EQ(context_Dummy_CF_TsnChanAction_fn_t.context, arg_context);
-} /* end Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_AndReturn_CFE_SUCCESS */
+}
 
 void Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels(void)
 {
@@ -1249,7 +1219,7 @@ void Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTran
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels */
+}
 
 void Test_CF_TsnChanAction_cmd_chan_IsASingleChannel(void)
 {
@@ -1267,8 +1237,7 @@ void Test_CF_TsnChanAction_cmd_chan_IsASingleChannel(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-
-} /* end Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels */
+}
 
 void Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid(void)
 {
@@ -1289,8 +1258,7 @@ void Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_TSN_CHAN_INVALID);
-
-} /* end Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid */
+}
 
 /*******************************************************************************
 **
@@ -1319,7 +1287,7 @@ void Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action(void)
     /* Assert */
     UtAssert_True(arg_context->same == 1, "CF_DoSuspRes_Txn set context->same to %d and should be 1 (direct set)",
                   arg_context->same);
-} /* end Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action */
+}
 
 void Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action(void)
 {
@@ -1343,7 +1311,7 @@ void Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action
     UtAssert_True(arg_t->flags.com.suspended == arg_context->action,
                   "CF_DoSuspRes_Txn set arg_t->flags.com.suspended to %d and should be %d (context->action)",
                   arg_t->flags.com.suspended, arg_context->action);
-} /* end Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action */
+}
 
 /*******************************************************************************
 **
@@ -1442,9 +1410,7 @@ void Test_CF_CmdSuspend_Call_CF_DoSuspRes_WithGiven_msg_And_action_1(void)
 
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
-} /* end Test_CF_CmdSuspend_Call_CF_DoSuspRes_WithGiven_msg_And_action_1 */
-
-/* end CF_CmdSuspend tests */
+}
 
 /*******************************************************************************
 **
@@ -1473,9 +1439,7 @@ void Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0(void)
 
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
-} /* end Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0 */
-
-/* end CF_CmdResume tests */
+}
 
 /*******************************************************************************
 **
@@ -1499,8 +1463,7 @@ void Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t(void)
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_CF_CFDP_CancelTransaction, arg_t);
-
-} /* end Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t */
+}
 
 /*******************************************************************************
 **
@@ -1526,7 +1489,7 @@ void Test_CF_CmdCancel_Success(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_CANCEL);
-} /* end Test_CF_CmdCancel_Success */
+}
 
 void Test_CF_CmdCancel_Failure(void)
 {
@@ -1545,7 +1508,7 @@ void Test_CF_CmdCancel_Failure(void)
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CANCEL_CHAN);
-} /* end Test_CF_CmdCancel_Failure */
+}
 
 /*******************************************************************************
 **
@@ -1572,8 +1535,7 @@ void Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void
     UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == 0,
                   "CF_CFDP_CancelTransaction was called with int %d and should be 0 (constant in call)",
                   context_CF_CFDP_ResetTransaction.keep_history);
-
-} /* end Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0 */
+}
 
 /*******************************************************************************
 **
@@ -1599,7 +1561,7 @@ void Test_CF_CmdAbandon_Success(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ABANDON);
-} /* end Test_CF_CmdAbandon_Success */
+}
 
 void Test_CF_CmdAbandon_Failure(void)
 {
@@ -1618,7 +1580,7 @@ void Test_CF_CmdAbandon_Failure(void)
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ABANDON_CHAN);
-} /* end Test_CF_CmdAbandon_Failure */
+}
 
 /*******************************************************************************
 **
@@ -1646,8 +1608,7 @@ void Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg(void
     UtAssert_True(CF_AppData.config_table->chan[arg_chan_num].dequeue_enabled == dummy_context.barg,
                   "Channel %u dequeue_enabled is %u and should be %u (context->barg)", arg_chan_num,
                   CF_AppData.config_table->chan[arg_chan_num].dequeue_enabled, dummy_context.barg);
-
-} /* end Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg */
+}
 
 /*******************************************************************************
 **
@@ -1693,7 +1654,7 @@ void Test_CF_CmdEnableDequeue_Success(void)
                   CF_AppData.hk.counters.cmd, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_DEQUEUE);
-} /* end Test_CF_CmdEnableDequeue_Success */
+}
 
 void Test_CF_CmdEnableDequeue_Failure(void)
 {
@@ -1722,7 +1683,7 @@ void Test_CF_CmdEnableDequeue_Failure(void)
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_DEQUEUE);
-} /* end Test_CF_CmdEnableDequeue_Failure */
+}
 
 /*******************************************************************************
 **
@@ -1767,7 +1728,7 @@ void Test_CF_CmdDisableDequeue_Success(void)
                   initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_DEQUEUE);
-} /* end Test_CF_CmdDisableDequeue_Success */
+}
 
 void Test_CF_CmdDisableDequeue_Failure(void)
 {
@@ -1796,7 +1757,7 @@ void Test_CF_CmdDisableDequeue_Failure(void)
     /* Assert for CF_DoFreezeThaw */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_DEQUEUE);
-} /* end Test_CF_CmdDisableDequeue_Failure */
+}
 
 /*******************************************************************************
 **
@@ -1841,7 +1802,7 @@ void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannel
     }
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 0, "CF_DoEnableDisablePolldir returned %d and should be 0", local_result);
-} /* end Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannelEnabledTo_context_barg */
+}
 
 void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg(void)
 {
@@ -1876,7 +1837,7 @@ void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_conte
                   CF_AppData.config_table->chan[arg_chan_num].polldir[dummy_polldir].enabled, expected_enabled);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 0, "CF_DoEnableDisablePolldir returned %d and should be 0", local_result);
-} /* end Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg */
+}
 
 void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent(void)
 {
@@ -1905,7 +1866,7 @@ void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_An
     UT_CF_AssertEventID(CF_EID_ERR_CMD_POLLDIR_INVALID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_True(local_result == -1, "CF_DoEnableDisablePolldir returned %d and should be -1", local_result);
-} /* end Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent */
+}
 
 void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
 {
@@ -1934,7 +1895,7 @@ void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
     UT_CF_AssertEventID(CF_EID_ERR_CMD_POLLDIR_INVALID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_True(local_result == -1, "CF_DoEnableDisablePolldir returned %d and should be -1", local_result);
-} /* end Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent */
+}
 
 /*******************************************************************************
 **
@@ -1980,7 +1941,7 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
                   initial_hk_cmd_counter);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_POLLDIR);
-} /* end Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess */
+}
 
 void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
 {
@@ -2013,9 +1974,7 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_POLLDIR);
-} /* end Test_CF_CmdEnablePolldir_FailWhenActionFail */
-
-/* end */
+}
 
 /*******************************************************************************
 **
@@ -2061,7 +2020,7 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
                   initial_hk_cmd_counter);
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_POLLDIR);
-} /* end Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess */
+}
 
 void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
 {
@@ -2094,7 +2053,7 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_POLLDIR);
-} /* end Test_CF_CmdDisablePolldir_FailWhenActionFail */
+}
 
 /*******************************************************************************
 **
@@ -2123,8 +2082,7 @@ void Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT(void)
     UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetHistory.h, &dummy_h);
     UtAssert_True(local_result == CF_CLIST_CONT, "CF_PurgeHistory returned %d and should be %d (CF_CLIST_CONT)",
                   local_result, CF_CLIST_CONT);
-
-} /* end Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT */
+}
 
 /*******************************************************************************
 **
@@ -2155,8 +2113,7 @@ void Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT
                   context_CF_CFDP_ResetTransaction.keep_history);
     UtAssert_True(local_result == CF_CLIST_CONT, "CF_PurgeHistory returned %d and should be %d (CF_CLIST_CONT)",
                   local_result, CF_CLIST_CONT);
-
-} /* end Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT */
+}
 
 /*******************************************************************************
 **
@@ -2197,7 +2154,7 @@ void Test_CF_DoPurgeQueue_PendOnly(void)
                   "context_CF_CList_Traverse.fn ==  CF_PurgeTransaction");
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, NULL);
     UtAssert_True(local_result == 0, "CF_DoPurgeQueue returned %d and should be 0", local_result);
-} /* end Test_CF_DoPurgeQueue_PendOnly */
+}
 
 void Test_CF_DoPurgeQueue_HistoryOnly(void)
 {
@@ -2234,7 +2191,7 @@ void Test_CF_DoPurgeQueue_HistoryOnly(void)
                   "context_CF_CList_Traverse.fn ==  (CF_CListFn_t )CF_PurgeHistory");
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, dummy_c);
     UtAssert_True(local_result == 0, "CF_DoPurgeQueue returned %d and should be 0", local_result);
-} /* end Test_CF_DoPurgeQueue_HistoryOnly */
+}
 
 void Test_CF_DoPurgeQueue_Both(void)
 {
@@ -2279,7 +2236,7 @@ void Test_CF_DoPurgeQueue_Both(void)
                   "context_CF_CList_Traverse[1].fn ==  (CF_CListFn_t )CF_PurgeHistory");
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[1].context, dummy_c);
     UtAssert_True(local_result == 0, "CF_DoPurgeQueue returned %d and should be 0", local_result);
-} /* end Test_CF_DoPurgeQueue_Both */
+}
 
 void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
 {
@@ -2303,7 +2260,7 @@ void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_ARG);
     UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
-} /* end Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1 */
+}
 
 void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
 {
@@ -2327,7 +2284,7 @@ void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_ARG);
     UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
-} /* end Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1 */
+}
 
 /*******************************************************************************
 **
@@ -2424,7 +2381,7 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectCommand */
+}
 
 void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand(void)
 {
@@ -2451,7 +2408,7 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand */
+}
 
 void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
 {
@@ -2482,7 +2439,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_IsNot_q_pend_SendEventAndRejectCommand(
     void)
@@ -2525,9 +2482,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_IsNot_q_pend_SendEventAndRejectCommand
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_queue_Is_q_pend_SendEventAndRejectCommand(
     void)
@@ -2571,9 +2526,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_queue_Is_q_pend_SendEventAndRejectCommand
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails(
     void)
@@ -2624,9 +2577,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand(
     void)
@@ -2681,9 +2632,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
     void)
@@ -2738,9 +2687,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(void)
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
     void)
@@ -2795,9 +2742,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
     void)
@@ -2854,9 +2799,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsPend_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
     void)
@@ -2911,9 +2854,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsPend_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(void)
-   */
+}
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
     void)
@@ -2968,9 +2909,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-} /* end
-     Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(void)
-   */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
 {
@@ -3023,8 +2962,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
 {
@@ -3072,8 +3010,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
 {
@@ -3121,8 +3058,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
 {
@@ -3170,8 +3106,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
 {
@@ -3224,8 +3159,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
 {
@@ -3273,8 +3207,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
 {
@@ -3322,8 +3255,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active */
+}
 
 /* Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Pend IS an error and is handled by a previous test */
 
@@ -3373,8 +3305,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
 {
@@ -3422,8 +3353,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
 {
@@ -3471,8 +3401,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active */
+}
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
 {
@@ -3520,10 +3449,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend */
-
-/* end CF_CmdWriteQueue tests */
+}
 
 /*******************************************************************************
 **
@@ -3543,8 +3469,7 @@ void Test_CF_CmdValidateChunkSize_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(
 
     /* Assert */
     UtAssert_True(local_result == 1, "CF_CmdValidateChunkSize returned %d and should be 1 (failed)", local_result);
-
-} /* end Test_CF_CmdValidateChunkSize_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1 */
+}
 
 void Test_CF_CmdValidateChunkSize_Any_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(void)
 {
@@ -3558,8 +3483,7 @@ void Test_CF_CmdValidateChunkSize_Any_val_GreaterThan_pdu_fd_data_t_FailAndRetur
 
     /* Assert */
     UtAssert_True(local_result == 1, "CF_CmdValidateChunkSize returned %d and should be 1 (failed)", local_result);
-
-} /* end Test_CF_CmdValidateChunkSize_Any_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1 */
+}
 
 void Test_CF_CmdValidateChunkSize_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0(void)
 {
@@ -3573,8 +3497,7 @@ void Test_CF_CmdValidateChunkSize_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0(vo
 
     /* Assert */
     UtAssert_True(local_result == 0, "CF_CmdValidateChunkSize returned %d and should be 0 (success)", local_result);
-
-} /* end Test_CF_CmdValidateChunkSize_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0 */
+}
 
 void Test_CF_CmdValidateChunkSize_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0(void)
 {
@@ -3588,8 +3511,7 @@ void Test_CF_CmdValidateChunkSize_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAn
 
     /* Assert */
     UtAssert_True(local_result == 0, "CF_CmdValidateChunkSize returned %d and should be 0 (success)", local_result);
-
-} /* end Test_CF_CmdValidateChunkSize_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0 */
+}
 
 /*******************************************************************************
 **
@@ -3612,8 +3534,7 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_IsNot_0_Return_0_Success(void)
 
     /* Assert */
     UtAssert_True(local_result == 0, "CF_CmdValidateMaxOutgoing returned %d and should be 0 (Success)", local_result);
-
-} /* end Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_IsNot_0_Return_0_Success */
+}
 
 void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_Return_0_Success(void)
 {
@@ -3631,8 +3552,7 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_R
 
     /* Assert */
     UtAssert_True(local_result == 0, "CF_CmdValidateMaxOutgoing returned %d and should be 0 (Success)", local_result);
-
-} /* end Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_Return_0_Success */
+}
 
 void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail(void)
 {
@@ -3650,10 +3570,7 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Retu
 
     /* Assert */
     UtAssert_True(local_result == 1, "CF_CmdValidateMaxOutgoing returned %d and should be 1 (Success)", local_result);
-
-} /* end Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail */
-
-/* end CF_CmdValidateMaxOutgoing tests */
+}
 
 /*******************************************************************************
 **
@@ -3727,8 +3644,6 @@ void Test_CF_CmdGetSetParam(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
 }
 
-/* end CF_CmdGetSetParam tests */
-
 /*******************************************************************************
 **
 **  CF_CmdSetParam tests
@@ -3759,10 +3674,7 @@ void Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value(void)
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET1);
     /* Assert for incremented counter() */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
-
-} /* end Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value */
-
-/* end CF_CmdSetParam tests */
+}
 
 /*******************************************************************************
 **
@@ -3793,8 +3705,7 @@ void Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstant
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET2);
     /* Assert for incremented counter() */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
-
-} /* end Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstantValue_0 */
+}
 
 /*******************************************************************************
 **
@@ -3827,8 +3738,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounter */
+}
 
 void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementErrCounter(void)
 {
@@ -3855,8 +3765,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementErrCounter */
+}
 
 void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounter(void)
 {
@@ -3880,8 +3789,7 @@ void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounte
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_ENA);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounter */
+}
 
 /*******************************************************************************
 **
@@ -3910,8 +3818,7 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-
-} /* end Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter */
+}
 
 void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(void)
 {
@@ -3936,10 +3843,7 @@ void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(v
     UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
                   initial_hk_err_counter);
-
-} /* end Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail */
-
-/* end CF_CmdDisableEngine tests */
+}
 
 /*******************************************************************************
 **
@@ -3970,8 +3874,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_EqTo_CF_NUM_COMMANDS_FailAndSendEvent
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
-
-} /* end Test_CF_ProcessGroundCommand_When_cmd_EqTo_CF_NUM_COMMANDS_FailAndSendEvent */
+}
 
 void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSendEvent(void)
 {
@@ -3996,8 +3899,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSe
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
-
-} /* end Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSendEvent */
+}
 
 void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForThatCommandSendEventAndFailure(void)
 {
@@ -4024,9 +3926,7 @@ void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForT
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_LEN);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
-
-} /* end Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForThatCommandSendEventAndFailure
-   */
+}
 
 void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_msg(void)
 {
@@ -4054,8 +3954,7 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_m
     UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
-
-} /* end Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_msg */
+}
 
 /* Hit a NULL entry to exercise that conditional and no action */
 void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x0C_AndDoNothingBecause_fns_12_Is_NULL(void)
@@ -4082,9 +3981,7 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x0C_AndDoNothingBecause_fns_1
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 0);
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 0);
-} /* end Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x0C_AndDoNothingBecause_fns_12_Is_NULL */
-
-/* end CF_ProcessGroundCommand tests */
+}
 
 /*******************************************************************************
 **
@@ -4096,7 +3993,7 @@ void add_CF_CmdNoop_tests(void)
 {
     UtTest_Add(Test_CF_CmdNoop_SendNoopEventAndAcceptCommand, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdNoop_SendNoopEventAndAcceptCommand");
-} /* end add_CF_CmdNoop_tests */
+}
 
 void add_CF_CmdReset_tests(void)
 {
@@ -4119,17 +4016,17 @@ void add_CF_CmdReset_tests(void)
                "Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEventAcceptCommand");
     UtTest_Add(Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent");
-} /* end add_CF_CmdReset_tests */
+}
 
 void add_CF_CmdTxFile_tests(void)
 {
     UtTest_Add(Test_CF_CmdTxFile, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "CF_CmdTxFile");
-} /* end add_CF_CmdTxFile_tests */
+}
 
 void add_CF_CmdPlaybackDir_tests(void)
 {
     UtTest_Add(Test_CF_CmdPlaybackDir, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "CF_CmdPlaybackDir");
-} /* end add_CF_CmdPlaybackDir_tests */
+}
 
 void add_CF_DoChanAction_tests(void)
 {
@@ -4148,13 +4045,13 @@ void add_CF_DoChanAction_tests(void)
                "Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendEvent_");
     UtTest_Add(Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent");
-} /* end add_CF_DoChanAction_tests */
+}
 
 void add_CF_DoFreezeThaw_tests(void)
 {
     UtTest_Add(Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0");
-} /* end add_CF_DoFreezeThaw_tests */
+}
 
 void add_CF_CmdFreeze_tests(void)
 {
@@ -4162,7 +4059,7 @@ void add_CF_CmdFreeze_tests(void)
                "Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand");
     UtTest_Add(Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand");
-} /* end add_CF_CmdFreeze_tests */
+}
 
 void add_CF_CmdThaw_tests(void)
 {
@@ -4170,7 +4067,7 @@ void add_CF_CmdThaw_tests(void)
                "Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand");
     UtTest_Add(Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand");
-} /* end add_CF_CmdThaw_tests */
+}
 
 void add_CF_FindTransactionBySequenceNumberAllChannels_tests(void)
 {
@@ -4179,7 +4076,7 @@ void add_CF_FindTransactionBySequenceNumberAllChannels_tests(void)
                "Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundReturn_NULL");
     UtTest_Add(Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound");
-} /* end add_CF_FindTransactionBySequenceNumberAllChannels_tests */
+}
 
 void add_CF_TsnChanAction_tests(void)
 {
@@ -4196,7 +4093,7 @@ void add_CF_TsnChanAction_tests(void)
                "Test_CF_TsnChanAction_cmd_chan_IsASingleChannel");
     UtTest_Add(Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid");
-} /* end add_CF_TsnChanAction_tests */
+}
 
 void add_CF_DoSuspRes_Txn_tests(void)
 {
@@ -4204,54 +4101,54 @@ void add_CF_DoSuspRes_Txn_tests(void)
                cf_cmd_tests_Teardown, "Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action");
     UtTest_Add(Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action");
-} /* end add_CF_DoSuspRes_Txn_tests */
+}
 
 void add_CF_DoSuspRes_tests(void)
 {
     UtTest_Add(Test_CF_DoSuspRes, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "CF_DoSuspRes");
-} /* end add_CF_DoSuspRes_tests */
+}
 
 void add_CF_CmdSuspend_tests(void)
 {
     UtTest_Add(Test_CF_CmdSuspend_Call_CF_DoSuspRes_WithGiven_msg_And_action_1, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdSuspend_Call_CF_DoSuspRes_WithGiven_msg_And_action_1");
-} /* end add_CF_CmdSuspend_tests */
+}
 
 void add_CF_CmdResume_tests(void)
 {
     UtTest_Add(Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0");
-} /* end add_CF_CmdResume_tests */
+}
 
 void add_CF_CmdCancel_Txn_tests(void)
 {
     UtTest_Add(Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t");
-} /* end add_CF_CF_CmdCancel_Txn_tests */
+}
 
 void add_CF_CmdCancel_tests(void)
 {
     UtTest_Add(Test_CF_CmdCancel_Failure, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_CmdCancel_Failure");
     UtTest_Add(Test_CF_CmdCancel_Success, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_CmdCancel_Success");
-} /* end add_CF_CmdCancel_tests */
+}
 
 void add_CF_CmdAbandon_Txn_tests(void)
 {
     UtTest_Add(Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0");
-} /* end add_CF_CmdAbandon_Txn_tests */
+}
 
 void add_CF_CmdAbandon_tests(void)
 {
     UtTest_Add(Test_CF_CmdAbandon_Failure, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_CmdAbandon_Failure");
     UtTest_Add(Test_CF_CmdAbandon_Success, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_CmdAbandon_Success");
-} /* end add_CF_CmdAbandon_Txn_tests */
+}
 
 void add_CF_DoEnableDisableDequeue_tests(void)
 {
     UtTest_Add(Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg");
-} /* end add_CF_DoEnableDisableDequeue_tests */
+}
 
 void add_CF_CmdEnableDequeue_tests(void)
 {
@@ -4259,7 +4156,7 @@ void add_CF_CmdEnableDequeue_tests(void)
                "Test_CF_CmdEnableDequeue_Success");
     UtTest_Add(Test_CF_CmdEnableDequeue_Failure, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdEnableDequeue_Failure");
-} /* end add_CF_CmdEnableDequeue_tests */
+}
 
 void add_CF_CmdDisableDequeue_tests(void)
 {
@@ -4267,7 +4164,7 @@ void add_CF_CmdDisableDequeue_tests(void)
                "Test_CF_CmdDisableDequeue_Success");
     UtTest_Add(Test_CF_CmdDisableDequeue_Failure, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdDisableDequeue_Failure");
-} /* end add_CF_CmdDisableDequeue_tests */
+}
 
 void add_CF_DoEnableDisablePolldir_tests(void)
 {
@@ -4283,7 +4180,7 @@ void add_CF_DoEnableDisablePolldir_tests(void)
                "Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent");
     UtTest_Add(Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent");
-} /* end add_CF_DoEnableDisablePolldir_tests */
+}
 
 void add_CF_CmdEnablePolldir_tests(void)
 {
@@ -4291,7 +4188,7 @@ void add_CF_CmdEnablePolldir_tests(void)
                "Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess");
     UtTest_Add(Test_CF_CmdEnablePolldir_FailWhenActionFail, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdEnablePolldir_FailWhenActionFail");
-} /* end add_CF_CmdEnablePolldir_tests */
+}
 
 void add_CF_CmdDisablePolldir_tests(void)
 {
@@ -4299,19 +4196,19 @@ void add_CF_CmdDisablePolldir_tests(void)
                "Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess");
     UtTest_Add(Test_CF_CmdDisablePolldir_FailWhenActionFail, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdDisablePolldir_FailWhenActionFail");
-} /* end add_CF_CmdDisablePolldir_tests */
+}
 
 void add_CF_PurgeHistory_tests(void)
 {
     UtTest_Add(Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT");
-} /* end add_CF_PurgeHistory_tests */
+}
 
 void add_CF_PurgeTransaction_tests(void)
 {
     UtTest_Add(Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT");
-} /* end add_CF_PurgeTransaction_tests */
+}
 
 void add_CF_DoPurgeQueue_tests(void)
 {
@@ -4324,7 +4221,7 @@ void add_CF_DoPurgeQueue_tests(void)
                cf_cmd_tests_Teardown, "Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1");
     UtTest_Add(Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1");
-} /* end add_CF_DoPurgeQueue_tests */
+}
 
 void add_CF_CmdPurgeQueue_tests(void)
 {
@@ -4332,7 +4229,7 @@ void add_CF_CmdPurgeQueue_tests(void)
                "Test_CF_CmdPurgeQueue_FailWhenActionFail");
     UtTest_Add(Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess");
-} /* end add_CF_CmdPurgeQueue_tests */
+}
 
 void add_CF_CmdWriteQueue_tests(void)
 {
@@ -4412,7 +4309,7 @@ void add_CF_CmdWriteQueue_tests(void)
                "Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active");
     UtTest_Add(Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
                "Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend");
-} /* end add_CF_CmdWriteQueue_tests */
+}
 
 void add_CF_CmdValidateChunkSize_tests(void)
 {
@@ -4425,7 +4322,7 @@ void add_CF_CmdValidateChunkSize_tests(void)
     UtTest_Add(Test_CF_CmdValidateChunkSize_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_CmdValidateChunkSize_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0");
-} /* end add_CF_CmdValidateChunkSize_tests */
+}
 
 void add_CF_CmdValidateMaxOutgoing_tests(void)
 {
@@ -4437,25 +4334,25 @@ void add_CF_CmdValidateMaxOutgoing_tests(void)
     UtTest_Add(Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail");
-} /* end add_CF_CmdValidateMaxOutgoing_tests */
+}
 
 void add_CF_CmdGetSetParam_tests(void)
 {
     UtTest_Add(Test_CF_CmdGetSetParam, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "CF_CmdGetSetParam");
-} /* end add_CF_CmdGetSetParam_tests */
+}
 
 void add_CF_CmdSetParam_tests(void)
 {
     UtTest_Add(Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value");
-} /* end add_CF_CmdSetParam_tests */
+}
 
 void add_CF_CmdGetParam_tests(void)
 {
     UtTest_Add(Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstantValue_0, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstantValue_0");
-} /* end add_CF_CmdGetParam_tests */
+}
 
 void add_CF_CmdEnableEngine_tests(void)
 {
@@ -4466,7 +4363,7 @@ void add_CF_CmdEnableEngine_tests(void)
                "Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementErrCounter");
     UtTest_Add(Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounter, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounter");
-} /* end add_CF_CmdEnableEngine_tests */
+}
 
 void add_CF_CmdDisableEngine_tests(void)
 {
@@ -4474,7 +4371,7 @@ void add_CF_CmdDisableEngine_tests(void)
                cf_cmd_tests_Teardown, "Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter");
     UtTest_Add(Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown, "Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail");
-} /* end add_CF_CmdDisableEngine_tests */
+}
 
 void add_CF_ProcessGroundCommand_tests(void)
 {
@@ -4492,9 +4389,7 @@ void add_CF_ProcessGroundCommand_tests(void)
     UtTest_Add(Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x0C_AndDoNothingBecause_fns_12_Is_NULL, cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x0C_AndDoNothingBecause_fns_12_Is_NULL");
-} /* end add_CF_ProcessGroundCommand_tests */
-
-/* end cf_cmd tests UtTest_Add groups */
+}
 
 /*******************************************************************************
 **
@@ -4579,7 +4474,4 @@ void UtTest_Setup(void)
     add_CF_CmdDisableEngine_tests();
 
     add_CF_ProcessGroundCommand_tests();
-
-} /* end UtTest_Setup for cf_cmd_tests.c */
-
-/* end cf_cmd_tests.c */
+}

--- a/unit-test/cf_codec_tests.c
+++ b/unit-test/cf_codec_tests.c
@@ -200,6 +200,7 @@ void Test_CF_CFDP_EncodeFileDirectiveHeader(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeLV(void)
 {
     /* Test for:
@@ -252,6 +253,7 @@ void Test_CF_CFDP_EncodeLV(void)
     UtAssert_UINT32_EQ(CF_CODEC_GET_POSITION(&state), sizeof(expected_nodata));
     UtAssert_MemCmp(bytes, expected_nodata, sizeof(expected_nodata), "Encoded Bytes");
 }
+
 void Test_CF_CFDP_EncodeTLV(void)
 {
     /* Test for:
@@ -316,6 +318,7 @@ void Test_CF_CFDP_EncodeTLV(void)
     UtAssert_UINT32_EQ(CF_CODEC_GET_POSITION(&state), sizeof(expected_nodata));
     UtAssert_MemCmp(bytes, expected_nodata, sizeof(expected_nodata), "Encoded Bytes");
 }
+
 void Test_CF_CFDP_EncodeSegmentRequest(void)
 {
     /* Test for:
@@ -347,6 +350,7 @@ void Test_CF_CFDP_EncodeSegmentRequest(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeAllTlv(void)
 {
     /* Test for:
@@ -388,6 +392,7 @@ void Test_CF_CFDP_EncodeAllTlv(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeAllSegments(void)
 {
     /* Test for:
@@ -428,6 +433,7 @@ void Test_CF_CFDP_EncodeAllSegments(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeMd(void)
 {
     /* Test for:
@@ -462,6 +468,7 @@ void Test_CF_CFDP_EncodeMd(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeFileDataHeader(void)
 {
     /* Test for:
@@ -508,6 +515,7 @@ void Test_CF_CFDP_EncodeFileDataHeader(void)
     UtAssert_UINT32_EQ(CF_CODEC_GET_POSITION(&state), sizeof(expected_meta));
     UtAssert_MemCmp(bytes, expected_meta, sizeof(expected_meta), "Encoded Bytes");
 }
+
 void Test_CF_CFDP_EncodeEof(void)
 {
     /* Test for:
@@ -544,6 +552,7 @@ void Test_CF_CFDP_EncodeEof(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeFin(void)
 {
     /* Test for:
@@ -576,6 +585,7 @@ void Test_CF_CFDP_EncodeFin(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeAck(void)
 {
     /* Test for:
@@ -609,6 +619,7 @@ void Test_CF_CFDP_EncodeAck(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeNak(void)
 {
     /* Test for:
@@ -646,6 +657,7 @@ void Test_CF_CFDP_EncodeNak(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_CFDP_EncodeCrc(void)
 {
     /* Test for:
@@ -676,6 +688,7 @@ void Test_CF_CFDP_EncodeCrc(void)
     UtAssert_MemCmp(bytes, expected, sizeof(expected), "Encoded Bytes");
     UtAssert_MemCmpValue(bytes + sizeof(expected), 0xEE, sizeof(bytes) - sizeof(expected), "Remainder unchanged");
 }
+
 void Test_CF_DecodeIntegerInSize(void)
 {
     /* Test for:
@@ -707,6 +720,7 @@ void Test_CF_DecodeIntegerInSize(void)
     UtAssert_BOOL_TRUE(CF_CODEC_IS_OK(&state));
     UtAssert_UINT32_EQ(CF_CODEC_GET_POSITION(&state), sizeof(bytes_4));
 }
+
 void Test_CF_CFDP_DecodeHeader(void)
 {
     /* Test for:
@@ -756,6 +770,7 @@ void Test_CF_CFDP_DecodeHeader(void)
     UT_CF_SetupDecodeState(&state, bad_tsn, sizeof(bad_tsn));
     UtAssert_INT32_EQ(CF_CFDP_DecodeHeader(&state, &out), -1);
 }
+
 void Test_CF_CFDP_DecodeFileDirectiveHeader(void)
 {
     /* Test for:
@@ -781,6 +796,7 @@ void Test_CF_CFDP_DecodeFileDirectiveHeader(void)
     UtAssert_UINT32_EQ(CF_CODEC_GET_POSITION(&state), sizeof(bytes));
     UtAssert_UINT32_EQ(out.directive_code, CF_CFDP_FileDirective_NAK);
 }
+
 void Test_CF_CFDP_DecodeLV(void)
 {
     /* Test for:
@@ -813,6 +829,7 @@ void Test_CF_CFDP_DecodeLV(void)
     CF_CFDP_DecodeLV(&state, &out);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(&state));
 }
+
 void Test_CF_CFDP_DecodeTLV(void)
 {
     /* Test for:
@@ -856,6 +873,7 @@ void Test_CF_CFDP_DecodeTLV(void)
     CF_CFDP_DecodeTLV(&state, &out);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(&state));
 }
+
 void Test_CF_CFDP_DecodeSegmentRequest(void)
 {
     /* Test for:
@@ -882,6 +900,7 @@ void Test_CF_CFDP_DecodeSegmentRequest(void)
     UtAssert_UINT32_EQ(out.offset_start, 0x11223344);
     UtAssert_UINT32_EQ(out.offset_end, 0x55667788);
 }
+
 void Test_CF_CFDP_DecodeAllTlv(void)
 {
     /* Test for:
@@ -936,6 +955,7 @@ void Test_CF_CFDP_DecodeAllTlv(void)
     CF_CFDP_DecodeAllTlv(&state, &out, 1 + CF_PDU_MAX_TLV);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(&state));
 }
+
 void Test_CF_CFDP_DecodeAllSegments(void)
 {
     /* Test for:
@@ -982,6 +1002,7 @@ void Test_CF_CFDP_DecodeAllSegments(void)
     CF_CFDP_DecodeAllSegments(&state, &out, 1 + CF_PDU_MAX_SEGMENTS);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(&state));
 }
+
 void Test_CF_CFDP_DecodeMd(void)
 {
     /* Test for:
@@ -1017,6 +1038,7 @@ void Test_CF_CFDP_DecodeMd(void)
     CF_CFDP_DecodeMd(&state, &out);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(&state));
 }
+
 void Test_CF_CFDP_DecodeFileDataHeader(void)
 {
     /* Test for:
@@ -1071,6 +1093,7 @@ void Test_CF_CFDP_DecodeFileDataHeader(void)
     CF_CFDP_DecodeFileDataHeader(&state, true, &out);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(&state));
 }
+
 void Test_CF_CFDP_DecodeEof(void)
 {
     /* Test for:
@@ -1108,6 +1131,7 @@ void Test_CF_CFDP_DecodeEof(void)
     CF_CFDP_DecodeEof(&state, &out);
     UtAssert_BOOL_FALSE(CF_CODEC_IS_OK(&state));
 }
+
 void Test_CF_CFDP_DecodeFin(void)
 {
     /* Test for:
@@ -1135,6 +1159,7 @@ void Test_CF_CFDP_DecodeFin(void)
     UtAssert_UINT32_EQ(out.delivery_code, 1);
     UtAssert_UINT32_EQ(out.file_status, 2);
 }
+
 void Test_CF_CFDP_DecodeAck(void)
 {
     /* Test for:
@@ -1163,6 +1188,7 @@ void Test_CF_CFDP_DecodeAck(void)
     UtAssert_UINT32_EQ(out.cc, 2);
     UtAssert_UINT32_EQ(out.txn_status, 3);
 }
+
 void Test_CF_CFDP_DecodeNak(void)
 {
     /* Test for:
@@ -1195,6 +1221,7 @@ void Test_CF_CFDP_DecodeNak(void)
     UtAssert_UINT32_EQ(out.segment_list.segments[1].offset_start, 0x7);
     UtAssert_UINT32_EQ(out.segment_list.segments[1].offset_end, 0x8);
 }
+
 void Test_CF_CFDP_DecodeCrc(void)
 {
     /* Test for:
@@ -1278,7 +1305,4 @@ void UtTest_Setup(void)
 
     Add_CF_Encode_tests();
     Add_CF_Decode_tests();
-
-} /* end UtTest_Setup for cf_codec_tests.c */
-
-/* end cf_codec_tests.c */
+}

--- a/unit-test/cf_timer_tests.c
+++ b/unit-test/cf_timer_tests.c
@@ -30,14 +30,12 @@
 void cf_timer_tests_Setup(void)
 {
     cf_tests_Setup();
-} /* end cf_timer_tests_Setup */
+}
 
 void cf_timer_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_timer_tests_Teardown */
-
-/* end cf_timer_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -57,10 +55,7 @@ void Test_CF_Timer_Sec2Ticks_ReturnExpectedValue(void)
 
     /* Act */
     UtAssert_UINT32_EQ(CF_Timer_Sec2Ticks(arg_sec), arg_sec * dummy_ticks_per_second);
-
-} /* end Test_CF_Timer_Sec2Ticks_ReturnExpectedValue */
-
-/* end CF_Timer_Sec2Ticks tests */
+}
 
 /*******************************************************************************
 **
@@ -89,9 +84,7 @@ void Test_CF_Timer_InitRelSec_ReceiveExpectedValue(void)
 
     /* Assert */
     UtAssert_UINT32_EQ(arg_t->tick, arg_rel_sec * dummy_ticks_per_second);
-} /* end Test_CF_Timer_InitRelSec_ReceiveExpectedValue */
-
-/* end CF_Timer_InitRelSec tests */
+}
 
 /*******************************************************************************
 **
@@ -109,8 +102,7 @@ void Test_CF_Timer_Expired_When_t_tick_Is_0_Return_1(void)
 
     /* Act */
     UtAssert_INT32_EQ(CF_Timer_Expired(arg_t), expected_result);
-
-} /* end Test_CF_Timer_Expired_When_t_tick_Is_0_Return_1 */
+}
 
 void Test_CF_Timer_Expired_When_t_tick_Is_1_Return_0(void)
 {
@@ -122,8 +114,7 @@ void Test_CF_Timer_Expired_When_t_tick_Is_1_Return_0(void)
 
     /* Act */
     UtAssert_INT32_EQ(CF_Timer_Expired(arg_t), expected_result);
-
-} /* end Test_CF_Timer_Expired_When_t_tick_Is_1_Return_0 */
+}
 
 void Test_CF_Timer_Expired_When_t_tick_IsAnyIntegerExcept_0_Return_0(void)
 {
@@ -135,9 +126,7 @@ void Test_CF_Timer_Expired_When_t_tick_IsAnyIntegerExcept_0_Return_0(void)
 
     /* Act */
     UtAssert_INT32_EQ(CF_Timer_Expired(arg_t), expected_result);
-} /* end Test_CF_Timer_Expired_When_t_tick_IsAnyIntegerExcept_0_Return_0 */
-
-/* end CF_Timer_Expired tests */
+}
 
 /*******************************************************************************
 **
@@ -159,10 +148,7 @@ void Test_CF_Timer_Tick_When_t_tick_Is_non0_Decrement_t_tick(void)
 
     /* Assert */
     UtAssert_UINT32_EQ(arg_t->tick, initial_tick - 1);
-
-} /* Test_CF_Timer_Tick_When_t_tick_Is_non0_Decrement_t_tick */
-
-/* end CF_Timer_Tick tests */
+}
 
 /*******************************************************************************
 **
@@ -200,8 +186,6 @@ void add_CF_Timer_Tick_tests(void)
                "Test_CF_Timer_Tick_When_t_tick_Is_non0_Decrement_t_tick");
 }
 
-/* end cf_timer_tests UtTest_Add groups */
-
 /*******************************************************************************
 **
 **  cf_timer_tests test UtTest_Setup
@@ -219,7 +203,4 @@ void UtTest_Setup(void)
     add_CF_Timer_Expired_tests();
 
     add_CF_Timer_Tick_tests();
-
-} /* end UtTest_Setup cf_timer_tests.c */
-
-/* end cf_timer_tests.c */
+}

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -41,14 +41,12 @@ typedef struct
 void cf_utils_tests_Setup(void)
 {
     cf_tests_Setup();
-} /* end cf_utils_tests_Setup */
+}
 
 void cf_utils_tests_Teardown(void)
 {
     cf_tests_Teardown();
-} /* end cf_utils_tests_Teardown */
-
-/* end cf_utils_tests Setup and Teardown */
+}
 
 /*******************************************************************************
 **
@@ -87,8 +85,6 @@ void local_handler_OS_close(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubC
 
 /*----------------------------------------------------------------
  *
- * Function: UT_Callback_CF_TraverseAllTransactions
- *
  * A UT-specific callback that can be used with CF_TraverseAllTransactions
  *
  *-----------------------------------------------------------------*/
@@ -105,8 +101,6 @@ static void UT_Callback_CF_TraverseAllTransactions(CF_Transaction_t *t, void *co
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_AltHandler_CF_CList_Traverse_SeqArg_SetTxn
  *
  * A simple handler that just sets the "t" output in the state object
  *
@@ -289,10 +283,7 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
     UtAssert_ADDRESS_EQ(context_clist_remove.node, expected_cl_node);
     UtAssert_True(updated_q_size == initial_q_size - 1, "q_size is %d and that is 1 less than initial value %d",
                   updated_q_size, initial_q_size);
-
-} /* end Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size */
-
-/* end CF_DequeueTransaction tests */
+}
 
 /* CF_MoveTransaction tests */
 
@@ -340,9 +331,7 @@ void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(
     UtAssert_True(arg_t->flags.com.q_index == arg_q,
                   "t->flags.com.q_index set to %u and should equal passed in q value %u", arg_t->flags.com.q_index,
                   arg_q);
-} /* end Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q */
-
-/* end CF_MoveTransaction tests */
+}
 
 /* CF_CList_Remove_Ex tests */
 
@@ -376,9 +365,7 @@ void Test_CF_CList_Remove_Ex_Call_CF_CList_Remove_AndDecrement_q_size(void)
     UtAssert_ADDRESS_EQ(context_clist_remove.node, expected_remove_node);
     UtAssert_True(updated_q_size == initial_q_size - 1, "q_size is %d and that is 1 less than initial value %d",
                   updated_q_size, initial_q_size);
-} /* end Test_CF_CList_Remove_Ex_Call_CF_CList_Remove_AndDecrement_q_size */
-
-/* end CF_CList_Remove_Ex tests */
+}
 
 /* CF_CList_InsertAfter_Ex tests */
 
@@ -412,10 +399,7 @@ void Test_CF_CList_InsertAfter_Ex_Call_CF_CList_InsertAfter_AndIncrement_q_size(
     UtAssert_ADDRESS_EQ(context_CF_CList_InsertAfter.after, arg_after);
     UtAssert_True(updated_q_size == (uint16)(initial_q_size + 1),
                   "q_size is %d and that is 1 more than initial value %d", updated_q_size, initial_q_size);
-
-} /* end Test_CF_CList_InsertAfter_Ex_Call_CF_CList_InsertAfter_AndIncrement_q_size */
-
-/* end CF_CList_InsertAfter_Ex tests */
+}
 
 /* CF_CList_InsertBack_Ex tests */
 
@@ -449,12 +433,7 @@ void Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size(vo
     UtAssert_ADDRESS_EQ(context_clist_insert_back.node, expected_insert_back_node);
     UtAssert_True(updated_q_size == (uint16)(initial_q_size + 1),
                   "q_size is %d and that is 1 more than initial value %d", updated_q_size, initial_q_size);
-
-} /* end Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size */
-
-/* end CF_CList_InsertBack_Ex tests */
-
-/* end cf_utils.h function tests */
+}
 
 /*******************************************************************************
 **
@@ -502,7 +481,6 @@ void Test_CF_Traverse_WriteHistoryQueueEntryToFile(void)
     UtAssert_UINT32_EQ(args.counter, 2); /* no increment */
     UtAssert_BOOL_TRUE(args.error);
 }
-/* end CF_Traverse_WriteHistoryQueueEntryToFile tests */
 
 /*******************************************************************************
 **
@@ -535,8 +513,6 @@ void Test_CF_Traverse_WriteTxnQueueEntryToFile(void)
     UtAssert_UINT32_EQ(args.counter, 1); /* no increment */
     UtAssert_BOOL_TRUE(args.error);
 }
-
-/* end CF_Traverse_WriteTxnQueueEntryToFile tests */
 
 /*******************************************************************************
 **
@@ -595,8 +571,6 @@ void Test_CF_WriteTxnQueueDataToFile(void)
     UtAssert_STUB_COUNT(CF_CList_Traverse, 1);
 }
 
-/* end CF_WriteQueueDataToFile tests */
-
 /*******************************************************************************
 **
 **  CF_WriteHistoryQueueDataToFile tests
@@ -622,8 +596,6 @@ void Test_CF_WriteHistoryQueueDataToFile(void)
     UtAssert_STUB_COUNT(CF_CList_Traverse, 1);
 }
 
-/* end CF_WriteHistoryQueueDataToFile tests */
-
 /*******************************************************************************
 **
 **  CF_PrioSearch tests
@@ -647,8 +619,7 @@ void Test_CF_PrioSearch_When_t_PrioIsGreaterThanContextPrioReturn_CLIST_CONT(voi
 
     /* Assert */
     UtAssert_INT32_EQ(result, CF_CLIST_CONT);
-
-} /* end Test_CF_PrioSearch_When_t_PrioIsGreaterThanContextPrioReturn_CLIST_CONT */
+}
 
 void Test_CF_PrioSearch_When_t_PrioIsEqToContextPrio_Set_context_t_To_t_AndReturn_CLIST_EXIT(void)
 {
@@ -671,8 +642,7 @@ void Test_CF_PrioSearch_When_t_PrioIsEqToContextPrio_Set_context_t_To_t_AndRetur
     /* Assert */
     UtAssert_INT32_EQ(result, CF_CLIST_EXIT);
     UtAssert_ADDRESS_EQ(dummy_p.t, &dummy_t);
-
-} /* end Test_CF_PrioSearch_When_t_PrioIsEqToContextPrio_Set_context_t_To_t_AndReturn_CLIST_EXIT */
+}
 
 void Test_CF_PrioSearch_When_t_PrioIsLessThanContextPrio_Set_context_t_To_t_AndReturn_CLIST_EXIT(void)
 {
@@ -695,10 +665,7 @@ void Test_CF_PrioSearch_When_t_PrioIsLessThanContextPrio_Set_context_t_To_t_AndR
     /* Assert */
     UtAssert_INT32_EQ(result, CF_CLIST_EXIT);
     UtAssert_ADDRESS_EQ(dummy_p.t, &dummy_t);
-
-} /* end Test_CF_PrioSearch_When_t_PrioIsLessThanContextPrio_Set_context_t_To_t_AndReturn_CLIST_EXIT */
-
-/* end CF_PrioSearch tests */
+}
 
 /*******************************************************************************
 **
@@ -741,7 +708,7 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_ind
     UtAssert_True(arg_t->flags.com.q_index == arg_q,
                   "arg_t->flags.com.q_index set to %d and should be %d (CF_QueueIdx_t q)", arg_t->flags.com.q_index,
                   arg_q);
-} /* end Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_index_To_q */
+}
 
 void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(void)
 {
@@ -799,8 +766,7 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(voi
     UtAssert_ADDRESS_EQ(context_CF_CList_InsertAfter.after, (CF_CListNode_t *)expected_insert_after_after);
     UtAssert_True(arg_t->flags.com.q_index == arg_q, "t->flags.com.q_index is %u and should be %u (q)",
                   arg_t->flags.com.q_index, arg_q);
-
-} /* end Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q */
+}
 
 void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
 {
@@ -854,10 +820,7 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     UtAssert_ADDRESS_EQ(context_clist_insert_back.node, expected_insert_back_node);
     UtAssert_True(arg_t->flags.com.q_index == arg_q, "t->flags.com.q_index is %u and should be %u (q)",
                   arg_t->flags.com.q_index, arg_q);
-
-} /* end Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex */
-
-/* end CF_InsertSortPrio tests */
+}
 
 /*******************************************************************************
 **
@@ -903,8 +866,7 @@ void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_T
                   "CF_TraverseAllTransactions_Impl set args->counter to %d which is 1 more than initial value %d",
                   arg_args->counter, initial_args_counter);
     UtAssert_INT32_EQ(result, CF_CLIST_CONT);
-
-} /* end Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_ToCounter */
+}
 
 /*******************************************************************************
 **
@@ -959,7 +921,7 @@ void Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_ar
                       "CF_CList_Traverse context_counter[%u] is %d and should be %d (+1 from previous)", i,
                       contexts_cf_clist_traverse[i].context_counter, i + 1);
     }
-} /* end Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_args_counter */
+}
 
 /*******************************************************************************
 **
@@ -980,10 +942,7 @@ void Test_CF_TraverseAllTransactions_All_Channels_ReturnTotalTraversals(void)
 
     /* Act */
     UtAssert_INT32_EQ(CF_TraverseAllTransactions_All_Channels(arg_fn, arg_context), expected_result);
-
-} /* end Test_CF_TraverseAllTransactions_All_Channels_ReturnTotalTraversals */
-
-/* end CF_TraverseAllTransactions_All_Channels tests */
+}
 
 /*******************************************************************************
 **
@@ -1010,9 +969,7 @@ void Test_CF_WrappedOpen_Call_OS_OpenCreate_WithGivenArgumentsAndReturnItsReturn
     // /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_PerfLogAdd, 2);
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
-} /* end Test_CF_WrappedOpen_Call_OS_OpenCreate_WithGivenArgumentsAndReturnItsReturnValue */
-
-/* end CF_WrappedOpen tests */
+}
 
 /*******************************************************************************
 **
@@ -1032,7 +989,7 @@ void Test_CF_WrappedClose_DoNotReceive_OS_SUCCESS_From_OS_close_EventSent(void)
     UtAssert_STUB_COUNT(CFE_ES_PerfLogAdd, 2);
     UtAssert_STUB_COUNT(OS_close, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end Test_CF_WrappedClose_DoNotReceive_OS_SUCCESS_From_OS_close_EventSent */
+}
 
 void Test_CF_WrappedClose_Receive_OS_SUCCESS_From_OS_close_NoEventSent(void)
 {
@@ -1047,9 +1004,7 @@ void Test_CF_WrappedClose_Receive_OS_SUCCESS_From_OS_close_NoEventSent(void)
     UtAssert_STUB_COUNT(CFE_ES_PerfLogAdd, 2);
     UtAssert_STUB_COUNT(OS_close, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end Test_CF_WrappedClose_Receive_OS_SUCCESS_From_OS_close_NoEventSent */
-
-/* end CF_WrappedClose tests */
+}
 
 /*******************************************************************************
 **
@@ -1068,10 +1023,7 @@ void Test_CF_WrappedRead_CallsOS_read_WithGivenArgumentsAndReturnItsReturnValue(
 
     /* Act */
     UtAssert_INT32_EQ(CF_WrappedRead(UT_CF_OS_OBJID, arg_buf, arg_read_size), arg_read_size);
-
-} /* end Test_CF_WrappedRead_CallsOS_read_WithGivenArgumentsAndReturnItsReturnValue */
-
-/* end CF_WrappedRead tests */
+}
 
 /*******************************************************************************
 **
@@ -1091,10 +1043,7 @@ void Test_CF_WrappedWrite_Call_OS_write_WithGivenArgumentsAndReturnItsReturnValu
 
     /* Act */
     UtAssert_INT32_EQ(CF_WrappedWrite(UT_CF_OS_OBJID, arg_buf, test_write_size), expected_result);
-
-} /* end Test_CF_WrappedWrite_Call_OS_write_WithGivenArgumentsAndReturnItsReturnValue */
-
-/* end CF_WrappedWrite tests */
+}
 
 /*******************************************************************************
 **
@@ -1113,10 +1062,7 @@ void Test_CF_WrappedLseek_Call_OS_lseek_WithGivenArgumentsAndReturnItsReturnValu
 
     /* Act */
     UtAssert_INT32_EQ(CF_WrappedLseek(UT_CF_OS_OBJID, test_offset, test_mode), expected_result);
-
-} /* end Test_CF_WrappedLseek_Call_OS_lseek_WithGivenArgumentsAndReturnItsReturnValue */
-
-/* end CF_WrappedLseek tests */
+}
 
 /*******************************************************************************
 **
@@ -1300,7 +1246,4 @@ void UtTest_Setup(void)
     add_CF_WrappedWrite_tests();
 
     add_CF_WrappedLseek_tests();
-
-} /* end UtTest_Setup for cf_utils_tests.c */
-
-/* end cf_utils_tests.c */
+}

--- a/unit-test/stubs/cf_app_stubs.c
+++ b/unit-test/stubs/cf_app_stubs.c
@@ -33,7 +33,6 @@
  */
 void CF_AppMain(void)
 {
-
     UT_GenStub_Execute(CF_AppMain, Basic, NULL);
 }
 
@@ -44,7 +43,6 @@ void CF_AppMain(void)
  */
 void CF_CheckTables(void)
 {
-
     UT_GenStub_Execute(CF_CheckTables, Basic, NULL);
 }
 
@@ -55,7 +53,6 @@ void CF_CheckTables(void)
  */
 void CF_HkCmd(void)
 {
-
     UT_GenStub_Execute(CF_HkCmd, Basic, NULL);
 }
 
@@ -122,6 +119,5 @@ int32 CF_ValidateConfigTable(void *tbl_ptr)
  */
 void CF_WakeUp(void)
 {
-
     UT_GenStub_Execute(CF_WakeUp, Basic, NULL);
 }

--- a/unit-test/stubs/cf_cfdp_handlers.c
+++ b/unit-test/stubs/cf_cfdp_handlers.c
@@ -49,8 +49,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CFDP_ConstructPduHeader
- *
  * Default always returns NULL, an alt handler can be registered for other pointer returns
  *
  *-----------------------------------------------------------------*/
@@ -64,8 +62,6 @@ void UT_DefaultHandler_CF_CFDP_ConstructPduHeader(void *UserObj, UT_EntryKey_t F
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_CFDP_TxFile
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
@@ -92,8 +88,6 @@ void UT_DefaultHandler_CF_CFDP_TxFile(void *UserObj, UT_EntryKey_t FuncKey, cons
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CFDP_TxFile
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -119,8 +113,6 @@ void UT_DefaultHandler_CF_CFDP_PlaybackDir(void *UserObj, UT_EntryKey_t FuncKey,
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CFDP_ResetTransaction
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -137,8 +129,6 @@ void UT_DefaultHandler_CF_CFDP_ResetTransaction(void *UserObj, UT_EntryKey_t Fun
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_CFDP_CancelTransaction
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.

--- a/unit-test/stubs/cf_cfdp_sbintf_handlers.c
+++ b/unit-test/stubs/cf_cfdp_sbintf_handlers.c
@@ -49,8 +49,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CFDP_MsgOutGet
- *
  * Default always returns NULL, an alt handler can be registered for other pointer returns
  *
  *-----------------------------------------------------------------*/

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -135,7 +135,6 @@ int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t 
  */
 void CF_CFDP_CycleEngine(void)
 {
-
     UT_GenStub_Execute(CF_CFDP_CycleEngine, Basic, NULL);
 }
 
@@ -192,7 +191,6 @@ void CF_CFDP_DecodeStart(CF_DecoderState_t *pdec, const void *msgbuf, CF_Logical
  */
 void CF_CFDP_DisableEngine(void)
 {
-
     UT_GenStub_Execute(CF_CFDP_DisableEngine, Basic, NULL);
 }
 

--- a/unit-test/stubs/cf_chunk_handlers.c
+++ b/unit-test/stubs/cf_chunk_handlers.c
@@ -42,8 +42,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_ChunkList_GetFirstChunk
- *
  * Default always returns NULL, an alt handler can be registered for other pointer returns
  *
  *-----------------------------------------------------------------*/

--- a/unit-test/stubs/cf_clist_handlers.c
+++ b/unit-test/stubs/cf_clist_handlers.c
@@ -41,8 +41,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CList_InitNode
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -58,8 +56,6 @@ void UT_DefaultHandler_CF_CList_InitNode(void *UserObj, UT_EntryKey_t FuncKey, c
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_CList_InsertBack
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
@@ -78,8 +74,6 @@ void UT_DefaultHandler_CF_CList_InsertBack(void *UserObj, UT_EntryKey_t FuncKey,
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CList_CF_CList_Pop
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -97,8 +91,6 @@ void UT_DefaultHandler_CF_CList_CF_CList_Pop(void *UserObj, UT_EntryKey_t FuncKe
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CList_Remove
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -115,8 +107,6 @@ void UT_DefaultHandler_CF_CList_Remove(void *UserObj, UT_EntryKey_t FuncKey, con
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_CList_InsertAfter
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
@@ -136,8 +126,6 @@ void UT_DefaultHandler_CF_CList_InsertAfter(void *UserObj, UT_EntryKey_t FuncKey
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CList_Traverse
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -152,8 +140,6 @@ void UT_DefaultHandler_CF_CList_Traverse(void *UserObj, UT_EntryKey_t FuncKey, c
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_CList_Traverse_R
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.

--- a/unit-test/stubs/cf_cmd_handlers.c
+++ b/unit-test/stubs/cf_cmd_handlers.c
@@ -36,8 +36,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_ProcessGroundCommand
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *

--- a/unit-test/stubs/cf_codec_handlers.c
+++ b/unit-test/stubs/cf_codec_handlers.c
@@ -31,8 +31,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CFDP_CodecCheckSize
- *
  * Translates return value into the correct size for returning
  *
  *-----------------------------------------------------------------*/
@@ -55,8 +53,6 @@ void UT_DefaultHandler_CF_CFDP_CodecCheckSize(void *UserObj, UT_EntryKey_t FuncK
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CFDP_DoEncodeChunk
- *
  * Default always returns NULL, an alt handler can be registered for other pointer returns
  *
  *-----------------------------------------------------------------*/
@@ -72,8 +68,6 @@ void UT_DefaultHandler_CF_CFDP_DoEncodeChunk(void *UserObj, UT_EntryKey_t FuncKe
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_CFDP_DoDecodeChunk
- *
  * Default always returns NULL, an alt handler can be registered for other pointer returns
  *
  *-----------------------------------------------------------------*/
@@ -88,8 +82,6 @@ void UT_DefaultHandler_CF_CFDP_DoDecodeChunk(void *UserObj, UT_EntryKey_t FuncKe
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_CFDP_GetValueEncodedSize
  *
  * Translates return value into the correct size for returning
  *
@@ -115,8 +107,6 @@ void UT_DefaultHandler_CF_CFDP_GetValueEncodedSize(void *UserObj, UT_EntryKey_t 
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_DecodeIntegerInSize
  *
  * Translates return value into the correct size for returning
  *

--- a/unit-test/stubs/cf_utils_handlers.c
+++ b/unit-test/stubs/cf_utils_handlers.c
@@ -42,8 +42,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_ResetHistory
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -60,8 +58,6 @@ void UT_DefaultHandler_CF_ResetHistory(void *UserObj, UT_EntryKey_t FuncKey, con
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_FindTransactionBySequenceNumber
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
@@ -93,8 +89,6 @@ void UT_DefaultHandler_CF_FindTransactionBySequenceNumber(void *UserObj, UT_Entr
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_FindUnusedTransaction
- *
  * Default always returns NULL, an alt handler can be registered for other pointer returns
  *
  *-----------------------------------------------------------------*/
@@ -108,8 +102,6 @@ void UT_DefaultHandler_CF_FindUnusedTransaction(void *UserObj, UT_EntryKey_t Fun
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_WriteTxnQueueDataToFile
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
@@ -128,8 +120,6 @@ void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *UserObj, UT_EntryKey_t F
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_WriteHistoryQueueDataToFile
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
@@ -151,8 +141,6 @@ void UT_DefaultHandler_CF_WriteHistoryQueueDataToFile(void *UserObj, UT_EntryKey
 
 /*----------------------------------------------------------------
  *
- * Function: UT_DefaultHandler_CF_TraverseAllTransactions
- *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
  *
@@ -170,8 +158,6 @@ void UT_DefaultHandler_CF_TraverseAllTransactions(void *UserObj, UT_EntryKey_t F
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.
@@ -193,8 +179,6 @@ void UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels(void *UserObj, UT
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_DefaultHandler_CF_WrappedOpenCreate
  *
  * For compatibility with other tests, this has a mechanism to save its
  * arguments to a test-provided context capture buffer.

--- a/unit-test/utilities/cf_test_alt_handler.c
+++ b/unit-test/utilities/cf_test_alt_handler.c
@@ -32,8 +32,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T
- *
  * A handler for CF_CList_Traverse which saves its arguments
  * including the opaque context pointer as a CF_TraverseAll_Arg_t object.
  *
@@ -74,8 +72,6 @@ void UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T(void *UserObj, UT_Entry
 
 /*----------------------------------------------------------------
  *
- * Function: UT_AltHandler_CF_CList_Traverse_POINTER
- *
  * A handler for CF_CList_Traverse which saves its arguments
  * to a CF_CList_Traverse_POINTER_context_t object.
  *
@@ -102,8 +98,6 @@ void UT_AltHandler_CF_CList_Traverse_POINTER(void *UserObj, UT_EntryKey_t FuncKe
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_AltHandler_CF_CList_Traverse_R_PRIO
  *
  * A handler for CF_CList_Traverse which saves its arguments
  * including the opaque context pointer as a CF_Traverse_PriorityArg_t object.
@@ -138,8 +132,6 @@ void UT_AltHandler_CF_CList_Traverse_R_PRIO(void *UserObj, UT_EntryKey_t FuncKey
 
 /*----------------------------------------------------------------
  *
- * Function: UT_AltHandler_CF_TraverseAllTransactions_All_Channels_Set_Context
- *
  * A handler for CF_TraverseAllTransactions which _sets_ the opaque context
  * pointer as a int* object.  The value is taken from the UserObj opaque pointer.
  *
@@ -158,8 +150,6 @@ void UT_AltHandler_CF_TraverseAllTransactions_All_Channels_Set_Context(void *Use
 }
 
 /*----------------------------------------------------------------
- *
- * Function: UT_AltHandler_GenericPointerReturn
  *
  * A simple handler that can be used for any stub that returns a pointer.
  * it just forces the return value to be the object passed in as UserObj.

--- a/unit-test/utilities/cf_test_utils.c
+++ b/unit-test/utilities/cf_test_utils.c
@@ -222,7 +222,6 @@ uint8 Any_uint8_ExceptUnsetBits(uint8 bits)
 
     while ((random_value | bits) == bits)
     {
-
         if (num_tries == max_tries)
         {
             UtPrintf("Any_uint8_ExceptUnsetBits unable to get valid number in %u checks\n", num_tries);

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -52,7 +52,6 @@ typedef enum
     UT_CF_Setup_NONE,
     UT_CF_Setup_TX,
     UT_CF_Setup_RX
-
 } UT_CF_Setup_t;
 
 /*******************************************************************************


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #330
Removes redundant comments (incl. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.

**Testing performed**
None (only comments and empty lines were amended).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, thereby improving readability.

**Contributor Info**
@thnkslprpt 