### PR TITLE
Fix #145, Clean up CF return codes

### DIFF
--- a/fsw/inc/cf_events.h
+++ b/fsw/inc/cf_events.h
@@ -239,7 +239,7 @@
 #define CF_EID_ERR_PDU_SHORT_HEADER (41)
 
 /**
- * \brief CF Metadata PDU Too Shourt Event ID
+ * \brief CF Metadata PDU Too Short Event ID
  *
  *  \par Type: ERROR
  *

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -109,10 +109,10 @@ void CF_CheckTables(void)
  * See description in cf_app.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_ValidateConfigTable(void *tbl_ptr)
+CFE_Status_t CF_ValidateConfigTable(void *tbl_ptr)
 {
     CF_ConfigTable_t * tbl = (CF_ConfigTable_t *)tbl_ptr;
-    int32              ret; /* initialized below */
+    CFE_Status_t       ret; /* initialized below */
     static const int32 no_ticks_per_second = -1;
     static const int32 crc_alignment       = -2;
     static const int32 outgoing_chunk_size = -3;
@@ -148,9 +148,9 @@ int32 CF_ValidateConfigTable(void *tbl_ptr)
  * See description in cf_app.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_TableInit(void)
+CFE_Status_t CF_TableInit(void)
 {
-    int32 status;
+    CFE_Status_t status;
 
     status = CFE_TBL_Register(&CF_AppData.config_handle, CF_CONFIG_TABLE_NAME, sizeof(CF_ConfigTable_t),
                               CFE_TBL_OPT_SNGL_BUFFER | CFE_TBL_OPT_LOAD_DUMP, CF_ValidateConfigTable);
@@ -203,9 +203,9 @@ int32 CF_TableInit(void)
  * See description in cf_app.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_Init(void)
+CFE_Status_t CF_Init(void)
 {
-    int32                            status;
+    CFE_Status_t                     status;
     static const CFE_SB_MsgId_Atom_t MID_VALUES[] = {CF_CMD_MID, CF_SEND_HK_MID, CF_WAKE_UP_MID};
     uint32                           i;
 

--- a/fsw/src/cf_app.h
+++ b/fsw/src/cf_app.h
@@ -35,6 +35,25 @@
 #include "cf_cfdp.h"
 #include "cf_clist.h"
 
+/**************************************************************************
+ **
+ ** Macro definitions
+ **
+ **************************************************************************/
+
+/**
+ * \name CF Error Codes
+ * \{
+ */
+#define CF_ERROR                        -1 /**< \brief Generic CF error return code */
+#define CF_PDU_METADATA_ERROR           -2 /**< \brief Invalid metadata PDU */
+#define CF_SHORT_PDU_ERROR              -3 /**< \brief PDU too short */
+#define CF_REC_PDU_FSIZE_MISMATCH_ERROR -4 /**< \brief Receive PDU: EOF file size mismatch */
+#define CF_REC_PDU_BAD_EOF_ERROR        -5 /**< \brief Receive PDU: Invalid EOF packet */
+#define CF_SEND_PDU_NO_BUF_AVAIL_ERROR  -6 /**< \brief Send PDU: No send buffer available, throttling limit reached */
+#define CF_SEND_PDU_ERROR               -7 /**< \brief Send PDU: Send failed */
+/**\}*/
+
 /**
  * @brief The name of the application command pipe for CF
  */
@@ -44,6 +63,12 @@
  * @brief A common prefix for all data pipes for CF
  */
 #define CF_CHANNEL_PIPE_PREFIX ("CF_CHAN_")
+
+/*************************************************************************
+ **
+ ** Type definitions
+ **
+ **************************************************************************/
 
 /**
  * @brief The CF application global state structure
@@ -64,10 +89,22 @@ typedef struct
     CF_Engine_t engine;
 } CF_AppData_t;
 
+/**************************************************************************
+ **
+ ** Exported data
+ **
+ **************************************************************************/
+
 /**
  * @brief Singleton instance of the application global data
  */
 extern CF_AppData_t CF_AppData;
+
+/**************************************************************************
+ **
+ **  Function Prototypes
+ **
+ **************************************************************************/
 
 /************************************************************************/
 /** @brief Send CF housekeeping packet
@@ -105,7 +142,7 @@ void CF_CheckTables(void);
  * @retval Returns anything else on error.
  *
  */
-int32 CF_ValidateConfigTable(void *tbl_ptr);
+CFE_Status_t CF_ValidateConfigTable(void *tbl_ptr);
 
 /************************************************************************/
 /** @brief Load the table on application start
@@ -118,7 +155,7 @@ int32 CF_ValidateConfigTable(void *tbl_ptr);
  * @retval Returns anything else on error.
  *
  */
-int32 CF_TableInit(void);
+CFE_Status_t CF_TableInit(void);
 
 /************************************************************************/
 /** @brief CF app init function
@@ -135,7 +172,7 @@ int32 CF_TableInit(void);
  * @retval Returns anything else on error.
  *
  */
-int32 CF_Init(void);
+CFE_Status_t CF_Init(void);
 
 /************************************************************************/
 /** @brief CF wakeup function

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -142,7 +142,7 @@ static inline CF_CFDP_Class_t CF_CFDP_GetClass(const CF_Transaction_t *t)
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
-static inline int CF_CFDP_IsSender(CF_Transaction_t *t)
+static inline bool CF_CFDP_IsSender(CF_Transaction_t *t)
 {
     CF_Assert(t->flags.com.q_index != CF_QueueIdx_FREE);
     /* the state could actually be CF_TxnState_IDLE, which is still not a sender. This would
@@ -321,19 +321,17 @@ static inline size_t CF_strnlen(const char *s, size_t maxlen)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_SendMd(CF_Transaction_t *t)
 {
     CF_Logical_PduBuffer_t *ph =
         CF_CFDP_ConstructPduHeader(t, CF_CFDP_FileDirective_METADATA, CF_AppData.config_table->local_eid,
                                    t->history->peer_eid, 0, t->history->seq_num, 0);
     CF_Logical_PduMd_t *md;
-    CF_SendRet_t        sret;
-
-    sret = CF_SendRet_SUCCESS;
+    CFE_Status_t        sret = CFE_SUCCESS;
 
     if (!ph)
     {
-        sret = CF_SendRet_NO_MSG;
+        sret = CF_SEND_PDU_NO_BUF_AVAIL_ERROR;
     }
     else
     {
@@ -365,10 +363,10 @@ CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
     /* NOTE: SendFd does not need a call to CF_CFDP_MsgOutGet, as the caller already has it */
-    CF_SendRet_t ret = CF_SendRet_SUCCESS;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     /* this should check if any encoding error occurred */
 
@@ -422,17 +420,17 @@ void CF_CFDP_AppendTlv(CF_Logical_TlvList_t *ptlv_list, CF_CFDP_TlvType_t tlv_ty
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_SendEof(CF_Transaction_t *t)
 {
     CF_Logical_PduBuffer_t *ph =
         CF_CFDP_ConstructPduHeader(t, CF_CFDP_FileDirective_EOF, CF_AppData.config_table->local_eid,
                                    t->history->peer_eid, 0, t->history->seq_num, 0);
     CF_Logical_PduEof_t *eof;
-    CF_SendRet_t         ret = CF_SendRet_SUCCESS;
+    CFE_Status_t         ret = CFE_SUCCESS;
 
     if (!ph)
     {
-        ret = CF_SendRet_NO_MSG;
+        ret = CF_SEND_PDU_NO_BUF_AVAIL_ERROR;
     }
     else
     {
@@ -461,12 +459,12 @@ CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_CFDP_FileDirective_t dir_code,
+CFE_Status_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_CFDP_FileDirective_t dir_code,
                              CF_CFDP_ConditionCode_t cc, CF_EntityId_t peer_eid, CF_TransactionSeq_t tsn)
 {
     CF_Logical_PduBuffer_t *ph;
     CF_Logical_PduAck_t *   ack;
-    CF_SendRet_t            ret = CF_SendRet_SUCCESS;
+    CFE_Status_t            ret = CFE_SUCCESS;
     CF_EntityId_t           src_eid;
     CF_EntityId_t           dst_eid;
 
@@ -487,7 +485,7 @@ CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_
                                     (dir_code == CF_CFDP_FileDirective_EOF), tsn, 0);
     if (!ph)
     {
-        ret = CF_SendRet_NO_MSG;
+        ret = CF_SEND_PDU_NO_BUF_AVAIL_ERROR;
     }
     else
     {
@@ -512,18 +510,18 @@ CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, CF_CFDP_FinFileStatus_t fs,
+CFE_Status_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, CF_CFDP_FinFileStatus_t fs,
                              CF_CFDP_ConditionCode_t cc)
 {
     CF_Logical_PduBuffer_t *ph =
         CF_CFDP_ConstructPduHeader(t, CF_CFDP_FileDirective_FIN, t->history->peer_eid,
                                    CF_AppData.config_table->local_eid, 1, t->history->seq_num, 0);
     CF_Logical_PduFin_t *fin;
-    CF_SendRet_t         ret = CF_SendRet_SUCCESS;
+    CFE_Status_t         ret = CFE_SUCCESS;
 
     if (!ph)
     {
-        ret = CF_SendRet_NO_MSG;
+        ret = CF_SEND_PDU_NO_BUF_AVAIL_ERROR;
     }
     else
     {
@@ -552,14 +550,14 @@ CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, 
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
     CF_Logical_PduNak_t *nak;
-    CF_SendRet_t         ret = CF_SendRet_SUCCESS;
+    CFE_Status_t         ret = CFE_SUCCESS;
 
     if (!ph)
     {
-        ret = CF_SendRet_NO_MSG;
+        ret = CF_SEND_PDU_NO_BUF_AVAIL_ERROR;
     }
     else
     {
@@ -586,9 +584,9 @@ CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     CF_Assert(chan_num < CF_NUM_CHANNELS);
     /*
@@ -601,7 +599,7 @@ int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_TRUNCATION, CFE_EVS_EventType_ERROR,
                           "CF: pdu rejected due to eid/seq number field truncation");
         ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
-        ret = -1;
+        ret = CF_ERROR;
     }
     /*
      * The "large file" flag is not supported by this implementation yet.
@@ -614,7 +612,7 @@ int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_LARGE_FILE, CFE_EVS_EventType_ERROR,
                           "CF: pdu with large file bit received (unsupported)");
         ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
-        ret = -1;
+        ret = CF_ERROR;
     }
     else
     {
@@ -628,7 +626,7 @@ int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
             CFE_EVS_SendEvent(CF_EID_ERR_PDU_SHORT_HEADER, CFE_EVS_EventType_ERROR, "CF: pdu too short (%lu received)",
                               (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
             ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
-            ret = -1;
+            ret = CF_SHORT_PDU_ERROR;
         }
         else
         {
@@ -646,11 +644,11 @@ int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
     const CF_Logical_PduMd_t *md = &ph->int_header.md;
     int                       lv_ret;
-    int                       ret = 0;
+    CFE_Status_t              ret = CFE_SUCCESS;
 
     CF_CFDP_DecodeMd(ph->pdec, &ph->int_header.md);
     if (!CF_CODEC_IS_OK(ph->pdec))
@@ -659,8 +657,7 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                           "CF: metadata packet too short: %lu bytes received",
                           (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
-        /* error return path */
-        ret = -1;
+        ret = CF_PDU_METADATA_ERROR;
     }
     else
     {
@@ -682,8 +679,7 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                               "CF: metadata pdu rejected due to invalid length in source filename of 0x%02x",
                               md->source_filename.length);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
-            /* error return path */
-            ret = -1;
+            ret = CF_PDU_METADATA_ERROR;
         }
         else
         {
@@ -695,8 +691,7 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                                   "CF: metadata pdu rejected due to invalid length in dest filename of 0x%02x",
                                   md->dest_filename.length);
                 ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
-                /* error return path */
-                ret = -1;
+                ret = CF_PDU_METADATA_ERROR;
             }
             else
             {
@@ -707,7 +702,6 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         }
     }
 
-    /* normal return path */
     return ret;
 }
 
@@ -717,9 +711,9 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     CF_CFDP_DecodeFileDataHeader(ph->pdec, ph->pdu_header.segment_meta_flag, &ph->int_header.fd);
 
@@ -742,7 +736,7 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                           "CF: filedata pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         CF_CFDP_SetTxnStatus(t, CF_TxnStatus_PROTOCOL_ERROR);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
-        ret = -1;
+        ret = CF_SHORT_PDU_ERROR;
     }
     else if (ph->pdu_header.segment_meta_flag)
     {
@@ -751,7 +745,7 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                           "CF: filedata pdu with segment metadata received");
         CF_CFDP_SetTxnStatus(t, CF_TxnStatus_PROTOCOL_ERROR);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
-        ret = -1;
+        ret = CF_ERROR;
     }
 
     return ret;
