### PR TITLE
Fix #336, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/inc/cf_events.h
+++ b/fsw/inc/cf_events.h
@@ -44,7 +44,7 @@
  *
  *  Successful completion of application initialization
  */
-#define CF_EID_INF_INIT (20)
+#define CF_INIT_INF_EID (20)
 
 /**
  * \brief CF Check Table Release Address Failed Event ID
@@ -166,7 +166,7 @@
  *
  *  Failure from create pipe call during engine channel initialization
  */
-#define CF_EID_ERR_INIT_PIPE (31)
+#define CF_CR_PIPE_ERR_EID (31)
 
 /**
  * \brief CF Channel Message Subscription Failed Event ID
@@ -897,7 +897,7 @@
  *
  *  Receipt of NOOP command
  */
-#define CF_EID_INF_CMD_NOOP (110)
+#define CF_NOOP_INF_EID (110)
 
 /**
  * \brief CF Reset Counters Command Received Event ID
@@ -908,7 +908,7 @@
  *
  *  Receipt and successful processing of reset counters command
  */
-#define CF_EID_INF_CMD_RESET (111)
+#define CF_RESET_INF_EID (111)
 
 /**
  * \brief CF Set Parameter Command Received Event ID
@@ -1348,7 +1348,7 @@
  *
  *  Received command length verification failure
  */
-#define CF_EID_ERR_CMD_GCMD_LEN (151)
+#define CF_CMD_LEN_ERR_EID (151)
 
 /**
  * \brief CF Command Code Invalid Event ID
@@ -1359,7 +1359,7 @@
  *
  *  Received command code unrecognized
  */
