### PR TITLE
Fix #109, Move variables declared mid-function to the top

### DIFF
--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -263,11 +263,12 @@ void CF_CFDP_S_SubstateSendFileData(CF_Transaction_t *t)
 int CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *t)
 {
     const CF_Chunk_t *c;
+    CF_SendRet_t      sret;
     int               ret = 0;
 
     if (t->flags.tx.md_need_send)
     {
-        CF_SendRet_t sret = CF_CFDP_SendMd(t);
+        sret = CF_CFDP_SendMd(t);
         if (sret == CF_SendRet_ERROR)
         {
             ret = -1; /* error occurred */
@@ -341,14 +342,13 @@ void CF_CFDP_S2_SubstateSendFileData(CF_Transaction_t *t)
  *-----------------------------------------------------------------*/
 void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
 {
-    bool         success = true;
-    int          status  = 0;
     CF_SendRet_t sret;
+    int32        ret;
+    int          status  = 0;
+    bool         success = true;
 
     if (!OS_ObjectIdDefined(t->fd))
     {
-        int32 ret;
-
         if (OS_FileOpenCheck(t->history->fnames.src_filename) == OS_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_ALREADY_OPEN, CFE_EVS_EventType_ERROR,
@@ -699,7 +699,8 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
     /* Steven is not real happy with this function. There should be a better way to separate out
      * the logic by state so that it isn't a bunch of if statements for different flags
      */
-    bool early_exit = false;
+    CF_SendRet_t sret;
+    bool         early_exit = false;
 
     /* at each tick, various timers used by S are checked */
     /* first, check inactivity timer */
@@ -743,7 +744,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
                         }
                         else
                         {
-                            CF_SendRet_t sret = CF_CFDP_S_SendEof(t);
+                            sret = CF_CFDP_S_SendEof(t);
                             if (sret == CF_SendRet_NO_MSG)
                             {
                                 early_exit = true;

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -180,6 +180,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
     CFE_MSG_Type_t    msg_type = CFE_MSG_Type_Invalid;
 
     CF_Logical_PduBuffer_t *ph;
+    CF_Transaction_t        t_finack;
 
     for (; count < CF_AppData.config_table->chan[chan_num].rx_max_messages_per_wakeup; ++count)
     {
@@ -231,8 +232,6 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
                 {
                     if (!CF_CFDP_RecvFin(t, ph))
                     {
-                        CF_Transaction_t t_finack;
-
                         memset(&t_finack, 0, sizeof(t_finack));
                         CF_CFDP_InitTxnTxFile(&t_finack, CF_CFDP_CLASS_2, 1, chan_num,
                                               0); /* populate transaction with needed fields for CF_CFDP_SendAck() */

--- a/fsw/src/cf_chunk.c
+++ b/fsw/src/cf_chunk.c
@@ -235,10 +235,14 @@ CF_ChunkIdx_t CF_Chunks_FindSmallestSize(const CF_ChunkList_t *chunks)
  *-----------------------------------------------------------------*/
 void CF_Chunks_Insert(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk)
 {
-    int n = CF_Chunks_CombineNext(chunks, i, chunk);
+    CF_ChunkIdx_t smallest_i;
+    CF_Chunk_t *  smallest_c;
+    int           n = CF_Chunks_CombineNext(chunks, i, chunk);
+    int           combined;
+
     if (n)
     {
-        int combined = CF_Chunks_CombinePrevious(chunks, i, &chunks->chunks[i]);
+        combined = CF_Chunks_CombinePrevious(chunks, i, &chunks->chunks[i]);
         if (combined)
         {
             CF_Chunks_EraseChunk(chunks, i);
@@ -246,7 +250,7 @@ void CF_Chunks_Insert(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t 
     }
     else
     {
-        int combined = CF_Chunks_CombinePrevious(chunks, i, chunk);
+        combined = CF_Chunks_CombinePrevious(chunks, i, chunk);
         if (!combined)
         {
             if (chunks->count < chunks->max_chunks)
@@ -255,8 +259,8 @@ void CF_Chunks_Insert(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t 
             }
             else
             {
-                CF_ChunkIdx_t smallest_i = CF_Chunks_FindSmallestSize(chunks);
-                CF_Chunk_t *  smallest_c = &chunks->chunks[smallest_i];
+                smallest_i = CF_Chunks_FindSmallestSize(chunks);
+                smallest_c = &chunks->chunks[smallest_i];
                 if (smallest_c->size < chunk->size)
                 {
                     CF_Chunks_EraseChunk(chunks, smallest_i);

--- a/fsw/src/cf_clist.c
+++ b/fsw/src/cf_clist.c
@@ -52,6 +52,8 @@ void CF_CList_InitNode(CF_CListNode_t *node)
  *-----------------------------------------------------------------*/
 void CF_CList_InsertFront(CF_CListNode_t **head, CF_CListNode_t *node)
 {
+    CF_CListNode_t *last;
+
     CF_Assert(head);
     CF_Assert(node);
     CF_Assert(node->next == node);
@@ -59,7 +61,7 @@ void CF_CList_InsertFront(CF_CListNode_t **head, CF_CListNode_t *node)
 
     if (*head)
     {
-        CF_CListNode_t *last = (*head)->prev;
+        last = (*head)->prev;
 
         node->next = *head;
         node->prev = last;
@@ -79,6 +81,8 @@ void CF_CList_InsertFront(CF_CListNode_t **head, CF_CListNode_t *node)
  *-----------------------------------------------------------------*/
 void CF_CList_InsertBack(CF_CListNode_t **head, CF_CListNode_t *node)
 {
+    CF_CListNode_t *last;
+
     CF_Assert(head);
     CF_Assert(node);
     CF_Assert(node->next == node);
@@ -90,7 +94,7 @@ void CF_CList_InsertBack(CF_CListNode_t **head, CF_CListNode_t *node)
     }
     else
     {
-        CF_CListNode_t *last = (*head)->prev;
+        last = (*head)->prev;
 
         node->next    = *head;
         (*head)->prev = node;

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -214,6 +214,7 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg)
  *-----------------------------------------------------------------*/
 int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context)
 {
+    int i;
     int ret = 0;
 
     /* this function is generic for any ground command that takes a single channel
@@ -222,7 +223,6 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_
     if (cmd->data.byte[0] == CF_ALL_CHANNELS)
     {
         /* apply to all channels */
-        int i;
         for (i = 0; i < CF_NUM_CHANNELS; ++i)
             ret |= fn(i, context);
     }
@@ -334,13 +334,14 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSe
  *-----------------------------------------------------------------*/
 int CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context)
 {
-    int ret = -1;
+    CF_Transaction_t *t;
+    int               ret = -1;
 
     if (cmd->chan == CF_COMPOUND_KEY)
     {
         /* special value 254 means to use the compound key (cmd->eid, cmd->ts) to find the transaction
          * to act upon */
-        CF_Transaction_t *t = CF_FindTransactionBySequenceNumberAllChannels(cmd->ts, cmd->eid);
+        t = CF_FindTransactionBySequenceNumberAllChannels(cmd->ts, cmd->eid);
         if (t)
         {
             fn(t, context);
@@ -587,12 +588,12 @@ void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg)
  *-----------------------------------------------------------------*/
 int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context)
 {
+    int i;
     int ret = 0;
     /* no need to bounds check chan_num, done in caller */
     if (context->msg->data.byte[1] == CF_ALL_POLLDIRS)
     {
         /* all polldirs in channel */
-        int i;
         for (i = 0; i < CF_MAX_POLLING_DIR_PER_CHAN; ++i)
             CF_AppData.config_table->chan[chan_num].polldir[i].enabled = context->barg;
     }

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -42,14 +42,16 @@
  *-----------------------------------------------------------------*/
 CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *c)
 {
+    CF_CListNode_t *  n;
+    CF_Transaction_t *t;
+    int               q_index; /* initialized below in if */
+
     CF_Assert(c);
 
     if (c->qs[CF_QueueIdx_FREE])
     {
-        int q_index; /* initialized below in if */
-
-        CF_CListNode_t *  n = c->qs[CF_QueueIdx_FREE];
-        CF_Transaction_t *t = container_of(n, CF_Transaction_t, cl_node);
+        n = c->qs[CF_QueueIdx_FREE];
+        t = container_of(n, CF_Transaction_t, cl_node);
 
         CF_CList_Remove_Ex(c, CF_QueueIdx_FREE, &t->cl_node);
 
@@ -327,6 +329,7 @@ void CF_InsertSortPrio(CF_Transaction_t *t, CF_QueueIdx_t q)
 {
     int           insert_back = 0;
     CF_Channel_t *c           = &CF_AppData.engine.channels[t->chan_num];
+
     CF_Assert(t->chan_num < CF_NUM_CHANNELS);
     CF_Assert(t->state != CF_TxnState_IDLE);
 

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -199,14 +199,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     dummy_msg->data.byte[0] = 5; /* 5 is size of 'names' */
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -224,14 +223,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     dummy_msg->data.byte[0] = Any_uint8_GreaterThan(5); /* 5 is size of 'names' */
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -273,9 +271,10 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
-    int                       i         = 0;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    int                       i                      = 0;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -296,8 +295,6 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
         CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
         CF_AppData.hk.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
     }
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -334,9 +331,10 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
-    int                       i         = 0;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    int                       i                      = 0;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -351,8 +349,6 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
         CF_AppData.hk.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
         CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
     }
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -383,9 +379,10 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
-    uint8                     i         = 0;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint8                     i                      = 0;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -397,8 +394,6 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
         CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
         CF_AppData.hk.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
     }
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -829,12 +824,12 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     int                       dummy_context;
     void *                    arg_context = &dummy_context;
     int                       local_result;
+    int                       catastrophe_count = 0;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* force CF_ALL_CHANNELS to not be a selection possibility */
     arg_cmd->data.byte[0] = CF_ALL_CHANNELS;
-    int catastrophe_count = 0;
     while (arg_cmd->data.byte[0] == CF_ALL_CHANNELS)
     {
         if (catastrophe_count == 10) /* 10 is arbitrary */
@@ -904,8 +899,9 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     uint8 dummy_chan_num = Any_cf_channel();
@@ -914,8 +910,6 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
 
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_chan_num;
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -968,8 +962,9 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     uint8 dummy_chan_num = Any_cf_channel();
@@ -978,8 +973,6 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
 
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_chan_num;
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1065,11 +1058,11 @@ void Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound(
     CF_Transaction_t    dummy_return_value;
     CF_Transaction_t *  local_result;
     CF_Transaction_t *  expected_result = &dummy_return_value;
+    int                 i               = 0;
 
     CF_FindTransactionBySequenceNumber_context_t contexts_CF_CFDP_FTBSN[CF_NUM_CHANNELS];
 
     /* set non-matching transactions */
-    int i = 0;
     for (i = 0; i < number_transaction_match; ++i)
     {
         contexts_CF_CFDP_FTBSN[i].forced_return = NULL;
@@ -1115,6 +1108,9 @@ void Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotF
     CF_TsnChanAction_fn_t       arg_fn = &Dummy_CF_TsnChanAction_fn_t;
     int                         dummy_context;
     void *                      arg_context = &dummy_context;
+    int                         i           = 0;
+
+    CF_FindTransactionBySequenceNumber_context_t contexts_CF_CFDP_FTBSN[CF_NUM_CHANNELS];
 
     memset(&utbuf, 0, sizeof(utbuf));
     AnyRandomStringOfLettersOfLengthCopy(dummy_cmdstr, 10);
@@ -1123,10 +1119,7 @@ void Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotF
     arg_cmd->chan = CF_COMPOUND_KEY;
 
     /* Arrange unstubbable: CF_FindTransactionBySequenceNumberAllChannels */
-    CF_FindTransactionBySequenceNumber_context_t contexts_CF_CFDP_FTBSN[CF_NUM_CHANNELS];
-
     /* set non-matching transactions */
-    int i = 0;
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
         contexts_CF_CFDP_FTBSN[i].forced_return = NULL;
@@ -1620,8 +1613,9 @@ void Test_CF_CmdEnableDequeue_Success(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
     CF_ConfigTable_t dummy_config_table;
@@ -1634,8 +1628,6 @@ void Test_CF_CmdEnableDequeue_Success(void)
 
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_chan_num;
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1695,8 +1687,9 @@ void Test_CF_CmdDisableDequeue_Success(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
     CF_ConfigTable_t dummy_config_table;
@@ -1709,8 +1702,6 @@ void Test_CF_CmdDisableDequeue_Success(void)
 
     /* Arrange unstubbable: CF_DoChanAction */
     dummy_msg->data.byte[0] = dummy_chan_num;
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1768,13 +1759,14 @@ void Test_CF_CmdDisableDequeue_Failure(void)
 void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannelEnabledTo_context_barg(void)
 {
     /* Arrange */
-    uint8                       arg_chan_num = Any_cf_channel();
     CF_UT_cmd_unionargs_buf_t   utbuf;
     CF_UnionArgsCmd_t *         dummy_msg = &utbuf.ua;
     CF_ChanAction_BoolMsgArg_t  dummy_context;
     CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
     CF_ConfigTable_t            dummy_config_table;
+    uint8                       arg_chan_num = Any_cf_channel();
     uint8                       expected_enabled;
+    uint8                       current_polldir = 0;
     int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
@@ -1792,8 +1784,6 @@ void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannel
     local_result = CF_DoEnableDisablePolldir(arg_chan_num, arg_context);
 
     /* Assert */
-    uint8 current_polldir = 0;
-
     for (current_polldir = 0; current_polldir < CF_MAX_POLLING_DIR_PER_CHAN; ++current_polldir)
     {
         UtAssert_True(CF_AppData.config_table->chan[arg_chan_num].polldir[current_polldir].enabled == expected_enabled,
@@ -1910,8 +1900,9 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
     uint8                     dummy_channel = Any_cf_channel();
     uint8                     dummy_polldir = Any_cf_polldir();
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&dummy_config_table, 0, sizeof(dummy_config_table));
@@ -1923,8 +1914,6 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     dummy_msg->data.byte[1] = dummy_polldir;
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1949,8 +1938,9 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     uint8 dummy_channel = Any_cf_channel();
     uint8 error_polldir = Any_uint8_BetweenInclusive(CF_MAX_POLLING_DIR_PER_CHAN, CF_ALL_CHANNELS - 1);
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -1959,8 +1949,6 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     dummy_msg->data.byte[1] = error_polldir;
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -1989,8 +1977,9 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
     uint8                     dummy_channel = Any_cf_channel();
     uint8                     dummy_polldir = Any_cf_polldir();
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&dummy_config_table, 0, sizeof(dummy_config_table));
@@ -2002,8 +1991,6 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     dummy_msg->data.byte[1] = dummy_polldir;
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -2028,8 +2015,9 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     uint8 dummy_channel = Any_cf_channel();
     uint8 error_polldir = Any_uint8_BetweenInclusive(CF_MAX_POLLING_DIR_PER_CHAN, CF_ALL_CHANNELS - 1);
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2038,8 +2026,6 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     dummy_msg->data.byte[1] = error_polldir;
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2298,8 +2284,9 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     uint8                     dummy_channel = Any_cf_channel();
     uint8                     error_purge   = 3; /* Shortest return from CF_DoPurgeQueue */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
+    uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2308,8 +2295,6 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
 
     /* Arrange unstubbable: CF_DoPurgeQueue */
     dummy_msg->data.byte[1] = error_purge;
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2361,15 +2346,14 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *    dummy_wq               = &utbuf.wq;
+    CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
+    uint16                  initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
     dummy_wq->chan = CF_NUM_CHANNELS;
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2387,15 +2371,14 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *    dummy_wq               = &utbuf.wq;
+    CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
+    uint16                  initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
     dummy_wq->chan = Any_uint8_GreaterThan(CF_NUM_CHANNELS);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2414,8 +2397,9 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *    dummy_wq               = &utbuf.wq;
+    CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
+    uint16                  initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2425,8 +2409,6 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     /* invalid combination up direction, pending queue */
     dummy_wq->type  = CF_Type_up;
     dummy_wq->queue = CF_Queue_pend;
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2445,9 +2427,11 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
+    uint16                         initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2461,13 +2445,10 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     /* invalid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Negative();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2488,9 +2469,11 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
+    uint16                         initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2504,14 +2487,10 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     /* invalid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Negative();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2532,9 +2511,13 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t              utbuf;
+    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    uint16                               initial_hk_err_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2548,22 +2531,15 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = 0;
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
-    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
-    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
-
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
                      sizeof(context_CF_WriteTxnQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2583,9 +2559,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t              utbuf;
+    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    int32                                context_CF_WrappedClose_fd;
+    uint16                               initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2599,26 +2580,17 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
-    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
-    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
-
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
                      sizeof(context_CF_WriteTxnQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    int32 context_CF_WrappedClose_fd;
-
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2638,9 +2610,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t                  utbuf;
+    CF_WriteQueueCmd_t *                     dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *                        arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t           context_CF_WrappedOpenCreate;
+    CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
+    int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
+    int32                                    context_CF_WrappedClose_fd;
+    uint16                                   initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2654,26 +2631,17 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* invalid result from CF_WriteHistoryQueueDataToFile */
-    int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
-    CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
-
     UT_SetDataBuffer(UT_KEY(CF_WriteHistoryQueueDataToFile), &context_CF_WriteHistoryQueueDataToFile,
                      sizeof(context_CF_WriteHistoryQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    int32 context_CF_WrappedClose_fd;
-
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2693,9 +2661,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t              utbuf;
+    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    int32                                context_CF_WrappedClose_fd;
+    uint16                               initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2709,26 +2682,17 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
-    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
-    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
-
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
                      sizeof(context_CF_WriteTxnQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    int32 context_CF_WrappedClose_fd;
-
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2748,9 +2712,15 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t              utbuf;
+    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile[2];
+    int32                                forced_return_CF_WriteTxnQueueDataToFile_1st_call = 0;
+    int32                                forced_return_CF_WriteTxnQueueDataToFile_2nd_call = Any_int32_Except(0);
+    int32                                context_CF_WrappedClose_fd;
+    uint16                               initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2764,28 +2734,18 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
-    int32                                forced_return_CF_WriteTxnQueueDataToFile_1st_call = 0;
-    int32                                forced_return_CF_WriteTxnQueueDataToFile_2nd_call = Any_int32_Except(0);
-    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile[2];
-
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
                      sizeof(context_CF_WriteTxnQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile_1st_call);
     UT_SetDeferredRetcode(UT_KEY(CF_WriteTxnQueueDataToFile), 2, forced_return_CF_WriteTxnQueueDataToFile_2nd_call);
 
-    int32 context_CF_WrappedClose_fd;
-
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2805,9 +2765,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t              utbuf;
+    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
+    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
+    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
+    int32                                context_CF_WrappedClose_fd;
+    uint16                               initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2821,26 +2786,17 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
-    int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
-    CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
-
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile), &context_CF_WriteTxnQueueDataToFile,
                      sizeof(context_CF_WriteTxnQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    int32 context_CF_WrappedClose_fd;
-
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2860,9 +2816,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t                  utbuf;
+    CF_WriteQueueCmd_t *                     dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *                        arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t           context_CF_WrappedOpenCreate;
+    CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
+    int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
+    int32                                    context_CF_WrappedClose_fd;
+    uint16                                   initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2876,26 +2837,17 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* invalid result from CF_WriteHistoryQueueDataToFile */
-    int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
-    CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
-
     UT_SetDataBuffer(UT_KEY(CF_WriteHistoryQueueDataToFile), &context_CF_WriteHistoryQueueDataToFile,
                      sizeof(context_CF_WriteHistoryQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    int32 context_CF_WrappedClose_fd;
-
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2914,9 +2866,13 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
+    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2930,24 +2886,16 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
-    int32 forced_return_CF_WriteHistoryQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -2967,9 +2915,12 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2983,19 +2934,13 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
-    int32 forced_return_CF_WriteHistoryQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3015,9 +2960,12 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3031,19 +2979,13 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3063,9 +3005,12 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3079,19 +3024,13 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3111,9 +3050,13 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
+    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3127,24 +3070,16 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
-    int32 forced_return_CF_WriteHistoryQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3164,9 +3099,12 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3180,19 +3118,13 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
-    int32 forced_return_CF_WriteHistoryQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3212,9 +3144,12 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3228,19 +3163,13 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3262,9 +3191,12 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3278,19 +3210,13 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3310,9 +3236,12 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3326,19 +3255,13 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3358,9 +3281,12 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3374,19 +3300,13 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3406,9 +3326,12 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
 {
     /* Arrange */
-    CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *       arg_msg  = &utbuf.buf;
+    CF_UT_cmd_write_q_buf_t        utbuf;
+    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
+    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16                         initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3422,19 +3345,13 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     /* valid result from CF_WrappedCreat */
     strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
-    int32 forced_return_CF_WriteTxnQueueDataToFile = 0;
-
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3715,12 +3632,11 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                          = NULL;
     uint32           forced_return_CF_CFDP_InitEngine = CFE_SUCCESS;
+    uint16           initial_hk_cmd_counter           = Any_uint16();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3742,12 +3658,11 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                          = NULL;
     uint32           forced_return_CF_CFDP_InitEngine = Any_uint32_Except(CFE_SUCCESS);
+    uint16           initial_hk_err_counter           = Any_uint16();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -3767,11 +3682,10 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
 void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounter(void)
 {
     /* Arrange */
-    CFE_SB_Buffer_t *arg_msg = NULL;
+    CFE_SB_Buffer_t *arg_msg                = NULL;
+    uint16           initial_hk_err_counter = Any_uint16();
 
     CF_AppData.engine.enabled = 1; /* 1 is enabled */
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -3797,11 +3711,10 @@ void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounte
 void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(void)
 {
     /* Arrange */
-    CFE_SB_Buffer_t *arg_msg = NULL;
+    CFE_SB_Buffer_t *arg_msg                = NULL;
+    uint16           initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.engine.enabled = 1; /* 1 is enabled */
-
-    uint16 initial_hk_cmd_counter = Any_uint16();
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -3820,11 +3733,10 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
 void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(void)
 {
     /* Arrange */
-    CFE_SB_Buffer_t *arg_msg = NULL;
+    CFE_SB_Buffer_t *arg_msg                = NULL;
+    uint16           initial_hk_err_counter = Any_uint16();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
-
-    uint16 initial_hk_err_counter = Any_uint16();
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -260,6 +260,7 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
     CF_CListNode_t **expected_head;
     CF_CListNode_t * expected_cl_node;
     uint16           initial_q_size = Any_uint16_Except(0); /* 0 will CF_Assert */
+    uint16           updated_q_size;
 
     CF_CList_Remove_context_t context_clist_remove;
 
@@ -276,7 +277,7 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
     /* Act */
     CF_DequeueTransaction(&arg_t);
 
-    uint16 updated_q_size = CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index];
+    updated_q_size = CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index];
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_clist_remove.head, expected_head);
@@ -290,26 +291,26 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
 void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(void)
 {
     /* Arrange */
-    CF_Transaction_t  dummy_t;
-    CF_Transaction_t *arg_t          = &dummy_t;
-    uint8             dummy_chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
-    CF_CListNode_t ** expected_remove_head;
-    CF_CListNode_t *  expected_remove_node;
-    CF_CListNode_t ** expected_insert_back_head;
-    CF_CListNode_t *  expected_insert_back_node;
-    CF_QueueIdx_t     arg_q = Any_cf_queue_index_t();
+    CF_Transaction_t              dummy_t;
+    CF_Transaction_t *            arg_t          = &dummy_t;
+    uint8                         dummy_chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    CF_CListNode_t **             expected_remove_head;
+    CF_CListNode_t *              expected_remove_node;
+    CF_CListNode_t **             expected_insert_back_head;
+    CF_CListNode_t *              expected_insert_back_node;
+    CF_QueueIdx_t                 arg_q = Any_cf_queue_index_t();
+    CF_CList_Remove_context_t     context_clist_remove;
+    CF_CList_InsertBack_context_t context_clist_insert_back;
 
     memset(&dummy_t, 0, sizeof(dummy_t));
 
     arg_t->chan_num = dummy_chan_num;
 
-    CF_CList_Remove_context_t context_clist_remove;
     UT_SetDataBuffer(UT_KEY(CF_CList_Remove), &context_clist_remove, sizeof(context_clist_remove), false);
 
     expected_remove_head = &CF_AppData.engine.channels[arg_t->chan_num].qs[arg_t->flags.com.q_index];
     expected_remove_node = &arg_t->cl_node;
 
-    CF_CList_InsertBack_context_t context_clist_insert_back;
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertBack), &context_clist_insert_back, sizeof(context_clist_insert_back), false);
 
     expected_insert_back_head = &CF_AppData.engine.channels[arg_t->chan_num].qs[arg_q];
@@ -345,8 +346,10 @@ void Test_CF_CList_Remove_Ex_Call_CF_CList_Remove_AndDecrement_q_size(void)
     CF_CListNode_t **expected_remove_head;
     CF_CListNode_t * expected_remove_node;
     uint16           initial_q_size = Any_uint16_Except(0);
+    uint16           updated_q_size;
 
     CF_CList_Remove_context_t context_clist_remove;
+
     UT_SetDataBuffer(UT_KEY(CF_CList_Remove), &context_clist_remove, sizeof(context_clist_remove), false);
 
     expected_remove_head = &arg_c->qs[arg_index];
@@ -357,7 +360,7 @@ void Test_CF_CList_Remove_Ex_Call_CF_CList_Remove_AndDecrement_q_size(void)
     /* Act */
     CF_CList_Remove_Ex(arg_c, arg_index, arg_node);
 
-    uint16 updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_Remove, 1);
@@ -378,10 +381,12 @@ void Test_CF_CList_InsertAfter_Ex_Call_CF_CList_InsertAfter_AndIncrement_q_size(
     CF_CListNode_t * arg_start = &dummy_start;
     CF_CListNode_t   dummy_after;
     CF_CListNode_t * arg_after                  = &dummy_after;
-    uint16           initial_q_size             = Any_uint16();
     CF_CListNode_t **expected_insert_after_head = &arg_c->qs[arg_index];
+    uint16           initial_q_size             = Any_uint16();
+    uint16           updated_q_size;
 
     CF_CList_InsertAfter_context_t context_CF_CList_InsertAfter;
+
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertAfter), &context_CF_CList_InsertAfter, sizeof(context_CF_CList_InsertAfter),
                      false);
 
@@ -390,7 +395,7 @@ void Test_CF_CList_InsertAfter_Ex_Call_CF_CList_InsertAfter_AndIncrement_q_size(
     /* Act */
     CF_CList_InsertAfter_Ex(arg_c, arg_index, arg_start, arg_after);
 
-    uint16 updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_InsertAfter, 1);
@@ -413,6 +418,7 @@ void Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size(vo
     uint16           initial_q_size = Any_uint16();
     CF_CListNode_t **expected_insert_back_head;
     CF_CListNode_t * expected_insert_back_node;
+    uint16           updated_q_size;
 
     CF_CList_InsertBack_context_t context_clist_insert_back;
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertBack), &context_clist_insert_back, sizeof(context_clist_insert_back), false);
@@ -425,7 +431,7 @@ void Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size(vo
     /* Act */
     CF_CList_InsertBack_Ex(arg_c, arg_index, arg_node);
 
-    uint16 updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);
@@ -683,11 +689,12 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_ind
     CF_CListNode_t ** expected_insert_back_head;
     CF_CListNode_t *  expected_insert_back_node;
 
+    CF_CList_InsertBack_context_t context_clist_insert_back;
+
     /* dummy_t settings to bypass CF_Assert */
     dummy_t.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
     dummy_t.state    = Any_uint8_Except(CF_TxnState_IDLE);
 
-    CF_CList_InsertBack_context_t context_clist_insert_back;
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertBack), &context_clist_insert_back, sizeof(context_clist_insert_back), false);
 
     /* setting (&CF_AppData.engine.channels[arg_t->chan_num])->qs[arg_q] to NULL
@@ -725,7 +732,9 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(voi
     CF_CListNode_t ** expected_insert_after_start;
     CF_CListNode_t ** expected_insert_after_after;
 
-    CF_CList_Traverse_R_context_t context_cf_clist_traverse_r;
+    CF_CList_Traverse_R_context_t  context_cf_clist_traverse_r;
+    CF_CList_InsertAfter_context_t context_CF_CList_InsertAfter;
+
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse_R), UT_AltHandler_CF_CList_Traverse_R_PRIO,
                           &context_cf_clist_traverse_r);
 
@@ -742,7 +751,6 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(voi
     context_cf_clist_traverse_r.context_t = &dummy_p_t;
 
     /* Arrange for CF_CList_InsertAfter_Ex */
-    CF_CList_InsertAfter_context_t context_CF_CList_InsertAfter;
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertAfter), &context_CF_CList_InsertAfter, sizeof(context_CF_CList_InsertAfter),
                      false);
 
@@ -782,6 +790,8 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     CF_CListNode_t *  expected_insert_back_node;
 
     CF_CList_Traverse_R_context_t context_cf_clist_traverse_r;
+    CF_CList_InsertBack_context_t context_clist_insert_back;
+
     UT_SetDataBuffer(UT_KEY(CF_CList_Traverse_R), &context_cf_clist_traverse_r, sizeof(context_cf_clist_traverse_r),
                      false);
 
@@ -804,7 +814,6 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     expected_insert_back_node = &arg_t->cl_node;
 
     /* Arrange for CF_CList_InsertBack_Ex */
-    CF_CList_InsertBack_context_t context_clist_insert_back;
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertBack), &context_clist_insert_back, sizeof(context_clist_insert_back), false);
 
     /* Act */
@@ -842,6 +851,8 @@ void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_T
     void *                expected_context;
     int32                 result;
 
+    UT_Callback_CF_TraverseAllTransactions_context_t func_ptr_context;
+
     dummy_args.fn      = UT_Callback_CF_TraverseAllTransactions;
     dummy_args.context = dummy_context;
     dummy_args.counter = initial_args_counter;
@@ -852,7 +863,6 @@ void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_T
     expected_t       = &dummy_t;
     expected_context = dummy_context;
 
-    UT_Callback_CF_TraverseAllTransactions_context_t func_ptr_context;
     UT_SetDataBuffer(UT_KEY(UT_Callback_CF_TraverseAllTransactions), &func_ptr_context, sizeof(func_ptr_context),
                      false);
 
@@ -883,18 +893,17 @@ void Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_ar
     void *          arg_context    = &dummy_context;
     uint8           expected_count = CF_QueueIdx_RX - CF_QueueIdx_PEND + 1;
     CF_CListNode_t *expected_qs_nodes[expected_count];
+    int             i = 0;
 
-    CF_TraverseAllTransactions_fn_t arg_fn = UT_Callback_CF_TraverseAllTransactions;
+    CF_TraverseAllTransactions_fn_t                 arg_fn = UT_Callback_CF_TraverseAllTransactions;
+    CF_CList_Traverse_TRAVERSE_ALL_ARGS_T_context_t contexts_cf_clist_traverse[expected_count];
 
-    int i = 0;
     for (i = 0; i < expected_count; ++i)
     {
         dummy_c.qs[i] = (CF_CListNode_t *)&expected_qs_nodes[i];
     }
 
     /* set context */
-    CF_CList_Traverse_TRAVERSE_ALL_ARGS_T_context_t contexts_cf_clist_traverse[expected_count];
-
     /* this must use data buffer hack to pass multiple contexts */
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T, NULL);
     UT_SetDataBuffer(UT_KEY(CF_CList_Traverse), contexts_cf_clist_traverse, sizeof(contexts_cf_clist_traverse), false);

--- a/unit-test/utilities/cf_test_utils.c
+++ b/unit-test/utilities/cf_test_utils.c
@@ -385,6 +385,7 @@ uint32 Any_uint32_Except(uint32 exception)
 int32 Any_int32_LessThan(int32 ceiling)
 {
     int32 random_val;
+    int32 new_ceiling;
 
     if (ceiling > 0)
     {
@@ -392,8 +393,8 @@ int32 Any_int32_LessThan(int32 ceiling)
     }
     else
     {
-        int32 new_ceiling = abs(INT32_MIN - ceiling);
-        random_val        = ceiling - (rand() % new_ceiling);
+        new_ceiling = abs(INT32_MIN - ceiling);
+        random_val  = ceiling - (rand() % new_ceiling);
     }
 
     return random_val;
@@ -449,7 +450,8 @@ int Any_int_Except(int exception)
 
 int Any_int_GreaterThan(int floor) /* NOTE: INTMAX_MAX will fail, and is invalid value */
 {
-    int random_val;
+    int  random_val;
+    bool coin_toss;
 
     if (floor > 0)
     {
@@ -459,7 +461,7 @@ int Any_int_GreaterThan(int floor) /* NOTE: INTMAX_MAX will fail, and is invalid
     }
     else
     {
-        bool coin_toss = rand() % 2;
+        coin_toss = rand() % 2;
 
         if (coin_toss == HEADS)
         {
@@ -562,10 +564,11 @@ char *AnyFilenameOfLength(size_t length)
 char *AnyRandomStringOfTextOfLength(size_t length)
 {
     size_t i;
+    int    value;
 
     for (i = 0; i < length; ++i)
     {
-        int value               = 32 + (rand() % 95); /* ASCII 32 to 126 */
+        value                   = 32 + (rand() % 95); /* ASCII 32 to 126 */
         random_length_string[i] = (char)value;
     }
     random_length_string[i] = '\0';
@@ -576,10 +579,11 @@ char *AnyRandomStringOfTextOfLength(size_t length)
 char *AnyRandomStringOfLettersOfLength(size_t length)
 {
     size_t i;
+    int    value;
 
     for (i = 0; i < length; ++i)
     {
-        int value = 65 + (rand() % 26); /* ASCII 65 to 91 */
+        value = 65 + (rand() % 26); /* ASCII 65 to 91 */
 
         if (AnyCoinFlip() == HEADS)
         {
@@ -596,10 +600,11 @@ char *AnyRandomStringOfLettersOfLength(size_t length)
 void AnyRandomStringOfLettersOfLengthCopy(char *random_string, size_t length)
 {
     size_t i;
+    int    value;
 
     for (i = 0; i < (length - 1); ++i)
     {
-        int value = 65 + (rand() % 26); /* ASCII 65 to 91 */
+        value = 65 + (rand() % 26); /* ASCII 65 to 91 */
 
         if (AnyCoinFlip() == HEADS)
         {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #109 
All variables (that I could find) that were declared mid-function were moved to the top of their respective functions.
 
**Testing performed**
Just the CI GitHub actions so far.

**Expected behavior changes**
Aligns CF with the rest of cFS and the relevant coding guidelines.
Makes it easier and quicker to identify all variables in a function.

**Contributor Info**
@thnkslprpt 