@@ -763,9 +757,9 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     CF_CFDP_DecodeEof(ph->pdec, &ph->int_header.eof);
 
@@ -773,7 +767,7 @@ int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_EOF_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: eof pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-        ret = -1;
+        ret = CF_SHORT_PDU_ERROR;
     }
 
     return ret;
@@ -785,9 +779,9 @@ int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     CF_CFDP_DecodeAck(ph->pdec, &ph->int_header.ack);
 
@@ -795,7 +789,7 @@ int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_ACK_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: ack pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-        ret = -1;
+        ret = CF_SHORT_PDU_ERROR;
     }
 
     /* nothing to do for this one, as all fields are bytes */
@@ -808,9 +802,9 @@ int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     CF_CFDP_DecodeFin(ph->pdec, &ph->int_header.fin);
 
@@ -818,7 +812,7 @@ int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FIN_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: fin pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-        ret = -1;
+        ret = CF_SHORT_PDU_ERROR;
     }
 
     /* NOTE: right now we don't care about the fault location */
@@ -832,9 +826,9 @@ int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     CF_CFDP_DecodeNak(ph->pdec, &ph->int_header.nak);
 
@@ -842,7 +836,7 @@ int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_NAK_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: nak pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-        ret = -1;
+        ret = CF_SHORT_PDU_ERROR;
     }
 
     return ret;
@@ -949,13 +943,13 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_CFDP_InitEngine(void)
+CFE_Status_t CF_CFDP_InitEngine(void)
 {
     /* initialize all transaction nodes */
     CF_History_t *     h;
     CF_Transaction_t * t                = CF_AppData.engine.transactions;
     CF_ChunkWrapper_t *c                = CF_AppData.engine.chunks;
-    int32              ret              = CFE_SUCCESS;
+    CFE_Status_t       ret              = CFE_SUCCESS;
     int                chunk_mem_offset = 0;
     int                i;
     int                j;
@@ -1059,11 +1053,11 @@ int32 CF_CFDP_InitEngine(void)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
+CFE_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
 {
     CF_CFDP_CycleTx_args_t *args = (CF_CFDP_CycleTx_args_t *)context;
     CF_Transaction_t *      t    = container_of(node, CF_Transaction_t, cl_node);
-    int                     ret  = 1; /* default option is exit traversal */
+    CFE_Status_t            ret  = 1; /* default option is exit traversal */
 
     if (t->flags.com.suspended)
     {
@@ -1138,9 +1132,9 @@ void CF_CFDP_CycleTx(CF_Channel_t *c)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
+CFE_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
 {
-    int                  ret  = CF_CLIST_CONT; /* CF_CLIST_CONT means don't tick one, keep looking for cur */
+    CFE_Status_t         ret  = CF_CLIST_CONT; /* CF_CLIST_CONT means don't tick one, keep looking for cur */
     CF_CFDP_Tick_args_t *args = (CF_CFDP_Tick_args_t *)context;
     CF_Transaction_t *   t    = container_of(node, CF_Transaction_t, cl_node);
     if (!args->c->cur || (args->c->cur == t))
@@ -1280,20 +1274,20 @@ static void CF_CFDP_TxFile_Initiate(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_cl
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
-                     uint8 chan, uint8 priority, CF_EntityId_t dest_id)
+CFE_Status_t CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
+                            uint8 chan, uint8 priority, CF_EntityId_t dest_id)
 {
     CF_Transaction_t *t;
     CF_Channel_t *    c = &CF_AppData.engine.channels[chan];
     CF_Assert(chan < CF_NUM_CHANNELS);
 
-    int32 ret = CFE_SUCCESS;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     if (c->num_cmd_tx == CF_MAX_COMMANDED_PLAYBACK_FILES_PER_CHAN)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_MAX_CMD_TX, CFE_EVS_EventType_ERROR,
                           "CF: max number of commanded files reached");
-        ret = -1;
+        ret = CF_ERROR;
     }
     else
     {
@@ -1321,11 +1315,11 @@ int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
-static int32 CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *p, const char *src_filename, const char *dst_filename,
-                                          CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan, uint8 priority,
-                                          CF_EntityId_t dest_id)
+static CFE_Status_t CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *p, const char *src_filename, const char *dst_filename,
+                                                 CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan, uint8 priority,
+                                                 CF_EntityId_t dest_id)
 {
-    int32 ret;
+    CFE_Status_t ret;
 
     /* make sure the directory can be open */
     ret = OS_DirectoryOpen(&p->dir_id, src_filename);
@@ -1361,8 +1355,8 @@ static int32 CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *p, const char *src_file
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
-                          uint8 chan, uint8 priority, uint16 dest_id)
+CFE_Status_t CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class,
+                                 uint8 keep, uint8 chan, uint8 priority, uint16 dest_id)
 {
     int            i;
     CF_Playback_t *p;
@@ -1379,7 +1373,7 @@ int32 CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF
     if (i == CF_MAX_COMMANDED_PLAYBACK_DIRECTORIES_PER_CHAN)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_DIR_SLOT, CFE_EVS_EventType_ERROR, "CF: no playback dir slot available");
-        return -1;
+        return CF_ERROR;
     }
 
     return CF_CFDP_PlaybackDir_Initiate(p, src_filename, dst_filename, cfdp_class, keep, chan, priority, dest_id);
@@ -1737,7 +1731,7 @@ int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t 
 
     /* ensure output is empty */
     buf[0] = 0;
-    return -1; /* invalid len in lv? */
+    return CF_ERROR; /* invalid len in lv? */
 }
 
 /*----------------------------------------------------------------
@@ -1763,7 +1757,7 @@ void CF_CFDP_CancelTransaction(CF_Transaction_t *t)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context)
+CFE_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context)
 {
     CF_Transaction_t *t = container_of(n, CF_Transaction_t, cl_node);
     if (OS_ObjectIdDefined(t->fd))

--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -130,7 +130,7 @@ void CF_CFDP_SendEotPkt(CF_Transaction_t *t);
  * @returns anything else on error.
  *
  */
-int32 CF_CFDP_InitEngine(void);
+CFE_Status_t CF_CFDP_InitEngine(void);
 
 /************************************************************************/
 /** @brief Cycle the engine. Called once per wakeup.
@@ -169,10 +169,10 @@ void CF_CFDP_DisableEngine(void);
  * @param dest_id       Entity ID of remote receiver
  *
  * @retval #CFE_SUCCESS \copydoc CFE_SUCCESS
- * @returns Anything else on error.
+ * @returns CFE_SUCCESS on success. CF_ERROR on error.
  */
-int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
-                     uint8 chan, uint8 priority, CF_EntityId_t dest_id);
+CFE_Status_t CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
+                            uint8 chan, uint8 priority, CF_EntityId_t dest_id);
 
 /************************************************************************/
 /** @brief Begin transmit of a directory.
@@ -193,10 +193,10 @@ int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP
  * @param dest_id       Entity ID of remote receiver
  *
  * @retval #CFE_SUCCESS \copydoc CFE_SUCCESS
- * @returns Anything else on error.
+ * @returns CFE_SUCCESS on success. CF_ERROR on error.
  */
-int32 CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
-                          uint8 chan, uint8 priority, uint16 dest_id);
+CFE_Status_t CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class,
+                                 uint8 keep, uint8 chan, uint8 priority, uint16 dest_id);
 
 /************************************************************************/
 /** @brief Build the PDU header in the output buffer to prepare to send a packet.
@@ -227,12 +227,11 @@ CF_Logical_PduBuffer_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *t, CF
  *
  * @param t              Pointer to the transaction object
  *
- * @returns CF_SendRet_t status code
- * @retval CF_SendRet_SUCCESS on success.
- * @retval CF_SendRet_NO_MSG if message buffer cannot be obtained.
- * @retval CF_SendRet_ERROR if an error occurred while building the packet.
+ * @returns CFE_Status_t status code
+ * @retval CFE_SUCCESS on success.
+ * @retval CF_SEND_PDU_NO_BUF_AVAIL_ERROR if message buffer cannot be obtained.
  */
-CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t);
+CFE_Status_t CF_CFDP_SendMd(CF_Transaction_t *t);
 
 /************************************************************************/
 /** @brief Send a previously-assembled filedata PDU for transmit.
@@ -248,10 +247,10 @@ CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t);
  * sends the PDU that was previously allocated and assembled.  As such, the
  * typical failure possibilities do not apply to this call.
  *
- * @returns CF_SendRet_t status code
- * @retval CF_SendRet_SUCCESS on success.
+ * @returns CFE_Status_t status code
+ * @retval CFE_SUCCESS on success. (error checks not yet implemented)
  */
-CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Build a eof PDU for transmit.
@@ -261,12 +260,11 @@ CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  *
  * @param t   Pointer to the transaction object
  *
- * @returns CF_SendRet_t status code
- * @retval CF_SendRet_SUCCESS on success.
- * @retval CF_SendRet_NO_MSG if message buffer cannot be obtained.
- * @retval CF_SendRet_ERROR if an error occurred while building the packet.
+ * @returns CFE_Status_t status code
+ * @retval CFE_SUCCESS on success.
+ * @retval CF_SEND_PDU_NO_BUF_AVAIL_ERROR if message buffer cannot be obtained.
  */
-CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t);
+CFE_Status_t CF_CFDP_SendEof(CF_Transaction_t *t);
 
 /************************************************************************/
 /** @brief Build a ack PDU for transmit.
@@ -285,13 +283,11 @@ CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t);
  * @param peer_eid Remote entity ID
  * @param tsn      Transaction sequence number
  *
- * @returns CF_SendRet_t status code
- * @retval CF_SendRet_SUCCESS on success.
- * @retval CF_SendRet_NO_MSG if message buffer cannot be obtained.
- * @retval CF_SendRet_ERROR if an error occurred while building the packet.
- *
+ * @returns CFE_Status_t status code
+ * @retval CFE_SUCCESS on success.
+ * @retval CF_SEND_PDU_NO_BUF_AVAIL_ERROR if message buffer cannot be obtained.
  */
-CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_CFDP_FileDirective_t dir_code,
+CFE_Status_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_CFDP_FileDirective_t dir_code,
                              CF_CFDP_ConditionCode_t cc, CF_EntityId_t peer_eid, CF_TransactionSeq_t tsn);
 
 /************************************************************************/
@@ -305,12 +301,11 @@ CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_
  * @param fs    Final file status (retained or rejected, etc)
  * @param cc    Final CFDP condition code
  *
- * @returns CF_SendRet_t status code
- * @retval CF_SendRet_SUCCESS on success.
- * @retval CF_SendRet_NO_MSG if message buffer cannot be obtained.
- * @retval CF_SendRet_ERROR if an error occurred while building the packet.
+ * @returns CFE_Status_t status code
+ * @retval CFE_SUCCESS on success.
+ * @retval CF_SEND_PDU_NO_BUF_AVAIL_ERROR if message buffer cannot be obtained.
  */
-CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, CF_CFDP_FinFileStatus_t fs,
+CFE_Status_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, CF_CFDP_FinFileStatus_t fs,
                              CF_CFDP_ConditionCode_t cc);
 
 /************************************************************************/
@@ -327,10 +322,11 @@ CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, 
  * encodes and sends the previously-assembled PDU buffer.  As such, the
  * typical failure possibilities do not apply to this call.
  *
- * @returns CF_SendRet_t status code
- * @retval CF_SendRet_SUCCESS on success.
+ * @returns CFE_Status_t status code
+ * @retval CFE_SUCCESS on success.
+ * @retval CF_SEND_PDU_NO_BUF_AVAIL_ERROR if message buffer cannot be obtained.
  */
-CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Appends a single TLV value to the logical PDU data
@@ -361,11 +357,11 @@ void CF_CFDP_AppendTlv(CF_Logical_TlvList_t *ptlv_list, CF_CFDP_TlvType_t tlv_ty
  * @param ph       The logical PDU buffer being received
  *
  * @returns integer status code
- * @retval 0 on success
- * @retval -1 on error
- *
+ * @retval CFE_SUCCESS on success
+ * @retval CF_ERROR for general errors
+ * @retval CF_SHORT_PDU_ERROR if PDU too short
  */
-int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Unpack a metadata PDU from a received message.
@@ -380,10 +376,10 @@ int CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph);
  * @param ph   The logical PDU buffer being received
  *
  * @returns integer status code
- * @retval 0 on success
- * @retval -1 on error
+ * @retval CFE_SUCCESS on success
+ * @retval CF_PDU_METADATA_ERROR on error
  */
-int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Unpack a file data PDU from a received message.
@@ -398,11 +394,11 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  * @param ph   The logical PDU buffer being received
  *
  * @returns integer status code
- * @retval 0 on success
- * @retval -1 on error
- *
+ * @retval CFE_SUCCESS on success
+ * @retval CF_ERROR for general errors
+ * @retval CF_SHORT_PDU_ERROR PDU too short
  */