-#define CF_EID_ERR_CMD_GCMD_CC (152)
+#define CF_CC_ERR_EID (152)
 
 /**
  * \brief CF Write Entry To File Failed Event ID

--- a/fsw/inc/cf_msg.h
+++ b/fsw/inc/cf_msg.h
@@ -180,11 +180,11 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_EID_INF_CMD_NOOP
+     *       - #CF_NOOP_INF_EID
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -212,11 +212,11 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_EID_INF_CMD_RESET
+     *       - #CF_RESET_INF_EID
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid counter type, #CF_EID_ERR_CMD_RESET_INVALID
      *
      *  \par Evidence of failure may be found in the following telemetry:
@@ -244,7 +244,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid parameter, #CF_EID_ERR_CMD_BAD_PARAM
      *       - Transaction initialization failure, #CF_EID_ERR_CMD_TX_FILE
      *
@@ -276,7 +276,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid parameter, #CF_EID_ERR_CMD_BAD_PARAM
      *       - Playback initialization failure, #CF_EID_ERR_CMD_PLAYBACK_DIR
      *
@@ -311,7 +311,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
      *       - Command processing failure, #CF_EID_ERR_CMD_FREEZE
      *
@@ -345,7 +345,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
      *       - Command processing failure, #CF_EID_ERR_CMD_THAW
      *
@@ -379,7 +379,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
      *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
      *       - Already in requested state, #CF_EID_ERR_CMD_SUSPRES_SAME
@@ -415,7 +415,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
      *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
      *       - Already in requested state, #CF_EID_ERR_CMD_SUSPRES_SAME
@@ -450,7 +450,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
      *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
      *       - No matching transaction, #CF_EID_ERR_CMD_CANCEL_CHAN
@@ -484,7 +484,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
      *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
      *       - No matching transaction, #CF_EID_ERR_CMD_ABANDON_CHAN
@@ -516,7 +516,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid configuration parameter key, #CF_EID_ERR_CMD_GETSET_PARAM
      *       - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
      *       - Parameter value failed validation, #CF_EID_ERR_CMD_GETSET_VALIDATE
@@ -548,7 +548,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid configuration parameter key, #CF_EID_ERR_CMD_GETSET_PARAM
      *       - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
      *
@@ -579,7 +579,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid parameter combination, #CF_EID_ERR_CMD_WQ_ARGS
      *       - Invalid channel number, #CF_EID_ERR_CMD_WQ_CHAN
      *       - Open file to write failed, #CF_EID_ERR_CMD_WQ_OPEN
@@ -617,7 +617,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
      *       - Enable dequeue failed, #CF_EID_ERR_CMD_ENABLE_DEQUEUE
      *
@@ -650,7 +650,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
      *       - Disable dequeue failed, #CF_EID_INF_CMD_DISABLE_DEQUEUE
      *
@@ -689,7 +689,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
      *       - Invalid polling directory index, #CF_EID_ERR_CMD_POLLDIR_INVALID
      *       - Enable directory polling failed, #CF_EID_ERR_CMD_ENABLE_POLLDIR
@@ -729,7 +729,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
      *       - Invalid polling directory index, #CF_EID_ERR_CMD_POLLDIR_INVALID
      *       - Disable directory polling failed, #CF_EID_ERR_CMD_DISABLE_POLLDIR
@@ -770,7 +770,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
      *       - Invalid purge queue argument, #CF_EID_ERR_CMD_PURGE_ARG
      *       - Purge queue failed, #CF_EID_ERR_CMD_PURGE_QUEUE
@@ -803,7 +803,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Engine initialization failed, #CF_EID_ERR_CMD_ENABLE_ENGINE
      *       - Engine already enabled, #CF_EID_ERR_CMD_ENG_ALREADY_ENA
      *
@@ -836,7 +836,7 @@ typedef enum
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
-     *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+     *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *       - Engine already disabled, #CF_EID_ERR_CMD_ENG_ALREADY_DIS
      *
      *  \par Evidence of failure may be found in the following telemetry:

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -249,7 +249,7 @@ CFE_Status_t CF_Init(void)
     if (status == CFE_SUCCESS)
     {
         status =
-            CFE_EVS_SendEvent(CF_EID_INF_INIT, CFE_EVS_EventType_INFORMATION, "CF Initialized. Version %d.%d.%d.%d",
+            CFE_EVS_SendEvent(CF_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "CF Initialized. Version %d.%d.%d.%d",
                               CF_MAJOR_VERSION, CF_MINOR_VERSION, CF_REVISION, CF_MISSION_REV);
         if (status != CFE_SUCCESS)
         {

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -968,7 +968,7 @@ CFE_Status_t CF_CFDP_InitEngine(void)
                                 nbuf);
         if (ret != CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_EID_ERR_INIT_PIPE, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
                               "CF: failed to create pipe %s, returned 0x%08lx", nbuf, (unsigned long)ret);
             break;
         }

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -46,7 +46,7 @@
  *-----------------------------------------------------------------*/
 void CF_CmdNoop(CFE_SB_Buffer_t *msg)
 {
-    CFE_EVS_SendEvent(CF_EID_INF_CMD_NOOP, CFE_EVS_EventType_INFORMATION, "CF: No-Op received, Version %d.%d.%d.%d",
+    CFE_EVS_SendEvent(CF_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: No-Op received, Version %d.%d.%d.%d",
                       CF_MAJOR_VERSION, CF_MINOR_VERSION, CF_REVISION, CF_MISSION_REV);
     ++CF_AppData.hk.counters.cmd;
 }
@@ -74,8 +74,8 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_EID_INF_CMD_RESET, CFE_EVS_EventType_INFORMATION,
-                          "CF: Received RESET COUNTERS command: %s", names[param]);
+        CFE_EVS_SendEvent(CF_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: Received RESET COUNTERS command: %s",
+                          names[param]);
 
         /* if the param is CF_Reset_command, or all counters */
         if ((param == CF_Reset_all) || (param == CF_Reset_command))
