### PR TITLE
Fix #344, add doc-prebuild dependency

### DIFF
--- a/docs/dox_src/CMakeLists.txt
+++ b/docs/dox_src/CMakeLists.txt
@@ -26,12 +26,16 @@ configure_file(
         @ONLY
 )
 
-add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/html/index.html" "${CMAKE_CURRENT_BINARY_DIR}/ALWAYSBUILD"
+add_custom_target(cf-usersguide-html
     COMMAND doxygen ${CMAKE_CURRENT_BINARY_DIR}/cf-usersguide.doxyfile
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
+# This requires some of the intermediate files from the CFE doc build to be
+# in place prior to running doxygen for CF
+add_dependencies(cf-usersguide-html doc-prebuild)
+
 add_custom_target(cf-usersguide
     COMMAND echo "CF UsersGuide: file://${CMAKE_CURRENT_BINARY_DIR}/html/index.html"
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ALWAYSBUILD"
+    DEPENDS cf-usersguide-html
 )


### PR DESCRIPTION

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The documentation requires some artifacts to be in place, this added dependency ensures they are created before doxygen runs.

Fixes #344

**Testing performed**
Run documentation build

**Expected behavior changes**
No missing file if this is the first/only target built  (file will be created due to dependency)

**System(s) tested on**
Ubuntu 22.04

**Additional context**
Requires merging nasa/cfe#2214 and nasa/osal#1341 before this will actually work.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