-int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Unpack an eof PDU from a received message.
@@ -417,11 +413,10 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  * @param ph   The logical PDU buffer being received
  *
  * @returns integer status code
- * @retval 0 on success
- * @retval -1 on error
- *
+ * @retval CFE_SUCCESS on success
+ * @retval CF_SHORT_PDU_ERROR on error
  */
-int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Unpack an ack PDU from a received message.
@@ -436,11 +431,10 @@ int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  * @param ph   The logical PDU buffer being received
  *
  * @returns integer status code
- * @retval 0 on success
- * @retval -1 on error
- *
+ * @retval CFE_SUCCESS on success
+ * @retval CF_SHORT_PDU_ERROR on error
  */
-int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Unpack an fin PDU from a received message.
@@ -455,11 +449,10 @@ int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  * @param ph   The logical PDU buffer being received
  *
  * @returns integer status code
- * @retval 0 on success
- * @retval -1 on error
- *
+ * @retval CFE_SUCCESS on success
+ * @retval CF_SHORT_PDU_ERROR on error
  */
-int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Unpack a nak PDU from a received message.
@@ -474,11 +467,10 @@ int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  * @param ph   The logical PDU buffer being received
  *
  * @returns integer status code
- * @retval 0 on success
- * @retval -1 on error
- *
+ * @retval CFE_SUCCESS on success
+ * @retval CF_SHORT_PDU_ERROR on error
  */
-int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Dispatch received packet to its handler.
@@ -546,7 +538,7 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint
  * @param src_lv     Pointer to LV pair from logical PDU buffer
  *
  * @returns The resulting string length, NOT including termination character
- * @retval -1 on error
+ * @retval CF_ERROR on error
  */
 int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t *src_lv);
 
@@ -610,7 +602,7 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  * @returns integer traversal code
  * @retval Always CF_LIST_CONT indicate list traversal should not exit early.
  */
-int CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context);
+CFE_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context);
 
 /************************************************************************/
 /** @brief Cycle the current active tx or make a new one active.
@@ -648,7 +640,7 @@ void CF_CFDP_CycleTx(CF_Channel_t *c);
  * @retval CF_CLIST_EXIT when it's found, which terminates list traversal
  * @retval CF_CLIST_CONT when it's isn't found, which causes list traversal to continue
  */
-int CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context);
+CFE_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context);
 
 /************************************************************************/
 /** @brief Call R and then S tick functions for all active transactions.
@@ -709,6 +701,6 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c);
  * @retval CF_CLIST_EXIT when it's found, which terminates list traversal
  * @retval CF_CLIST_CONT when it's isn't found, which causes list traversal to continue
  */
-int CF_CFDP_DoTick(CF_CListNode_t *node, void *context);
+CFE_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context);
 
 #endif /* !CF_CFDP_H */

--- a/fsw/src/cf_cfdp_r.h
+++ b/fsw/src/cf_cfdp_r.h
@@ -149,13 +149,13 @@ void CF_CFDP_R2_Reset(CF_Transaction_t *t);
  *       t must not be NULL.
  *
  *
- * @retval 0 on CRC match, otherwise error.
+ * @retval CFE_SUCCESS on CRC match, otherwise error.
  *
  *
  * @param t            Pointer to the transaction object
  * @param expected_crc Expected CRC
  */
-int CF_CFDP_R_CheckCrc(CF_Transaction_t *t, uint32 expected_crc);
+CFE_Status_t CF_CFDP_R_CheckCrc(CF_Transaction_t *t, uint32 expected_crc);
 
 /************************************************************************/
 /** @brief Checks R2 transaction state for transaction completion status.
@@ -184,13 +184,13 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *t, int ok_to_send_nak);
  *       t must not be NULL.
  *
  *
- * @retval 0 on success. Returns anything else on error.
+ * @retval CFE_SUCCESS on success. CF_ERROR on error.
  *
  *
  * @param t  Pointer to the transaction object
  * @param ph Pointer to the PDU information
  */
-int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Processing receive EOF common functionality for R1/R2.
@@ -204,13 +204,13 @@ int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  *       t must not be NULL. ph must not be NULL.
  *
  *
- * @retval 0 on success. Returns anything else on error.
+ * @retval CFE_SUCCESS on success. Returns anything else on error.
  *
  *
  * @param t  Pointer to the transaction object
  * @param ph Pointer to the PDU information
  */
-int CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
+CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
 /** @brief Process receive EOF for R1.
@@ -303,11 +303,11 @@ void CF_CFDP_R2_GapCompute(const CF_ChunkList_t *chunks, const CF_Chunk_t *c, vo
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
  *
- * @retval 0 on success. Returns anything else on error.
+ * @retval CFE_SUCCESS on success. CF_ERROR on error.
  *
  * @param t  Pointer to the transaction object
  */
-int CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t);
+CFE_Status_t CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t);
 
 /************************************************************************/
 /** @brief Calculate up to the configured amount of bytes of CRC.
@@ -326,11 +326,11 @@ int CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t);
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
  *
- * @retval 0 on completion
- * @retval -1 on non-completion. Error status is stored in condition code.
+ * @retval CFE_SUCCESS on completion.
+ * @retval CF_ERROR on non-completion.
  *
  */
-int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t);
+CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t);
 
 /************************************************************************/
 /** @brief Send a FIN pdu.
@@ -338,12 +338,12 @@ int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t);
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
  *
- * @retval 0 on success. Returns anything else on error.
+ * @retval CFE_SUCCESS on success. CF_ERROR on error.
  *
  * @param t  Pointer to the transaction object
  *
  */
-int CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t);
+CFE_Status_t CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t);
 
 /************************************************************************/
 /** @brief Process receive FIN-ACK pdu.

--- a/fsw/src/cf_cfdp_s.h
+++ b/fsw/src/cf_cfdp_s.h
@@ -129,13 +129,13 @@ void CF_CFDP_S_Cancel(CF_Transaction_t *t);
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
  *
- * @retval CF_SendRet_SUCCESS on success.
- * @retval CF_SendRet_NO_MSG if message buffer cannot be obtained.
- * @retval CF_SendRet_ERROR if an error occurred while building the packet.
+ * @retval CFE_SUCCESS on success.
+ * @retval CF_SEND_PDU_NO_BUF_AVAIL_ERROR if message buffer cannot be obtained.
+ * @retval CF_SEND_PDU_ERROR if an error occurred while building the packet.
  *
  * @param t  Pointer to the transaction object
  */
-CF_SendRet_t CF_CFDP_S_SendEof(CF_Transaction_t *t);
+CFE_Status_t CF_CFDP_S_SendEof(CF_Transaction_t *t);
 
 /************************************************************************/
 /** @brief Sends an eof for S1.
@@ -168,7 +168,8 @@ void CF_CFDP_S2_SubstateSendEof(CF_Transaction_t *t);
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
  *
- * @returns The number of bytes sent in the file data PDU, or negative value on error
+ * @returns The number of bytes sent in the file data PDU (CFE_SUCCESS,
+ *          i.e. 0, if no bytes were processed), or CF_ERROR on error
  *
  * @param t     Pointer to the transaction object
  * @param foffs Position in file to send data from
@@ -176,7 +177,7 @@ void CF_CFDP_S2_SubstateSendEof(CF_Transaction_t *t);
  * @param calc_crc Enable CRC/Checksum calculation
  *
  */
-int32 CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_read, uint8 calc_crc);
+CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_read, uint8 calc_crc);
 
 /************************************************************************/
 /** @brief Standard state function to send the next file data PDU for active transaction.
@@ -204,13 +205,13 @@ void CF_CFDP_S_SubstateSendFileData(CF_Transaction_t *t);
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
  *
- * @returns  negative value if error.
+ * @returns CF_ERROR if error.
  * @retval 0 if no NAK processed.
  * @retval 1 if NAK processed.
  *
  * @param t     Pointer to the transaction object
  */
-int CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *t);
+CFE_Status_t CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *t);
 
 /************************************************************************/
 /** @brief Send filedata handling for S2.

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -249,7 +249,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
                                               0); /* populate transaction with needed fields for CF_CFDP_SendAck() */
                         if (CF_CFDP_SendAck(&t_finack, CF_CFDP_AckTxnStatus_UNRECOGNIZED, CF_CFDP_FileDirective_FIN,
                                             ph->int_header.fin.cc, ph->pdu_header.destination_eid,
-                                            ph->pdu_header.sequence_num) != CF_SendRet_NO_MSG)
+                                            ph->pdu_header.sequence_num) != CF_SEND_PDU_NO_BUF_AVAIL_ERROR)
                         {
                             /* couldn't get output buffer -- don't care about a send error (oh well, can't send) but we
                              * do care that there was no message because c->cur will be set to this transaction */

--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -104,17 +104,6 @@ typedef enum
 } CF_RxSubState_t;
 
 /**
- * @brief Special return values from some receive PDU processing functions
- */
-typedef enum
-{
-    CF_RxEofRet_SUCCESS        = 0,
-    CF_RxEofRet_FSIZE_MISMATCH = 1,
-    CF_RxEofRet_BAD_EOF        = 2,
-    CF_RxEofRet_INVALID        = 3,
-} CF_RxEofRet_t;
-
-/**
  * @brief Direction identifier
  *
  * Differentiates between send and receive history entries
@@ -480,16 +469,5 @@ typedef struct CF_Engine
     uint32 outgoing_counter;
     uint8  enabled;
 } CF_Engine_t;
-
-/**
- * @brief Special return values from some send PDU processing functions
- */
-typedef enum
-{
-    CF_SendRet_SUCCESS = 0, /**< \brief Successfully sent */
-    CF_SendRet_NO_MSG  = 1, /**< \brief No send buffer available, throttling limit reached */
-    CF_SendRet_ERROR   = 2, /**< \brief the send itself failed */
-    CF_SendRet_FAILURE = 3, /**< \brief generic failure message not relating to message send */
-} CF_SendRet_t;
 
 #endif

--- a/fsw/src/cf_chunk.c
+++ b/fsw/src/cf_chunk.c
@@ -167,10 +167,10 @@ int CF_Chunks_CombinePrevious(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_
  * See description in cf_chunk.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk)
+CFE_Status_t CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk)
 {
     CF_ChunkIdx_t    combined_i = i;
-    int              ret        = 0;
+    CFE_Status_t     ret        = 0;
     CF_ChunkOffset_t chunk_end  = chunk->offset + chunk->size;
 
     /* Assert no rollover, only possible as a bug */

--- a/fsw/src/cf_chunk.h
+++ b/fsw/src/cf_chunk.h
@@ -278,7 +278,7 @@ int CF_Chunks_CombinePrevious(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_
  * @retval 0 if not combined
  *
  */
-int CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk);
+CFE_Status_t CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk);
 
 /************************************************************************/
 /** @brief Finds the smallest size out of all chunks.

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -212,10 +212,10 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context)
+CFE_Status_t CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context)
 {
-    int i;
-    int ret = 0;
+    int          i;
+    CFE_Status_t ret = 0;
 
     /* this function is generic for any ground command that takes a single channel
      * argument which must be less than CF_NUM_CHANNELS or 255 which is a special
@@ -235,7 +235,7 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_
         /* bad parameter */
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_CHAN_PARAM, CFE_EVS_EventType_ERROR,
                           "CF: %s: channel parameter out of range. received %d", errstr, cmd->data.byte[0]);
-        ret = -1;
+        ret = CF_ERROR;
     }
 
     return ret;