@@ -1240,7 +1240,7 @@ void CF_ProcessGroundCommand(CFE_SB_Buffer_t *msg)
         }
         else
         {
-            CFE_EVS_SendEvent(CF_EID_ERR_CMD_GCMD_LEN, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                               "CF: invalid ground command length for command 0x%02x, expected %d got %zd", cmd,
                               expected_lengths[cmd], len);
             ++CF_AppData.hk.counters.err;
@@ -1248,8 +1248,8 @@ void CF_ProcessGroundCommand(CFE_SB_Buffer_t *msg)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_EID_ERR_CMD_GCMD_CC, CFE_EVS_EventType_ERROR,
-                          "CF: invalid ground command packet cmd_code=0x%02x", cmd);
+        CFE_EVS_SendEvent(CF_CC_ERR_EID, CFE_EVS_EventType_ERROR, "CF: invalid ground command packet cmd_code=0x%02x",
+                          cmd);
         ++CF_AppData.hk.counters.err;
     }
 }

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -630,7 +630,7 @@ void Test_CF_AppMain_CFE_SB_ReceiveBuffer_Cases(void)
 
     /* Event from CF_Init and CF_AppMain */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_INIT);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_INIT_INF_EID);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_INIT_MSG_RECV);
 
     /* Reset, return CFE_SUCCESS from CFE_SB_ReceiveBuffer and buffer NULL */
@@ -642,7 +642,7 @@ void Test_CF_AppMain_CFE_SB_ReceiveBuffer_Cases(void)
 
     /* Event from CF_Init and CF_AppMain */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_INIT);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_INIT_INF_EID);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_INIT_MSG_RECV);
 
     /* Reset, return non-error codes and non-NULL buffer */
@@ -659,7 +659,7 @@ void Test_CF_AppMain_CFE_SB_ReceiveBuffer_Cases(void)
 
     /* Event from CF_Init */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_INIT);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_INIT_INF_EID);
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 3);
 }
 

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -184,7 +184,7 @@ void Test_CF_CmdNoop_SendNoopEventAndAcceptCommand(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
+    UT_CF_AssertEventID(CF_NOOP_INF_EID);
     /* Assert to show counter incremented */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -261,7 +261,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
+    UT_CF_AssertEventID(CF_RESET_INF_EID);
     UtAssert_ZERO(CF_AppData.hk.counters.cmd);
     UtAssert_ZERO(CF_AppData.hk.counters.err);
 }
@@ -302,7 +302,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
+    UT_CF_AssertEventID(CF_RESET_INF_EID);
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
@@ -356,7 +356,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
+    UT_CF_AssertEventID(CF_RESET_INF_EID);
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
@@ -401,7 +401,7 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
+    UT_CF_AssertEventID(CF_RESET_INF_EID);
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
@@ -469,7 +469,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
+    UT_CF_AssertEventID(CF_RESET_INF_EID);
 
     UtAssert_ZERO(CF_AppData.hk.counters.cmd);
     UtAssert_ZERO(CF_AppData.hk.counters.err);
@@ -3792,7 +3792,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_EqTo_CF_NUM_COMMANDS_FailAndSendEvent
     /* Assert */
     UtAssert_STUB_COUNT(CFE_MSG_GetFcnCode, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
+    UT_CF_AssertEventID(CF_CC_ERR_EID);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
 }
@@ -3817,7 +3817,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSe
     /* Assert */
     UtAssert_STUB_COUNT(CFE_MSG_GetFcnCode, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
+    UT_CF_AssertEventID(CF_CC_ERR_EID);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
 }
@@ -3844,7 +3844,7 @@ void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForT
     UtAssert_STUB_COUNT(CFE_MSG_GetFcnCode, 1);
     UtAssert_STUB_COUNT(CFE_MSG_GetSize, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_LEN);
+    UT_CF_AssertEventID(CF_CMD_LEN_ERR_EID);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
 }
@@ -3872,7 +3872,7 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_m
     UtAssert_STUB_COUNT(CFE_MSG_GetSize, 1);
     /* Assert for CF_CmdNoop */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
+    UT_CF_AssertEventID(CF_NOOP_INF_EID);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #336
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt