### PR TITLE
Fix #262, Update inaccurate event ID name

### DIFF
--- a/fsw/inc/cf_events.h
+++ b/fsw/inc/cf_events.h
@@ -132,7 +132,7 @@
  *
  *  Invalid message ID received on the software bus pipe
  */
-#define CF_EID_ERR_INVALID_MID (28)
+#define CF_MID_ERR_EID (28)
 
 /**
  * \brief CF SB Receive Buffer Failed Event ID

--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -163,7 +163,6 @@ typedef enum
 
     /* keep last */
     CF_TxnStatus_MAX = 22
-
 } CF_TxnStatus_t;
 
 /**

--- a/fsw/src/cf_dispatch.c
+++ b/fsw/src/cf_dispatch.c
@@ -151,7 +151,7 @@ void CF_AppPipe(const CFE_SB_Buffer_t *msg)
 
         default:
             ++CF_AppData.hk.Payload.counters.err;
-            CFE_EVS_SendEvent(CF_EID_ERR_INVALID_MID, CFE_EVS_EventType_ERROR, "CF: invalid command packet id=0x%lx",
+            CFE_EVS_SendEvent(CF_MID_ERR_EID, CFE_EVS_EventType_ERROR, "CF: invalid command packet id=0x%lx",
                               (unsigned long)CFE_SB_MsgIdToValue(msg_id));
             break;
     }

--- a/unit-test/cf_dispatch_tests.c
+++ b/unit-test/cf_dispatch_tests.c
@@ -262,7 +262,7 @@ void Test_CF_AppPipe_UnrecognizedCommandEnterDefaultPath(void)
     /* Assert */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_ERR_INVALID_MID);
+    UT_CF_AssertEventID(CF_MID_ERR_EID);
 }
 
 void add_CF_ProcessGroundCommand_tests(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #262
  - Updates Event ID `CF_EID_ERR_INIT_CMD_LENGTH` to a more accurate name and something that more consistent with other apps - `CF_MID_ERR_EID`.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi Weiss @thnkslprpt