@@ -247,11 +247,11 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
+CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 {
     /* no need to bounds check chan_num, done in caller */
     CF_AppData.hk.channel_hk[chan_num].frozen = context->barg;
-    return 0;
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
@@ -332,10 +332,10 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSe
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context)
+CFE_Status_t CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context)
 {
     CF_Transaction_t *t;
-    int               ret = -1;
+    CFE_Status_t      ret = CF_ERROR;
 
     if (cmd->chan == CF_COMPOUND_KEY)
     {
@@ -527,11 +527,11 @@ void CF_CmdAbandon(CFE_SB_Buffer_t *msg)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
+CFE_Status_t CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 {
     /* no need to bounds check chan_num, done in caller */
     CF_AppData.config_table->chan[chan_num].dequeue_enabled = context->barg;
-    return 0;
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
@@ -586,10 +586,10 @@ void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context)
+CFE_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context)
 {
-    int i;
-    int ret = 0;
+    int          i;
+    CFE_Status_t ret = CFE_SUCCESS;
     /* no need to bounds check chan_num, done in caller */
     if (context->msg->data.byte[1] == CF_ALL_POLLDIRS)
     {
@@ -606,7 +606,7 @@ int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_POLLDIR_INVALID, CFE_EVS_EventType_ERROR,
                           "CF: enable/disable polldir: invalid polldir %d on channel %d", context->msg->data.byte[1],
                           chan_num);
-        ret = -1;
+        ret = CF_ERROR;
     }
 
     return ret;
@@ -668,7 +668,7 @@ void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c)
+CFE_Status_t CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c)
 {
     CF_History_t *h = container_of(n, CF_History_t, cl_node);
     CF_ResetHistory(c, h); /* ok to reset transaction since it's in PEND it hasn't started yet */
@@ -681,7 +681,7 @@ int CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_PurgeTransaction(CF_CListNode_t *n, void *ignored)
+CFE_Status_t CF_PurgeTransaction(CF_CListNode_t *n, void *ignored)
 {
     CF_Transaction_t *t = container_of(n, CF_Transaction_t, cl_node);
     CF_CFDP_ResetTransaction(t, 0);
@@ -694,9 +694,9 @@ int CF_PurgeTransaction(CF_CListNode_t *n, void *ignored)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
+CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
     /* no need to bounds check chan_num, done in caller */
     CF_Channel_t *c = &CF_AppData.engine.channels[chan_num];
 
@@ -721,7 +721,7 @@ int CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
         default:
             CFE_EVS_SendEvent(CF_EID_ERR_CMD_PURGE_ARG, CFE_EVS_EventType_ERROR, "CF: purge queue invalid arg %d",
                               cmd->data.byte[1]);
-            ret = -1;
+            ret = CF_ERROR;
             break;
     }
 
@@ -898,12 +898,12 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CmdValidateChunkSize(uint32 val, uint8 chan_num /* ignored */)
+CFE_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num /* ignored */)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
     if (val > sizeof(CF_CFDP_PduFileDataContent_t))
     {
-        ret = 1; /* failed */
+        ret = CF_ERROR; /* failed */
     }
     return ret;
 }
@@ -914,14 +914,14 @@ int CF_CmdValidateChunkSize(uint32 val, uint8 chan_num /* ignored */)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
+CFE_Status_t CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
 {
-    int ret = 0;
+    CFE_Status_t ret = CFE_SUCCESS;
 
     if (!val && !CF_AppData.config_table->chan[chan_num].sem_name[0])
     {
         /* can't have unlimited messages and no semaphore */
-        ret = 1; /* failed */
+        ret = CF_ERROR; /* failed */
     }
 
     return ret;

--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -155,9 +155,9 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg);
  * @param context   Opaque pointer to pass through to callback (not used in this function)
  *
  * @returns The return value from the given action function.
- *
+ * @retval CF_ERROR on error
  */
-int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context);
+CFE_Status_t CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context);
 
 /************************************************************************/
 /** @brief Channel action to set the frozen bit for a channel.
@@ -168,9 +168,9 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_
  * @param chan_num  channel number
  * @param context   Pointer to object passed through from initial call
  *
- * @returns Always succeeds, so returns 0.
+ * @returns Always succeeds, so returns CFE_SUCCESS.
  */
-int CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context);
+CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context);
 
 /************************************************************************/
 /** @brief Freeze a channel.
@@ -226,7 +226,7 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSe
  * @returns returns the number of transactions acted upon
  *
  */
-int CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context);
+CFE_Status_t CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context);
 
 /************************************************************************/
 /** @brief Set the suspended bit in a transaction.
@@ -329,10 +329,10 @@ void CF_CmdAbandon(CFE_SB_Buffer_t *msg);
  * @param chan_num  channel number
  * @param context   Pointer to object passed through from initial call
  *
- * @returns Always succeeds, so returns 0.
+ * @returns Always succeeds, so returns CFE_SUCCESS.
  *
  */
-int CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context);
+CFE_Status_t CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context);
 
 /************************************************************************/
 /** @brief Handle an enable dequeue ground command.
@@ -364,10 +364,10 @@ void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg);
  * @param context   Pointer to object passed through from initial call
  *
  * @returns success/fail status code
- * @retval  0 if successful
- * @retval  -1 if failed
+ * @retval  CFE_SUCCESS if successful
+ * @retval  CF_ERROR if failed
  */
-int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context);
+CFE_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context);
 
 /************************************************************************/
 /** @brief Enable a polling dir ground command.
@@ -402,7 +402,7 @@ void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg);
  *
  * @returns Always #CF_CLIST_CONT to process all entries
  */
-int CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c);
+CFE_Status_t CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c);
 
 /************************************************************************/
 /** @brief Purge the pending transaction queue.
@@ -417,7 +417,7 @@ int CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c);
  *
  * @returns Always #CF_CLIST_CONT to process all entries
  */
-int CF_PurgeTransaction(CF_CListNode_t *n, void *ignored);
+CFE_Status_t CF_PurgeTransaction(CF_CListNode_t *n, void *ignored);
 
 /************************************************************************/
 /** @brief Channel action command to perform purge queue operations.
@@ -433,10 +433,10 @@ int CF_PurgeTransaction(CF_CListNode_t *n, void *ignored);
  * @param cmd       Pointer to purge queue command
  *
  * @returns integer status code indicating success or failure
- * @retval  0 if successful
- * @retval  -1 if error occurred
+ * @retval  CFE_SUCCESS if successful
+ * @retval  CF_ERROR on error
  */
-int CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd);
+CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd);
 
 /************************************************************************/
 /** @brief Ground command to purge either the history or pending queues.
@@ -468,11 +468,11 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg);
  * @param chan_num  Ignored by this implementation
  *
  * @returns status code indicating if check passed
- * @retval 0 if successful (val is less than or equal to max PDU)
- * @retval 1 if failed (val is greater than max PDU)
+ * @retval CFE_SUCCESS if successful (val is less than or equal to max PDU)
+ * @retval CF_ERROR if failed (val is greater than max PDU)
  *
  */
-int CF_CmdValidateChunkSize(uint32 val, uint8 chan_num);
+CFE_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num);
 
 /************************************************************************/
 /** @brief Checks if the value is within allowable range as outgoing packets per wakeup
@@ -484,8 +484,8 @@ int CF_CmdValidateChunkSize(uint32 val, uint8 chan_num);
  * @param chan_num  CF channel number
  *
  * @returns status code indicating if check passed
- * @retval 0 if successful (val is allowable as max packets per wakeup)
- * @retval 1 if failed (val is not allowed)
+ * @retval CFE_SUCCESS if successful (val is allowable as max packets per wakeup)
+ * @retval CF_ERROR if failed (val is not allowed)
  *
  */
 int CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num);

--- a/fsw/src/cf_codec.c
+++ b/fsw/src/cf_codec.c
@@ -23,6 +23,7 @@
  * CFDP protocol data structure encode/decode implementation
  */
 
+#include "cf_app.h"
 #include "cf_cfdp_pdu.h"
 #include "cf_codec.h"
 #include "cf_events.h"
@@ -762,10 +763,10 @@ uint64 CF_DecodeIntegerInSize(CF_DecoderState_t *state, uint8 decode_size)
  * See description in cf_codec.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh)
+CFE_Status_t CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh)
 {
     const CF_CFDP_PduHeader_t *peh; /* for decoding fixed sized fields */
-    int32                      ret = CFE_SUCCESS;
+    CFE_Status_t               ret = CFE_SUCCESS;
 
     /* decode the standard PDU header */
     peh = CF_DECODE_FIXED_CHUNK(state, CF_CFDP_PduHeader_t);
@@ -786,7 +787,7 @@ int32 CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh
         CF_Codec_Load_uint16(&(plh->data_encoded_length), &(peh->length));
         if ((plh->eid_length > sizeof(plh->source_eid)) || (plh->txn_seq_length > sizeof(plh->sequence_num)))
         {
-            ret = -1;
+            ret = CF_ERROR;
         }
         else
         {

--- a/fsw/src/cf_codec.h
+++ b/fsw/src/cf_codec.h
@@ -620,9 +620,9 @@ void CF_CFDP_EncodeCrc(CF_EncoderState_t *state, uint32 *plcrc);
  * @param state  Decoder state object
  * @param plh    Pointer to logical PDU base header data
  * @retval #CFE_SUCCESS \copydoc CFE_SUCCESS
- * @retval Returns anything else on error.
+ * @retval CF_ERROR on error.
  */
-int32 CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh);
+CFE_Status_t CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh);
 
 /************************************************************************/
 /**

--- a/fsw/src/cf_timer.c
+++ b/fsw/src/cf_timer.c
@@ -62,7 +62,7 @@ void CF_Timer_InitRelSec(CF_Timer_t *t, uint32 rel_sec)
  * See description in cf_timer.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_Timer_Expired(const CF_Timer_t *t)
+bool CF_Timer_Expired(const CF_Timer_t *t)
 {
     return !t->tick;
 }

--- a/fsw/src/cf_timer.h
+++ b/fsw/src/cf_timer.h
@@ -73,7 +73,7 @@ void CF_Timer_InitRelSec(CF_Timer_t *t, CF_Timer_Seconds_t rel_sec);
  * @retval 1 if expired
  * @retval 0 if not expired
  */
-int CF_Timer_Expired(const CF_Timer_t *t);
+bool CF_Timer_Expired(const CF_Timer_t *t);
 
 /************************************************************************/
 /** @brief Notify a timer object a tick has occurred.

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -116,10 +116,10 @@ void CF_FreeTransaction(CF_Transaction_t *t)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context)
+CFE_Status_t CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context)
 {
     CF_Transaction_t *t   = container_of(n, CF_Transaction_t, cl_node);
-    int               ret = 0;
+    CFE_Status_t      ret = 0;
 
     if ((t->history->src_eid == context->src_eid) && (t->history->seq_num == context->transaction_sequence_number))
     {
@@ -168,14 +168,14 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *c, CF_Transac
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
+CFE_Status_t CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
 {
     static const char *CF_DSTR[] = {"RX", "TX"}; /* conversion of CF_Direction_t to string */
 
-    int   i;
-    int32 ret;
-    int32 len;
-    char  linebuf[(CF_FILENAME_MAX_LEN * 2) + 128]; /* buffer for line data */
+    int          i;
+    CFE_Status_t ret;
+    int32        len;
+    char         linebuf[(CF_FILENAME_MAX_LEN * 2) + 128]; /* buffer for line data */
 
     for (i = 0; i < 3; ++i)
     {
@@ -202,11 +202,11 @@ int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CMD_WHIST_WRITE, CFE_EVS_EventType_ERROR,
                               "CF: writing queue file failed, expected %ld got %ld", (long)len, (long)ret);
-            return -1;
+            return CF_ERROR;
         }
     }
 
-    return 0;
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
@@ -215,7 +215,7 @@ int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
+CFE_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
 {
     CF_Traverse_WriteHistoryFileArg_t *context = arg;
     CF_History_t *                     h       = container_of(n, CF_History_t, cl_node);
@@ -242,7 +242,7 @@ int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
+CFE_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
 {
     CF_Traverse_WriteTxnFileArg_t *context = arg;
     CF_Transaction_t *             t       = container_of(n, CF_Transaction_t, cl_node);
@@ -264,7 +264,7 @@ int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
+CFE_Status_t CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
 {
     CF_Traverse_WriteTxnFileArg_t arg;
 
@@ -282,7 +282,7 @@ int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction_t dir)
+CFE_Status_t CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction_t dir)
 {
     CF_Traverse_WriteHistoryFileArg_t arg;
 
@@ -301,7 +301,7 @@ int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_PrioSearch(CF_CListNode_t *node, void *context)
+CFE_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context)
 {
     CF_Transaction_t *         t = container_of(node, CF_Transaction_t, cl_node);
     CF_Traverse_PriorityArg_t *p = (CF_Traverse_PriorityArg_t *)context;
@@ -368,7 +368,7 @@ void CF_InsertSortPrio(CF_Transaction_t *t, CF_QueueIdx_t q)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args)
+CFE_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args)
 {
     CF_Transaction_t *t = container_of(n, CF_Transaction_t, cl_node);
     args->fn(t, args->context);
@@ -382,7 +382,7 @@ int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *arg
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t fn, void *context)
+CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t fn, void *context)
 {
     CF_TraverseAll_Arg_t args = {fn, context, 0};
     CF_QueueIdx_t        queueidx;
@@ -398,10 +398,10 @@ int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t 
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
+CFE_Status_t CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
 {
-    int i;
-    int ret = 0;
+    int          i;
+    CFE_Status_t ret = 0;
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
         ret += CF_TraverseAllTransactions(CF_AppData.engine.channels + i, fn, context);
     return ret;
@@ -413,9 +413,9 @@ int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, 
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 access)
+CFE_Status_t CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 access)
 {
-    int32 ret;
+    CFE_Status_t ret;
 
     CFE_ES_PerfLogEntry(CF_PERF_ID_FOPEN);
     ret = OS_OpenCreate(fd, fname, flags, access);
@@ -450,9 +450,9 @@ void CF_WrappedClose(osal_id_t fd)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
+CFE_Status_t CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
 {
-    int32 ret;
+    CFE_Status_t ret;
 
     CFE_ES_PerfLogEntry(CF_PERF_ID_FREAD);
     ret = OS_read(fd, buf, read_size);
@@ -466,9 +466,9 @@ int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
+CFE_Status_t CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
 {
-    int32 ret;
+    CFE_Status_t ret;
 
     CFE_ES_PerfLogEntry(CF_PERF_ID_FWRITE);
     ret = OS_write(fd, buf, write_size);
@@ -482,9 +482,9 @@ int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
  * See description in cf_utils.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CF_WrappedLseek(osal_id_t fd, off_t offset, int mode)
+CFE_Status_t CF_WrappedLseek(osal_id_t fd, off_t offset, int mode)
 {
-    int ret;
+    CFE_Status_t ret;
     CFE_ES_PerfLogEntry(CF_PERF_ID_FSEEK);
     ret = OS_lseek(fd, offset, mode);
     CFE_ES_PerfLogExit(CF_PERF_ID_FSEEK);

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -229,7 +229,7 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *c, CF_Transac
  * @retval 0 when it isn't found, which causes list traversal to continue
  *
  */
-int CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context);
+CFE_Status_t CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context);
 
 /************************************************************************/
 /** @brief Write a single history to a file.
@@ -247,10 +247,10 @@ int CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_Trans
  * @param fd Open File descriptor to write to
  * @param h  Pointer to CF history object to write
  *
- * @retval 0 on success
- * @retval -1 on error
+ * @retval CFE_SUCCESS on success
+ * @retval CF_ERROR on error
  */
-int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h);
+CFE_Status_t CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h);
 
 /************************************************************************/
 /** @brief Write a transaction-based queue's transaction history to a file.
@@ -265,7 +265,7 @@ int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h);
  * @retval 0 on success
  * @retval 1 on error
  */
