### PR TITLE
Fix #361, add option for trailer bytes in CFDP PDUs

### DIFF
--- a/fsw/inc/cf_platform_cfg.h
+++ b/fsw/inc/cf_platform_cfg.h
@@ -349,6 +349,28 @@ typedef uint32 CF_TransactionSeq_t;
 #define CF_STARTUP_SEM_TASK_DELAY 100
 
 /**
+ * @brief Number of trailing bytes to add to CFDP PDU
+ *
+ * @par Description
+ *      Additional padding bytes to be appended to the tail of CFDP PDUs
+ *      This reserves extra space to the software bus encapsulation buffer for every
+ *      CFDP PDU such that platform-specific trailer information may be added.  This
+ *      includes, but is not limited to a separate CRC or error control field in addition
+ *      to the error control field(s) within the the nominal CFDP protocol.
+ *
+ *      These extra bytes are added at the software bus encapsulation layer, they are not
+ *      part of the CFDP PDU itself.
+ *
+ *      Set to 0 to disable this feature, such that the software bus buffer
+ *      encapsulates only the CFDP PDU and no extra bytes are added.
+ *
+ *  @par Limits:
+ *       Maximum value is the difference between the maximum size of a CFDP PDU and the
+ *       maximum size of an SB message.
+ */
+#define CF_PDU_ENCAPSULATION_EXTRA_TRAILING_BYTES 0
+
+/**
  * \brief Mission specific version number
  *
  *  \par Description:


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds an option to insert platform-specific padding at the end of CFDP PDU encapsulation.  The padding area may be utilized by the deployment to add arbitrary verification information to the PDU.

Fixes #361

**Testing performed**
Build and run all tests
Run a CFDP file transfer

**Expected behavior changes**
None with default config.  New config option allows user to add padding to the end of CFDP PDUs for trailer bytes.

**System(s) tested on**
Debian

**Additional context**
The extra space is added only to the SB encapsulation of CFDP PDUs, this is not within the CFDP PDU itself (that is, the size inside the CFDP PDU does not include these extra bytes, but the size in the CFE SB message that holds the PDU does include it).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
