### PR TITLE
Fix #184, work around throttle sem creation race

### DIFF
--- a/fsw/platform_inc/cf_platform_cfg.h
+++ b/fsw/platform_inc/cf_platform_cfg.h
@@ -327,6 +327,28 @@ typedef uint32 CF_TransactionSeq_t;
 #define CF_RCVMSG_TIMEOUT (100)
 
 /**
+ * @brief Limits the number of retries to obtain the CF throttle sem
+ *
+ * @par Description
+ *      If the CF throttle sem is not available during CF startup, the initialization
+ *      will retry after a short delay.
+ *
+ * @sa CF_STARTUP_SEM_TASK_DELAY
+ */
+#define CF_STARTUP_SEM_MAX_RETRIES 25
+
+/**
+ * @brief Number of milliseconds to wait if CF throttle sem is not available
+ *
+ * @par Description
+ *      If the CF throttle sem is not available during CF startup, the initialization
+ *      will delay for this period of time before trying again
+ *
+ * @sa CF_STARTUP_SEM_MAX_RETRIES
+ */
+#define CF_STARTUP_SEM_TASK_DELAY 100
+
+/**
  * \brief Mission specific version number
  *
  *  \par Description:


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a retry loop around OS_CountSemGetIdByName, because if this sem is created by another app there may be some delay until the other app gets to the point where it creates the sem.  This works around the race condition.

A retry limit is also imposed so CF will not spin here forever.

Fixes #184

**Testing performed**
Build and run tests, check file transfers with BP

**Expected behavior changes**
Should start up more reliably

**System(s) tested on**
Ubuntu 22.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