-int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q);
+CFE_Status_t CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q);
 
 /************************************************************************/
 /** @brief Write a history-based queue's entries to a file.
@@ -280,7 +280,7 @@ int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
  * @retval 0 on success
  * @retval 1 on error
  */
-int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction_t dir);
+CFE_Status_t CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction_t dir);
 
 /************************************************************************/
 /** @brief Insert a transaction into a priority sorted transaction queue.
@@ -311,7 +311,7 @@ void CF_InsertSortPrio(CF_Transaction_t *t, CF_QueueIdx_t q);
  *
  * @returns Number of transactions traversed
  */
-int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t fn, void *context);
+CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t fn, void *context);
 
 /************************************************************************/
 /** @brief Traverses all transactions on all channels and performs an operation on them.
@@ -341,7 +341,7 @@ int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, 
  *
  * @retval 0 for do not exit early (always continue)
  */
-int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args);
+CFE_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args);
 
 /************************************************************************/
 /** @brief Writes a human readable representation of a history queue entry to a file
@@ -361,7 +361,7 @@ int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *arg
  * @retval CF_CLIST_CONT if everything is going well
  * @retval CF_CLIST_EXIT if a write error occurred, which means traversal should stop
  */
-int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg);
+CFE_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg);
 
 /************************************************************************/
 /** @brief Writes a human readable representation of a transaction history entry to a file
@@ -378,7 +378,7 @@ int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg);
  * @retval CF_CLIST_CONT if everything is going well
  * @retval CF_CLIST_EXIT if a write error occurred, which means traversal should stop
  */
-int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg);
+CFE_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg);
 
 /************************************************************************/
 /** @brief Searches for the first transaction with a lower priority than given.
@@ -393,7 +393,7 @@ int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg);
  * @retval CF_CLIST_CONT when it isn't found, which causes list traversal to continue
  *
  */
-int CF_PrioSearch(CF_CListNode_t *node, void *context);
+CFE_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context);
 
 /************************************************************************/
 /** @brief Wrap the filesystem open call with a perf counter.
@@ -410,7 +410,7 @@ int CF_PrioSearch(CF_CListNode_t *node, void *context);
  *
  * @returns Status code from OSAL
  */
-int32 CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 access);
+CFE_Status_t CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 access);
 
 /************************************************************************/
 /** @brief Wrap the filesystem close call with a perf counter.
@@ -439,7 +439,7 @@ void CF_WrappedClose(osal_id_t fd);
  *
  * @returns Status code from OSAL (byte count or error code)
  */
-int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size);
+CFE_Status_t CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size);
 
 /************************************************************************/
 /** @brief Wrap the filesystem write call with a perf counter.
@@ -455,7 +455,7 @@ int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size);
  *
  * @returns Status code from OSAL (byte count or error code)
  */
-int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size);
+CFE_Status_t CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size);
 
 /************************************************************************/
 /** @brief Wrap the filesystem lseek call with a perf counter.
@@ -471,7 +471,7 @@ int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size);
  *
  * @returns Status code from OSAL (byte count or error code)
  */
-int32 CF_WrappedLseek(osal_id_t fd, off_t offset, int mode);
+CFE_Status_t CF_WrappedLseek(osal_id_t fd, off_t offset, int mode);
 
 /************************************************************************/
 /** @brief Converts the internal transaction status to a CFDP condition code

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -216,7 +216,7 @@ void Test_CF_CFDP_R_Tick(void)
 
     /* same as above, but SendAck fails */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendAck), 1, CF_SendRet_NO_MSG);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendAck), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     t->state                     = CF_TxnState_R2;
     t->flags.rx.send_ack         = true;
     t->flags.rx.inactivity_fired = true;
@@ -233,7 +233,7 @@ void Test_CF_CFDP_R_Tick(void)
 
     /* same as above, but CF_CFDP_R_SubstateSendNak fails */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendNak), 1, CF_SendRet_NO_MSG);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendNak), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     t->state                     = CF_TxnState_R2;
     t->flags.rx.send_nak         = true;
     t->flags.rx.inactivity_fired = true;
@@ -250,7 +250,7 @@ void Test_CF_CFDP_R_Tick(void)
 
     /* same as above, but CF_CFDP_R2_SubstateSendFin fails */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendFin), 1, CF_SendRet_NO_MSG);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendFin), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     t->state                     = CF_TxnState_R2;
     t->flags.rx.send_fin         = true;
     t->flags.rx.inactivity_fired = true;
@@ -625,13 +625,13 @@ void Test_CF_CFDP_R_SubstateRecvEof(void)
     t->flags.rx.md_recv = true;
     eof->size           = 100;
     t->fsize            = 300;
-    UtAssert_INT32_EQ(CF_CFDP_R_SubstateRecvEof(t, ph), CF_RxEofRet_FSIZE_MISMATCH);
+    UtAssert_INT32_EQ(CF_CFDP_R_SubstateRecvEof(t, ph), CF_REC_PDU_FSIZE_MISMATCH_ERROR);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_SIZE_MISMATCH);
 
     /* with failure of CF_CFDP_RecvEof() */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_RecvEof), -1);
-    UtAssert_INT32_EQ(CF_CFDP_R_SubstateRecvEof(t, ph), CF_RxEofRet_BAD_EOF);
+    UtAssert_INT32_EQ(CF_CFDP_R_SubstateRecvEof(t, ph), CF_REC_PDU_BAD_EOF_ERROR);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_EOF);
 
     /* these counters should have been updated during the test */
@@ -713,7 +713,7 @@ void Test_CF_CFDP_R2_SubstateRecvEof(void)
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 1); /* unchanged */
 
     /* failure in CF_CFDP_R_SubstateRecvEof - not a stub, but calls CF_CFDP_RecvEof, which is. */
-    /* This will follow the CF_RxEofRet_BAD_EOF processing path, which just sets state to FILEDATA */
+    /* This will follow the CF_REC_PDU_BAD_EOF_ERROR processing path, which just sets state to FILEDATA */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvEof), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_R2_SubstateRecvEof(t, ph));
@@ -858,7 +858,7 @@ void Test_CF_CFDP_R_SubstateSendNak(void)
 
     /* same, but with failure of CF_CFDP_SendNak */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendNak), 1, CF_SendRet_NO_MSG);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendNak), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateSendNak(t), -1);
     UT_CF_AssertEventID(CF_EID_INF_CFDP_R_REQUEST_MD);
     UtAssert_STUB_COUNT(CF_CFDP_SendNak, 2);
@@ -892,7 +892,7 @@ void Test_CF_CFDP_R_SubstateSendNak(void)
     /* this also should use the max chunks instead of count */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, &t, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_ChunkList_ComputeGaps), 1, 1);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendNak), 1, CF_SendRet_NO_MSG);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendNak), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     t->flags.rx.md_recv = true;
     t->chunks           = &chunks;
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateSendNak(t), -1);
@@ -999,7 +999,7 @@ void Test_CF_CFDP_R2_SubstateSendFin(void)
 
     /* failure in CF_CFDP_SendFin */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendFin), 1, CF_SendRet_NO_MSG);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendFin), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     UtAssert_INT32_EQ(CF_CFDP_R2_SubstateSendFin(t), -1);
 
     /* non-success transaction status code */
@@ -1074,21 +1074,21 @@ void Test_CF_CFDP_R2_RecvMd(void)
 
     /* OS_mv failure */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(OS_mv), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(OS_mv), 1, CF_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_RENAME);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* reopen failure */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, CF_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_OPEN);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* CF_CFDP_RecvMd failure */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvMd), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvMd), 1, CF_PDU_METADATA_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_MD);
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error, 1);

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -301,7 +301,7 @@ void Test_CF_CFDP_ReceiveMessage(void)
 
     /* FIN handling special case, but failure of CF_CFDP_SendAck */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &c, NULL, &t, &config);
-    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendAck), 1, CF_SendRet_NO_MSG);
+    UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendAck), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     config->local_eid             = 123;
     ph->pdu_header.source_eid     = config->local_eid;
     ph->fdirective.directive_code = CF_CFDP_FileDirective_FIN;

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -3385,7 +3385,7 @@ void Test_CF_CmdValidateChunkSize_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(
     local_result = CF_CmdValidateChunkSize(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == 1, "CF_CmdValidateChunkSize returned %d and should be 1 (failed)", local_result);
+    UtAssert_True(local_result == -1, "CF_CmdValidateChunkSize returned %d and should be -1 (failed)", local_result);
 }
 
 void Test_CF_CmdValidateChunkSize_Any_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(void)
@@ -3399,7 +3399,7 @@ void Test_CF_CmdValidateChunkSize_Any_val_GreaterThan_pdu_fd_data_t_FailAndRetur
     local_result = CF_CmdValidateChunkSize(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == 1, "CF_CmdValidateChunkSize returned %d and should be 1 (failed)", local_result);
+    UtAssert_True(local_result == -1, "CF_CmdValidateChunkSize returned %d and should be -1 (failed)", local_result);
 }
 
 void Test_CF_CmdValidateChunkSize_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0(void)
@@ -3483,7 +3483,7 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Retu
     local_result = CF_CmdValidateMaxOutgoing(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == 1, "CF_CmdValidateMaxOutgoing returned %d and should be 1 (Success)", local_result);
+    UtAssert_True(local_result == -1, "CF_CmdValidateMaxOutgoing returned %d and should be -1 (failed)", local_result);
 }
 
 /*******************************************************************************

--- a/unit-test/stubs/cf_app_stubs.c
+++ b/unit-test/stubs/cf_app_stubs.c
@@ -61,13 +61,13 @@ void CF_HkCmd(void)
  * Generated stub function for CF_Init()
  * ----------------------------------------------------
  */
-int32 CF_Init(void)
+CFE_Status_t CF_Init(void)
 {
-    UT_GenStub_SetupReturnBuffer(CF_Init, int32);
+    UT_GenStub_SetupReturnBuffer(CF_Init, CFE_Status_t);
 
     UT_GenStub_Execute(CF_Init, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_Init, int32);
+    return UT_GenStub_GetReturnValue(CF_Init, CFE_Status_t);
 }
 
 /*
@@ -87,13 +87,13 @@ void CF_ProcessMsg(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_TableInit()
  * ----------------------------------------------------
  */
-int32 CF_TableInit(void)
+CFE_Status_t CF_TableInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TableInit, int32);
+    UT_GenStub_SetupReturnBuffer(CF_TableInit, CFE_Status_t);
 
     UT_GenStub_Execute(CF_TableInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_TableInit, int32);
+    return UT_GenStub_GetReturnValue(CF_TableInit, CFE_Status_t);
 }
 
 /*
@@ -101,15 +101,15 @@ int32 CF_TableInit(void)
  * Generated stub function for CF_ValidateConfigTable()
  * ----------------------------------------------------
  */
-int32 CF_ValidateConfigTable(void *tbl_ptr)
+CFE_Status_t CF_ValidateConfigTable(void *tbl_ptr)
 {
-    UT_GenStub_SetupReturnBuffer(CF_ValidateConfigTable, int32);
+    UT_GenStub_SetupReturnBuffer(CF_ValidateConfigTable, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_ValidateConfigTable, void *, tbl_ptr);
 
     UT_GenStub_Execute(CF_ValidateConfigTable, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_ValidateConfigTable, int32);
+    return UT_GenStub_GetReturnValue(CF_ValidateConfigTable, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_cfdp_r_stubs.c
+++ b/unit-test/stubs/cf_cfdp_r_stubs.c
@@ -82,15 +82,15 @@ void CF_CFDP_R1_SubstateRecvFileData(CF_Transaction_t *t, CF_Logical_PduBuffer_t
  * Generated stub function for CF_CFDP_R2_CalcCrcChunk()
  * ----------------------------------------------------
  */
-int CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_R2_CalcCrcChunk, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_R2_CalcCrcChunk, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_R2_CalcCrcChunk, CF_Transaction_t *, t);
 
     UT_GenStub_Execute(CF_CFDP_R2_CalcCrcChunk, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_R2_CalcCrcChunk, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_R2_CalcCrcChunk, CFE_Status_t);
 }
 
 /*
@@ -215,15 +215,15 @@ void CF_CFDP_R2_SubstateRecvFileData(CF_Transaction_t *t, CF_Logical_PduBuffer_t
  * Generated stub function for CF_CFDP_R2_SubstateSendFin()
  * ----------------------------------------------------
  */
-int CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_R2_SubstateSendFin, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_R2_SubstateSendFin, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_R2_SubstateSendFin, CF_Transaction_t *, t);
 
     UT_GenStub_Execute(CF_CFDP_R2_SubstateSendFin, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_R2_SubstateSendFin, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_R2_SubstateSendFin, CFE_Status_t);
 }
 
 /*
@@ -243,16 +243,16 @@ void CF_CFDP_R_Cancel(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_R_CheckCrc()
  * ----------------------------------------------------
  */
-int CF_CFDP_R_CheckCrc(CF_Transaction_t *t, uint32 expected_crc)
+CFE_Status_t CF_CFDP_R_CheckCrc(CF_Transaction_t *t, uint32 expected_crc)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_CheckCrc, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_CheckCrc, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_R_CheckCrc, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_R_CheckCrc, uint32, expected_crc);
 
     UT_GenStub_Execute(CF_CFDP_R_CheckCrc, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_R_CheckCrc, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_R_CheckCrc, CFE_Status_t);
 }
 
 /*
@@ -272,16 +272,16 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_R_ProcessFd()
  * ----------------------------------------------------
  */
-int CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_ProcessFd, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_ProcessFd, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_R_ProcessFd, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_R_ProcessFd, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_R_ProcessFd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_R_ProcessFd, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_R_ProcessFd, CFE_Status_t);
 }
 
 /*
@@ -301,16 +301,16 @@ void CF_CFDP_R_SendInactivityEvent(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_R_SubstateRecvEof()
  * ----------------------------------------------------
  */
-int CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_SubstateRecvEof, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_SubstateRecvEof, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_R_SubstateRecvEof, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_R_SubstateRecvEof, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_R_SubstateRecvEof, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_R_SubstateRecvEof, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_R_SubstateRecvEof, CFE_Status_t);
 }
 
 /*
@@ -318,15 +318,15 @@ int CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_R_SubstateSendNak()
  * ----------------------------------------------------
  */
-int CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_SubstateSendNak, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_R_SubstateSendNak, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_R_SubstateSendNak, CF_Transaction_t *, t);
 
     UT_GenStub_Execute(CF_CFDP_R_SubstateSendNak, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_R_SubstateSendNak, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_R_SubstateSendNak, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_cfdp_s_stubs.c
+++ b/unit-test/stubs/cf_cfdp_s_stubs.c
@@ -194,15 +194,15 @@ void CF_CFDP_S_Cancel(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_S_CheckAndRespondNak()
  * ----------------------------------------------------
  */
-int CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *t)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_S_CheckAndRespondNak, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_S_CheckAndRespondNak, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_S_CheckAndRespondNak, CF_Transaction_t *, t);
 
     UT_GenStub_Execute(CF_CFDP_S_CheckAndRespondNak, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_S_CheckAndRespondNak, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_S_CheckAndRespondNak, CFE_Status_t);
 }
 
 /*
@@ -210,15 +210,15 @@ int CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_S_SendEof()
  * ----------------------------------------------------
  */
-CF_SendRet_t CF_CFDP_S_SendEof(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_S_SendEof(CF_Transaction_t *t)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_S_SendEof, CF_SendRet_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_S_SendEof, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_S_SendEof, CF_Transaction_t *, t);
 
     UT_GenStub_Execute(CF_CFDP_S_SendEof, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_S_SendEof, CF_SendRet_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_S_SendEof, CFE_Status_t);
 }
 
 /*
@@ -226,9 +226,9 @@ CF_SendRet_t CF_CFDP_S_SendEof(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_S_SendFileData()
  * ----------------------------------------------------
  */
-int32 CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_read, uint8 calc_crc)
+CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_read, uint8 calc_crc)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_S_SendFileData, int32);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_S_SendFileData, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_S_SendFileData, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_S_SendFileData, uint32, foffs);
@@ -237,7 +237,7 @@ int32 CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 bytes_to_
 
     UT_GenStub_Execute(CF_CFDP_S_SendFileData, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_S_SendFileData, int32);
+    return UT_GenStub_GetReturnValue(CF_CFDP_S_SendFileData, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -74,16 +74,16 @@ void CF_CFDP_CancelTransaction(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_CloseFiles()
  * ----------------------------------------------------
  */
-int CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context)
+CFE_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *n, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_CloseFiles, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_CloseFiles, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_CloseFiles, CF_CListNode_t *, n);
     UT_GenStub_AddParam(CF_CFDP_CloseFiles, void *, context);
 
     UT_GenStub_Execute(CF_CFDP_CloseFiles, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_CloseFiles, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_CloseFiles, CFE_Status_t);
 }
 
 /*
@@ -155,16 +155,16 @@ void CF_CFDP_CycleTx(CF_Channel_t *c)
  * Generated stub function for CF_CFDP_CycleTxFirstActive()
  * ----------------------------------------------------
  */
-int CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
+CFE_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_CycleTxFirstActive, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_CycleTxFirstActive, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_CycleTxFirstActive, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_CFDP_CycleTxFirstActive, void *, context);
 
     UT_GenStub_Execute(CF_CFDP_CycleTxFirstActive, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_CycleTxFirstActive, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_CycleTxFirstActive, CFE_Status_t);
 }
 
 /*
@@ -212,16 +212,16 @@ void CF_CFDP_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_DoTick()
  * ----------------------------------------------------
  */
-int CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
+CFE_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_DoTick, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_DoTick, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_DoTick, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_CFDP_DoTick, void *, context);
 
     UT_GenStub_Execute(CF_CFDP_DoTick, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_DoTick, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_DoTick, CFE_Status_t);
 }
 
 /*
@@ -246,13 +246,13 @@ void CF_CFDP_EncodeStart(CF_EncoderState_t *penc, void *msgbuf, CF_Logical_PduBu
  * Generated stub function for CF_CFDP_InitEngine()
  * ----------------------------------------------------
  */
-int32 CF_CFDP_InitEngine(void)
+CFE_Status_t CF_CFDP_InitEngine(void)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_InitEngine, int32);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_InitEngine, CFE_Status_t);
 
     UT_GenStub_Execute(CF_CFDP_InitEngine, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_InitEngine, int32);
+    return UT_GenStub_GetReturnValue(CF_CFDP_InitEngine, CFE_Status_t);
 }
 
 /*
@@ -276,10 +276,10 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint
  * Generated stub function for CF_CFDP_PlaybackDir()
  * ----------------------------------------------------
  */
-int32 CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
-                          uint8 chan, uint8 priority, uint16 dest_id)
+CFE_Status_t CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class,
+                                 uint8 keep, uint8 chan, uint8 priority, uint16 dest_id)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_PlaybackDir, int32);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_PlaybackDir, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_PlaybackDir, const char *, src_filename);
     UT_GenStub_AddParam(CF_CFDP_PlaybackDir, const char *, dst_filename);
@@ -291,7 +291,7 @@ int32 CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filename, CF
 
     UT_GenStub_Execute(CF_CFDP_PlaybackDir, Basic, UT_DefaultHandler_CF_CFDP_PlaybackDir);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_PlaybackDir, int32);
+    return UT_GenStub_GetReturnValue(CF_CFDP_PlaybackDir, CFE_Status_t);
 }
 
 /*
@@ -324,16 +324,16 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c)
  * Generated stub function for CF_CFDP_RecvAck()
  * ----------------------------------------------------
  */
-int CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvAck, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvAck, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_RecvAck, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_RecvAck, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_RecvAck, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_RecvAck, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_RecvAck, CFE_Status_t);
 }
 
 /*
@@ -354,16 +354,16 @@ void CF_CFDP_RecvDrop(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_RecvEof()
  * ----------------------------------------------------
  */
-int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvEof, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvEof, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_RecvEof, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_RecvEof, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_RecvEof, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_RecvEof, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_RecvEof, CFE_Status_t);
 }
 
 /*
@@ -371,16 +371,16 @@ int CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_RecvFd()
  * ----------------------------------------------------
  */
-int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvFd, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvFd, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_RecvFd, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_RecvFd, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_RecvFd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_RecvFd, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_RecvFd, CFE_Status_t);
 }
 
 /*
@@ -388,16 +388,16 @@ int CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_RecvFin()
  * ----------------------------------------------------
  */
-int CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvFin, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvFin, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_RecvFin, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_RecvFin, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_RecvFin, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_RecvFin, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_RecvFin, CFE_Status_t);
 }
 
 /*
@@ -418,16 +418,16 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_RecvMd()
  * ----------------------------------------------------
  */
-int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvMd, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvMd, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_RecvMd, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_RecvMd, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_RecvMd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_RecvMd, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_RecvMd, CFE_Status_t);
 }
 
 /*
@@ -435,16 +435,16 @@ int CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_RecvNak()
  * ----------------------------------------------------
  */
-int CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvNak, int);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_RecvNak, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_RecvNak, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_RecvNak, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_RecvNak, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_RecvNak, int);
+    return UT_GenStub_GetReturnValue(CF_CFDP_RecvNak, CFE_Status_t);
 }
 
 /*
@@ -482,10 +482,10 @@ void CF_CFDP_ResetTransaction(CF_Transaction_t *t, int keep_history)
  * Generated stub function for CF_CFDP_SendAck()
  * ----------------------------------------------------
  */
-CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_CFDP_FileDirective_t dir_code,
+CFE_Status_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_CFDP_FileDirective_t dir_code,
                              CF_CFDP_ConditionCode_t cc, CF_EntityId_t peer_eid, CF_TransactionSeq_t tsn)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendAck, CF_SendRet_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendAck, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_SendAck, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_SendAck, CF_CFDP_AckTxnStatus_t, ts);
@@ -496,7 +496,7 @@ CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_
 
     UT_GenStub_Execute(CF_CFDP_SendAck, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_SendAck, CF_SendRet_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_SendAck, CFE_Status_t);
 }
 
 /*
@@ -504,15 +504,15 @@ CF_SendRet_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_
  * Generated stub function for CF_CFDP_SendEof()
  * ----------------------------------------------------
  */
-CF_SendRet_t CF_CFDP_SendEof(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_SendEof(CF_Transaction_t *t)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendEof, CF_SendRet_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendEof, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_SendEof, CF_Transaction_t *, t);
 
     UT_GenStub_Execute(CF_CFDP_SendEof, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_SendEof, CF_SendRet_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_SendEof, CFE_Status_t);
 }
 
 /*
@@ -532,16 +532,16 @@ void CF_CFDP_SendEotPkt(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_SendFd()
  * ----------------------------------------------------
  */
-CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendFd, CF_SendRet_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendFd, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_SendFd, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_SendFd, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_SendFd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_SendFd, CF_SendRet_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_SendFd, CFE_Status_t);
 }
 
 /*
@@ -549,10 +549,10 @@ CF_SendRet_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_SendFin()
  * ----------------------------------------------------
  */
-CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, CF_CFDP_FinFileStatus_t fs,
+CFE_Status_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, CF_CFDP_FinFileStatus_t fs,
                              CF_CFDP_ConditionCode_t cc)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendFin, CF_SendRet_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendFin, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_SendFin, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_SendFin, CF_CFDP_FinDeliveryCode_t, dc);
@@ -561,7 +561,7 @@ CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, 
 
     UT_GenStub_Execute(CF_CFDP_SendFin, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_SendFin, CF_SendRet_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_SendFin, CFE_Status_t);
 }
 
 /*
@@ -569,15 +569,15 @@ CF_SendRet_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, 
  * Generated stub function for CF_CFDP_SendMd()
  * ----------------------------------------------------
  */
-CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t)
+CFE_Status_t CF_CFDP_SendMd(CF_Transaction_t *t)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendMd, CF_SendRet_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendMd, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_SendMd, CF_Transaction_t *, t);
 
     UT_GenStub_Execute(CF_CFDP_SendMd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_SendMd, CF_SendRet_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_SendMd, CFE_Status_t);
 }
 
 /*
@@ -585,16 +585,16 @@ CF_SendRet_t CF_CFDP_SendMd(CF_Transaction_t *t)
  * Generated stub function for CF_CFDP_SendNak()
  * ----------------------------------------------------
  */
-CF_SendRet_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
+CFE_Status_t CF_CFDP_SendNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendNak, CF_SendRet_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_SendNak, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_SendNak, CF_Transaction_t *, t);
     UT_GenStub_AddParam(CF_CFDP_SendNak, CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_SendNak, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_SendNak, CF_SendRet_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_SendNak, CFE_Status_t);
 }
 
 /*
@@ -627,10 +627,10 @@ void CF_CFDP_TickTransactions(CF_Channel_t *c)
  * Generated stub function for CF_CFDP_TxFile()
  * ----------------------------------------------------
  */
-int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
-                     uint8 chan, uint8 priority, CF_EntityId_t dest_id)
+CFE_Status_t CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP_Class_t cfdp_class, uint8 keep,
+                            uint8 chan, uint8 priority, CF_EntityId_t dest_id)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_TxFile, int32);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_TxFile, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_TxFile, const char *, src_filename);
     UT_GenStub_AddParam(CF_CFDP_TxFile, const char *, dst_filename);
@@ -642,5 +642,5 @@ int32 CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, CF_CFDP
 
     UT_GenStub_Execute(CF_CFDP_TxFile, Basic, UT_DefaultHandler_CF_CFDP_TxFile);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_TxFile, int32);
+    return UT_GenStub_GetReturnValue(CF_CFDP_TxFile, CFE_Status_t);
 }

--- a/unit-test/stubs/cf_chunk_stubs.c
+++ b/unit-test/stubs/cf_chunk_stubs.c
@@ -124,9 +124,9 @@ void CF_ChunkList_RemoveFromFirst(CF_ChunkList_t *chunks, CF_ChunkSize_t size)
  * Generated stub function for CF_Chunks_CombineNext()
  * ----------------------------------------------------
  */
-int CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk)
+CFE_Status_t CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t *chunk)
 {
-    UT_GenStub_SetupReturnBuffer(CF_Chunks_CombineNext, int);
+    UT_GenStub_SetupReturnBuffer(CF_Chunks_CombineNext, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_Chunks_CombineNext, CF_ChunkList_t *, chunks);
     UT_GenStub_AddParam(CF_Chunks_CombineNext, CF_ChunkIdx_t, i);
@@ -134,7 +134,7 @@ int CF_Chunks_CombineNext(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chun
 
     UT_GenStub_Execute(CF_Chunks_CombineNext, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_Chunks_CombineNext, int);
+    return UT_GenStub_GetReturnValue(CF_Chunks_CombineNext, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -302,16 +302,16 @@ void CF_CmdTxFile(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_CmdValidateChunkSize()
  * ----------------------------------------------------
  */
-int CF_CmdValidateChunkSize(uint32 val, uint8 chan_num)
+CFE_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CmdValidateChunkSize, int);
+    UT_GenStub_SetupReturnBuffer(CF_CmdValidateChunkSize, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CmdValidateChunkSize, uint32, val);
     UT_GenStub_AddParam(CF_CmdValidateChunkSize, uint8, chan_num);
 
     UT_GenStub_Execute(CF_CmdValidateChunkSize, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CmdValidateChunkSize, int);
+    return UT_GenStub_GetReturnValue(CF_CmdValidateChunkSize, CFE_Status_t);
 }
 
 /*
@@ -319,16 +319,16 @@ int CF_CmdValidateChunkSize(uint32 val, uint8 chan_num)
  * Generated stub function for CF_CmdValidateMaxOutgoing()
  * ----------------------------------------------------
  */
-int CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
+CFE_Status_t CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CmdValidateMaxOutgoing, int);
+    UT_GenStub_SetupReturnBuffer(CF_CmdValidateMaxOutgoing, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CmdValidateMaxOutgoing, uint32, val);
     UT_GenStub_AddParam(CF_CmdValidateMaxOutgoing, uint8, chan_num);
 
     UT_GenStub_Execute(CF_CmdValidateMaxOutgoing, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CmdValidateMaxOutgoing, int);
+    return UT_GenStub_GetReturnValue(CF_CmdValidateMaxOutgoing, CFE_Status_t);
 }
 
 /*
@@ -348,9 +348,9 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_DoChanAction()
  * ----------------------------------------------------
  */
-int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context)
+CFE_Status_t CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoChanAction, int);
+    UT_GenStub_SetupReturnBuffer(CF_DoChanAction, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_DoChanAction, CF_UnionArgsCmd_t *, cmd);
     UT_GenStub_AddParam(CF_DoChanAction, const char *, errstr);
@@ -359,7 +359,7 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_
 
     UT_GenStub_Execute(CF_DoChanAction, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoChanAction, int);
+    return UT_GenStub_GetReturnValue(CF_DoChanAction, CFE_Status_t);
 }
 
 /*
@@ -367,16 +367,16 @@ int CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_
  * Generated stub function for CF_DoEnableDisableDequeue()
  * ----------------------------------------------------
  */
-int CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
+CFE_Status_t CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisableDequeue, int);
+    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisableDequeue, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_DoEnableDisableDequeue, uint8, chan_num);
     UT_GenStub_AddParam(CF_DoEnableDisableDequeue, const CF_ChanAction_BoolArg_t *, context);
 
     UT_GenStub_Execute(CF_DoEnableDisableDequeue, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoEnableDisableDequeue, int);
+    return UT_GenStub_GetReturnValue(CF_DoEnableDisableDequeue, CFE_Status_t);
 }
 
 /*
@@ -384,16 +384,16 @@ int CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *con
  * Generated stub function for CF_DoEnableDisablePolldir()
  * ----------------------------------------------------
  */
-int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context)
+CFE_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisablePolldir, int);
+    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisablePolldir, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_DoEnableDisablePolldir, uint8, chan_num);
     UT_GenStub_AddParam(CF_DoEnableDisablePolldir, const CF_ChanAction_BoolMsgArg_t *, context);
 
     UT_GenStub_Execute(CF_DoEnableDisablePolldir, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoEnableDisablePolldir, int);
+    return UT_GenStub_GetReturnValue(CF_DoEnableDisablePolldir, CFE_Status_t);
 }
 
 /*
@@ -401,16 +401,16 @@ int CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *
  * Generated stub function for CF_DoFreezeThaw()
  * ----------------------------------------------------
  */
-int CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
+CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoFreezeThaw, int);
+    UT_GenStub_SetupReturnBuffer(CF_DoFreezeThaw, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_DoFreezeThaw, uint8, chan_num);
     UT_GenStub_AddParam(CF_DoFreezeThaw, const CF_ChanAction_BoolArg_t *, context);
 
     UT_GenStub_Execute(CF_DoFreezeThaw, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoFreezeThaw, int);
+    return UT_GenStub_GetReturnValue(CF_DoFreezeThaw, CFE_Status_t);
 }
 
 /*
@@ -418,16 +418,16 @@ int CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
  * Generated stub function for CF_DoPurgeQueue()
  * ----------------------------------------------------
  */
-int CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
+CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoPurgeQueue, int);
+    UT_GenStub_SetupReturnBuffer(CF_DoPurgeQueue, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_DoPurgeQueue, uint8, chan_num);
     UT_GenStub_AddParam(CF_DoPurgeQueue, CF_UnionArgsCmd_t *, cmd);
 
     UT_GenStub_Execute(CF_DoPurgeQueue, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoPurgeQueue, int);
+    return UT_GenStub_GetReturnValue(CF_DoPurgeQueue, CFE_Status_t);
 }
 
 /*
@@ -490,16 +490,16 @@ void CF_ProcessGroundCommand(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_PurgeHistory()
  * ----------------------------------------------------
  */
-int CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c)
+CFE_Status_t CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c)
 {
-    UT_GenStub_SetupReturnBuffer(CF_PurgeHistory, int);
+    UT_GenStub_SetupReturnBuffer(CF_PurgeHistory, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_PurgeHistory, CF_CListNode_t *, n);
     UT_GenStub_AddParam(CF_PurgeHistory, CF_Channel_t *, c);
 
     UT_GenStub_Execute(CF_PurgeHistory, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_PurgeHistory, int);
+    return UT_GenStub_GetReturnValue(CF_PurgeHistory, CFE_Status_t);
 }
 
 /*
@@ -507,16 +507,16 @@ int CF_PurgeHistory(CF_CListNode_t *n, CF_Channel_t *c)
  * Generated stub function for CF_PurgeTransaction()
  * ----------------------------------------------------
  */
-int CF_PurgeTransaction(CF_CListNode_t *n, void *ignored)
+CFE_Status_t CF_PurgeTransaction(CF_CListNode_t *n, void *ignored)
 {
-    UT_GenStub_SetupReturnBuffer(CF_PurgeTransaction, int);
+    UT_GenStub_SetupReturnBuffer(CF_PurgeTransaction, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_PurgeTransaction, CF_CListNode_t *, n);
     UT_GenStub_AddParam(CF_PurgeTransaction, void *, ignored);
 
     UT_GenStub_Execute(CF_PurgeTransaction, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_PurgeTransaction, int);
+    return UT_GenStub_GetReturnValue(CF_PurgeTransaction, CFE_Status_t);
 }
 
 /*
@@ -524,9 +524,9 @@ int CF_PurgeTransaction(CF_CListNode_t *n, void *ignored)
  * Generated stub function for CF_TsnChanAction()
  * ----------------------------------------------------
  */
-int CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context)
+CFE_Status_t CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TsnChanAction, int);
+    UT_GenStub_SetupReturnBuffer(CF_TsnChanAction, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_TsnChanAction, CF_TransactionCmd_t *, cmd);
     UT_GenStub_AddParam(CF_TsnChanAction, const char *, cmdstr);
@@ -535,5 +535,5 @@ int CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAct
 
     UT_GenStub_Execute(CF_TsnChanAction, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_TsnChanAction, int);
+    return UT_GenStub_GetReturnValue(CF_TsnChanAction, CFE_Status_t);
 }

--- a/unit-test/stubs/cf_codec_stubs.c
+++ b/unit-test/stubs/cf_codec_stubs.c
@@ -161,16 +161,16 @@ void CF_CFDP_DecodeFin(CF_DecoderState_t *state, CF_Logical_PduFin_t *plfin)
  * Generated stub function for CF_CFDP_DecodeHeader()
  * ----------------------------------------------------
  */
-int32 CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh)
+CFE_Status_t CF_CFDP_DecodeHeader(CF_DecoderState_t *state, CF_Logical_PduHeader_t *plh)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_DecodeHeader, int32);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_DecodeHeader, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_DecodeHeader, CF_DecoderState_t *, state);
     UT_GenStub_AddParam(CF_CFDP_DecodeHeader, CF_Logical_PduHeader_t *, plh);
 
     UT_GenStub_Execute(CF_CFDP_DecodeHeader, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_DecodeHeader, int32);
+    return UT_GenStub_GetReturnValue(CF_CFDP_DecodeHeader, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_timer_stubs.c
+++ b/unit-test/stubs/cf_timer_stubs.c
@@ -31,7 +31,7 @@
  * Generated stub function for CF_Timer_Expired()
  * ----------------------------------------------------
  */
-int CF_Timer_Expired(const CF_Timer_t *t)
+bool CF_Timer_Expired(const CF_Timer_t *t)
 {
     UT_GenStub_SetupReturnBuffer(CF_Timer_Expired, int);
 

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -60,16 +60,16 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *c, CF_Transac
  * Generated stub function for CF_FindTransactionBySequenceNumber_Impl()
  * ----------------------------------------------------
  */
-int CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context)
+CFE_Status_t CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *n, CF_Traverse_TransSeqArg_t *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_FindTransactionBySequenceNumber_Impl, int);
+    UT_GenStub_SetupReturnBuffer(CF_FindTransactionBySequenceNumber_Impl, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber_Impl, CF_CListNode_t *, n);
     UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber_Impl, CF_Traverse_TransSeqArg_t *, context);
 
     UT_GenStub_Execute(CF_FindTransactionBySequenceNumber_Impl, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_FindTransactionBySequenceNumber_Impl, int);
+    return UT_GenStub_GetReturnValue(CF_FindTransactionBySequenceNumber_Impl, CFE_Status_t);
 }
 
 /*
@@ -118,16 +118,16 @@ void CF_InsertSortPrio(CF_Transaction_t *t, CF_QueueIdx_t q)
  * Generated stub function for CF_PrioSearch()
  * ----------------------------------------------------
  */
-int CF_PrioSearch(CF_CListNode_t *node, void *context)
+CFE_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_PrioSearch, int);
+    UT_GenStub_SetupReturnBuffer(CF_PrioSearch, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_PrioSearch, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_PrioSearch, void *, context);
 
     UT_GenStub_Execute(CF_PrioSearch, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_PrioSearch, int);
+    return UT_GenStub_GetReturnValue(CF_PrioSearch, CFE_Status_t);
 }
 
 /*
@@ -148,9 +148,9 @@ void CF_ResetHistory(CF_Channel_t *c, CF_History_t *h)
  * Generated stub function for CF_TraverseAllTransactions()
  * ----------------------------------------------------
  */
-int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t fn, void *context)
+CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t fn, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions, int);
+    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_TraverseAllTransactions, CF_Channel_t *, c);
     UT_GenStub_AddParam(CF_TraverseAllTransactions, CF_TraverseAllTransactions_fn_t, fn);
@@ -158,7 +158,7 @@ int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t 
 
     UT_GenStub_Execute(CF_TraverseAllTransactions, Basic, UT_DefaultHandler_CF_TraverseAllTransactions);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions, int);
+    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions, CFE_Status_t);
 }
 
 /*
@@ -166,9 +166,9 @@ int CF_TraverseAllTransactions(CF_Channel_t *c, CF_TraverseAllTransactions_fn_t 
  * Generated stub function for CF_TraverseAllTransactions_All_Channels()
  * ----------------------------------------------------
  */
-int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
+CFE_Status_t CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_All_Channels, int);
+    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_All_Channels, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_TraverseAllTransactions_All_Channels, CF_TraverseAllTransactions_fn_t, fn);
     UT_GenStub_AddParam(CF_TraverseAllTransactions_All_Channels, void *, context);
@@ -176,7 +176,7 @@ int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, 
     UT_GenStub_Execute(CF_TraverseAllTransactions_All_Channels, Basic,
                        UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_All_Channels, int);
+    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_All_Channels, CFE_Status_t);
 }
 
 /*
@@ -184,16 +184,16 @@ int CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, 
  * Generated stub function for CF_TraverseAllTransactions_Impl()
  * ----------------------------------------------------
  */
-int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args)
+CFE_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *args)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_Impl, int);
+    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_Impl, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_TraverseAllTransactions_Impl, CF_CListNode_t *, n);
     UT_GenStub_AddParam(CF_TraverseAllTransactions_Impl, CF_TraverseAll_Arg_t *, args);
 
     UT_GenStub_Execute(CF_TraverseAllTransactions_Impl, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_Impl, int);
+    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_Impl, CFE_Status_t);
 }
 
 /*
@@ -201,16 +201,16 @@ int CF_TraverseAllTransactions_Impl(CF_CListNode_t *n, CF_TraverseAll_Arg_t *arg
  * Generated stub function for CF_Traverse_WriteHistoryQueueEntryToFile()
  * ----------------------------------------------------
  */
-int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
+CFE_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteHistoryQueueEntryToFile, int);
+    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteHistoryQueueEntryToFile, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_Traverse_WriteHistoryQueueEntryToFile, CF_CListNode_t *, n);
     UT_GenStub_AddParam(CF_Traverse_WriteHistoryQueueEntryToFile, void *, arg);
 
     UT_GenStub_Execute(CF_Traverse_WriteHistoryQueueEntryToFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_Traverse_WriteHistoryQueueEntryToFile, int);
+    return UT_GenStub_GetReturnValue(CF_Traverse_WriteHistoryQueueEntryToFile, CFE_Status_t);
 }
 
 /*
@@ -218,16 +218,16 @@ int CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *n, void *arg)
  * Generated stub function for CF_Traverse_WriteTxnQueueEntryToFile()
  * ----------------------------------------------------
  */
-int CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
+CFE_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *n, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteTxnQueueEntryToFile, int);
+    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteTxnQueueEntryToFile, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_Traverse_WriteTxnQueueEntryToFile, CF_CListNode_t *, n);
     UT_GenStub_AddParam(CF_Traverse_WriteTxnQueueEntryToFile, void *, arg);
 
     UT_GenStub_Execute(CF_Traverse_WriteTxnQueueEntryToFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_Traverse_WriteTxnQueueEntryToFile, int);
+    return UT_GenStub_GetReturnValue(CF_Traverse_WriteTxnQueueEntryToFile, CFE_Status_t);
 }
 
 /*
@@ -295,9 +295,9 @@ void CF_WrappedClose(osal_id_t fd)
  * Generated stub function for CF_WrappedLseek()
  * ----------------------------------------------------
  */
-int32 CF_WrappedLseek(osal_id_t fd, off_t offset, int mode)
+CFE_Status_t CF_WrappedLseek(osal_id_t fd, off_t offset, int mode)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WrappedLseek, int32);
+    UT_GenStub_SetupReturnBuffer(CF_WrappedLseek, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_WrappedLseek, osal_id_t, fd);
     UT_GenStub_AddParam(CF_WrappedLseek, off_t, offset);
@@ -305,7 +305,7 @@ int32 CF_WrappedLseek(osal_id_t fd, off_t offset, int mode)
 
     UT_GenStub_Execute(CF_WrappedLseek, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_WrappedLseek, int32);
+    return UT_GenStub_GetReturnValue(CF_WrappedLseek, CFE_Status_t);
 }
 
 /*
@@ -313,9 +313,9 @@ int32 CF_WrappedLseek(osal_id_t fd, off_t offset, int mode)
  * Generated stub function for CF_WrappedOpenCreate()
  * ----------------------------------------------------
  */
-int32 CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 access)
+CFE_Status_t CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 access)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WrappedOpenCreate, int32);
+    UT_GenStub_SetupReturnBuffer(CF_WrappedOpenCreate, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_WrappedOpenCreate, osal_id_t *, fd);
     UT_GenStub_AddParam(CF_WrappedOpenCreate, const char *, fname);
@@ -324,7 +324,7 @@ int32 CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 
 
     UT_GenStub_Execute(CF_WrappedOpenCreate, Basic, UT_DefaultHandler_CF_WrappedOpenCreate);
 
-    return UT_GenStub_GetReturnValue(CF_WrappedOpenCreate, int32);
+    return UT_GenStub_GetReturnValue(CF_WrappedOpenCreate, CFE_Status_t);
 }
 
 /*
@@ -332,9 +332,9 @@ int32 CF_WrappedOpenCreate(osal_id_t *fd, const char *fname, int32 flags, int32 
  * Generated stub function for CF_WrappedRead()
  * ----------------------------------------------------
  */
-int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
+CFE_Status_t CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WrappedRead, int32);
+    UT_GenStub_SetupReturnBuffer(CF_WrappedRead, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_WrappedRead, osal_id_t, fd);
     UT_GenStub_AddParam(CF_WrappedRead, void *, buf);
@@ -342,7 +342,7 @@ int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
 
     UT_GenStub_Execute(CF_WrappedRead, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_WrappedRead, int32);
+    return UT_GenStub_GetReturnValue(CF_WrappedRead, CFE_Status_t);
 }
 
 /*
@@ -350,9 +350,9 @@ int32 CF_WrappedRead(osal_id_t fd, void *buf, size_t read_size)
  * Generated stub function for CF_WrappedWrite()
  * ----------------------------------------------------
  */
-int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
+CFE_Status_t CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WrappedWrite, int32);
+    UT_GenStub_SetupReturnBuffer(CF_WrappedWrite, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_WrappedWrite, osal_id_t, fd);
     UT_GenStub_AddParam(CF_WrappedWrite, const void *, buf);
@@ -360,7 +360,7 @@ int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
 
     UT_GenStub_Execute(CF_WrappedWrite, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_WrappedWrite, int32);
+    return UT_GenStub_GetReturnValue(CF_WrappedWrite, CFE_Status_t);
 }
 
 /*
@@ -368,16 +368,16 @@ int32 CF_WrappedWrite(osal_id_t fd, const void *buf, size_t write_size)
  * Generated stub function for CF_WriteHistoryEntryToFile()
  * ----------------------------------------------------
  */
-int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
+CFE_Status_t CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WriteHistoryEntryToFile, int);
+    UT_GenStub_SetupReturnBuffer(CF_WriteHistoryEntryToFile, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_WriteHistoryEntryToFile, osal_id_t, fd);
     UT_GenStub_AddParam(CF_WriteHistoryEntryToFile, const CF_History_t *, h);
 
     UT_GenStub_Execute(CF_WriteHistoryEntryToFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_WriteHistoryEntryToFile, int);
+    return UT_GenStub_GetReturnValue(CF_WriteHistoryEntryToFile, CFE_Status_t);
 }
 
 /*
@@ -385,9 +385,9 @@ int CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *h)
  * Generated stub function for CF_WriteHistoryQueueDataToFile()
  * ----------------------------------------------------
  */
-int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction_t dir)
+CFE_Status_t CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction_t dir)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WriteHistoryQueueDataToFile, int32);
+    UT_GenStub_SetupReturnBuffer(CF_WriteHistoryQueueDataToFile, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_WriteHistoryQueueDataToFile, osal_id_t, fd);
     UT_GenStub_AddParam(CF_WriteHistoryQueueDataToFile, CF_Channel_t *, c);
@@ -395,7 +395,7 @@ int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction
 
     UT_GenStub_Execute(CF_WriteHistoryQueueDataToFile, Basic, UT_DefaultHandler_CF_WriteHistoryQueueDataToFile);
 
-    return UT_GenStub_GetReturnValue(CF_WriteHistoryQueueDataToFile, int32);
+    return UT_GenStub_GetReturnValue(CF_WriteHistoryQueueDataToFile, CFE_Status_t);
 }
 
 /*
@@ -403,9 +403,9 @@ int32 CF_WriteHistoryQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_Direction
  * Generated stub function for CF_WriteTxnQueueDataToFile()
  * ----------------------------------------------------
  */
-int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
+CFE_Status_t CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
 {
-    UT_GenStub_SetupReturnBuffer(CF_WriteTxnQueueDataToFile, int32);
+    UT_GenStub_SetupReturnBuffer(CF_WriteTxnQueueDataToFile, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_WriteTxnQueueDataToFile, osal_id_t, fd);
     UT_GenStub_AddParam(CF_WriteTxnQueueDataToFile, CF_Channel_t *, c);
@@ -413,5 +413,5 @@ int32 CF_WriteTxnQueueDataToFile(osal_id_t fd, CF_Channel_t *c, CF_QueueIdx_t q)
 
     UT_GenStub_Execute(CF_WriteTxnQueueDataToFile, Basic, UT_DefaultHandler_CF_WriteTxnQueueDataToFile);
 
-    return UT_GenStub_GetReturnValue(CF_WriteTxnQueueDataToFile, int32);
+    return UT_GenStub_GetReturnValue(CF_WriteTxnQueueDataToFile, CFE_Status_t);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #145
- most `int`/`int32` return types were converted to `CFE_Status_t` (cases of specifically unsigned or intentionally long/short types (e.g. `uint64`, `uint8`) were not changed)
- successful returns now almost all represented by `CFE_SUCCESS` rather than 0 (zero)
- unsuccessful returns now almost all represented by `CF_ERROR` macro, or specific error macros where appropriate for repeat cases
- new error return macros all negative (unlike previously where some were positive enum values)
- `CF_Timer_Expired()` changed to bool return type
- converted `CF_SendRet_t` enum error return values to macros (all negative)
   - deleted unused `CF_SendRet_FAILURE` enum value
- converted `CF_RxEofRet_t` enum error return values to macros (all negative)
   - deleted unused `CF_RxEofRet_INVALID` enum value

---

Minor changes:
- updated this test message: should say `(failed)`, not `(success)`:
   - https://github.com/nasa/CF/blob/19c18b9dbdb0093e9bea78322de777e8f282acfb/unit-test/cf_cmd_tests.c#L3569
- couple of typos that were noticed along the way (e.g. deode instead of decode)
- added documentation for `@retval CF_SEND_PDU_NO_BUF_AVAIL_ERROR` (previously `CF_SendRet_NO_MSG`) for `CF_CFDP_SendNak()` (was simply missing)
- `@retval CF_SEND_PDU_ERROR` (previously `CF_SendRet_ERROR`) was not actually implemented/used and was removed from the prototype descriptions of:
   - `CF_CFDP_SendFin()`
   - `CF_CFDP_SendAck()`
   - `CF_CFDP_SendMd()`
   - `CF_CFDP_SendEof()`
- removed `/* error return path */` comments that are no longer relevant since the `goto`'s were removed

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Behavior essentially unchanged.
Removing positive error return values eases future maintainability.
Using a defined set of error return macros improves code clarity and makes CF more consistent with cFE and the other cFS apps.
Synchronizing the return types to `CFE_Status_t` simplifies the code, and makes it more type-safe.

Could consider adding to this PR, or in the future, defining unique error return macros for each unique return type.

**Contributor Info**
Avi Weiss @thnkslprpt