### PR TITLE
Fix #105, Remove 'dummy' from variable names

### DIFF
--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -168,23 +168,23 @@ void Test_CF_CheckTables_CallTo_CFE_TBL_GetAddress_Returns_CFE_TBL_INFO_UPDATED(
 /* CF_ValidateConfigTable tests specific items */
 
 /* CF_ValidateConfigTable tests specific global variables */
-CF_ConfigTable_t dummy_table;
+CF_ConfigTable_t table;
 
 /* CF_ValidateConfigTable tests specific functions */
-void cf_config_table_tests_set_dummy_table_to_nominal(void)
+void cf_config_table_tests_set_table_to_nominal(void)
 {
-    /* all values for dummy_table.ticks_per_second nominal except 0 */
-    dummy_table.ticks_per_second = Any_uint32_Except(0);
+    /* all values for table.ticks_per_second nominal except 0 */
+    table.ticks_per_second = Any_uint32_Except(0);
     /* all values (except 0) & 3ff == 0 are nominal (1024 byte aligned) */
-    dummy_table.rx_crc_calc_bytes_per_wakeup = Any_uint32_Except(0) << 10;
+    table.rx_crc_calc_bytes_per_wakeup = Any_uint32_Except(0) << 10;
     /* all values less than sizeof(CF_CFDP_PduFileDataContent_t) are nominal */
-    dummy_table.outgoing_file_chunk_size = Any_uint16_LessThan(sizeof(CF_CFDP_PduFileDataContent_t));
+    table.outgoing_file_chunk_size = Any_uint16_LessThan(sizeof(CF_CFDP_PduFileDataContent_t));
 }
 
 void Setup_cf_config_table_tests(void)
 {
     cf_app_tests_Setup();
-    cf_config_table_tests_set_dummy_table_to_nominal();
+    cf_config_table_tests_set_table_to_nominal();
 }
 
 /* end CF_ValidateConfigTable tests specific items */
@@ -192,7 +192,7 @@ void Setup_cf_config_table_tests(void)
 void Test_CF_ValidateConfigTable_FailBecauseTableTicksPerSecondIs0(void)
 {
     /* Arrange */
-    CF_ConfigTable_t *arg_table = &dummy_table;
+    CF_ConfigTable_t *arg_table = &table;
     int32             result;
 
     arg_table->ticks_per_second = 0;
@@ -207,7 +207,7 @@ void Test_CF_ValidateConfigTable_FailBecauseTableTicksPerSecondIs0(void)
 void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIs0(void)
 {
     /* Arrange */
-    CF_ConfigTable_t *arg_table = &dummy_table;
+    CF_ConfigTable_t *arg_table = &table;
     int32             result;
 
     arg_table->ticks_per_second             = 1;
@@ -223,7 +223,7 @@ void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIs0(void)
 void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIsNot1024ByteAligned(void)
 {
     /* Arrange */
-    CF_ConfigTable_t *arg_table = &dummy_table;
+    CF_ConfigTable_t *arg_table = &table;
     int32             result;
 
     arg_table->ticks_per_second = 1;
@@ -242,7 +242,7 @@ void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIsNot1024ByteAlign
 void Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArray(void)
 {
     /* Arrange */
-    CF_ConfigTable_t *arg_table = &dummy_table;
+    CF_ConfigTable_t *arg_table = &table;
     int32             result;
 
     /* outgoing_file_chunk_size set to greater than sizeof(CF_CFDP_PduFileDataContent_t) */
@@ -260,7 +260,7 @@ void Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArra
 void Test_CF_ValidateConfigTable_Success(void)
 {
     /* Arange */
-    CF_ConfigTable_t *arg_table = &dummy_table;
+    CF_ConfigTable_t *arg_table = &table;
     int32             result;
 
     arg_table->ticks_per_second             = 1;
@@ -668,13 +668,13 @@ void Test_CF_AppMain_RunLoopCallTo_CFE_SB_ReceiveBuffer_Returns_CFE_SUCCESS_AndV
     /* Arrange */
     CFE_SB_MsgId_t   forced_MsgID = CFE_SB_INVALID_MSG_ID;
     CFE_SB_Buffer_t  fake_msg;
-    CFE_SB_Buffer_t *dummy_msg = &fake_msg;
+    CFE_SB_Buffer_t *msg = &fake_msg;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 1, true);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RunLoop), false);
 
     /* Actual data not used, just address is needed */
-    UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), &dummy_msg, sizeof(dummy_msg), false);
+    UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), &msg, sizeof(msg), false);
 
     /* Arrange unstubbable: CF_ProcessMsg, invalid ID */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -134,7 +134,7 @@ CF_TransactionSeq_t Any_CF_TransactionSeq_t(void)
 
 /*******************************************************************************
 **
-**  cf_cmd_tests dummy test functions
+**  cf_cmd_tests test functions
 **
 *******************************************************************************/
 
@@ -142,18 +142,18 @@ typedef struct
 {
     CF_Transaction_t *t;
     void *            context;
-} Dummy_CF_TsnChanAction_fn_t_context_t;
+} CF_TsnChanAction_fn_t_context_t;
 
-int Dummy_chan_action_fn_t(uint8 chan_num, void *context)
+int Chan_action_fn_t(uint8 chan_num, void *context)
 {
     /* This one does not need to save its context, just call default so count works */
-    return UT_DEFAULT_IMPL(Dummy_chan_action_fn_t);
+    return UT_DEFAULT_IMPL(Chan_action_fn_t);
 }
 
 void Dummy_CF_TsnChanAction_fn_t(CF_Transaction_t *t, void *context)
 {
-    Dummy_CF_TsnChanAction_fn_t_context_t *ctxt =
-        UT_CF_GetContextBuffer(UT_KEY(Dummy_CF_TsnChanAction_fn_t), Dummy_CF_TsnChanAction_fn_t_context_t);
+    CF_TsnChanAction_fn_t_context_t *ctxt =
+        UT_CF_GetContextBuffer(UT_KEY(Dummy_CF_TsnChanAction_fn_t), CF_TsnChanAction_fn_t_context_t);
 
     if (ctxt)
     {
@@ -199,13 +199,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    dummy_msg->byte[0] = 5; /* 5 is size of 'names' */
+    msg->byte[0] = 5; /* 5 is size of 'names' */
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -223,13 +223,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    dummy_msg->byte[0] = Any_uint8_GreaterThan(5); /* 5 is size of 'names' */
+    msg->byte[0] = Any_uint8_GreaterThan(5); /* 5 is size of 'names' */
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -247,12 +247,12 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       msg     = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg = &utbuf.buf;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    dummy_msg->byte[0] = CF_Reset_command;
+    msg->byte[0] = CF_Reset_command;
 
     CF_AppData.hk.counters.cmd = Any_uint16_Except(0);
     CF_AppData.hk.counters.err = Any_uint16_Except(0);
@@ -271,14 +271,14 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     int                       i                      = 0;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    dummy_msg->byte[0] = CF_Reset_fault;
+    msg->byte[0] = CF_Reset_fault;
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
@@ -331,14 +331,14 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     int                       i                      = 0;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    dummy_msg->byte[0] = CF_Reset_up;
+    msg->byte[0] = CF_Reset_up;
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
@@ -379,14 +379,14 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint8                     i                      = 0;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    dummy_msg->byte[0] = CF_Reset_down;
+    msg->byte[0] = CF_Reset_down;
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
@@ -421,13 +421,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
-    int                       i         = 0;
+    CF_UnionArgsCmd_t *       msg     = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg = &utbuf.buf;
+    int                       i       = 0;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    dummy_msg->byte[0] = CF_Reset_all;
+    msg->byte[0] = CF_Reset_all;
 
     CF_AppData.hk.counters.cmd = Any_uint16_Except(0);
     CF_AppData.hk.counters.err = Any_uint16_Except(0);
@@ -644,9 +644,9 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       arg_cmd    = &utbuf.ua;
     const char *              arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
-    int                       dummy_context;
-    void *                    arg_context    = &dummy_context;
+    CF_ChanActionFn_t         arg_fn     = &Chan_action_fn_t;
+    int                       context;
+    void *                    arg_context    = &context;
     uint8                     random_fn_call = Any_uint8_LessThan(CF_NUM_CHANNELS) + 1;
     int                       local_result;
 
@@ -654,16 +654,16 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
 
     arg_cmd->byte[0] = CF_ALL_CHANNELS;
 
-    UT_SetDeferredRetcode(UT_KEY(Dummy_chan_action_fn_t), random_fn_call, 1);
+    UT_SetDeferredRetcode(UT_KEY(Chan_action_fn_t), random_fn_call, 1);
 
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
 
-    UT_GetStubCount(UT_KEY(Dummy_chan_action_fn_t));
+    UT_GetStubCount(UT_KEY(Chan_action_fn_t));
     UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, CF_NUM_CHANNELS);
+    UtAssert_STUB_COUNT(Chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (an fn returned 1)", local_result);
 }
@@ -674,25 +674,25 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       arg_cmd    = &utbuf.ua;
     const char *              arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
-    int                       dummy_context;
-    void *                    arg_context = &dummy_context;
+    CF_ChanActionFn_t         arg_fn     = &Chan_action_fn_t;
+    int                       context;
+    void *                    arg_context = &context;
     int                       local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     arg_cmd->byte[0] = CF_ALL_CHANNELS;
 
-    UT_SetDefaultReturnValue(UT_KEY(Dummy_chan_action_fn_t), 1);
+    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 1);
 
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
 
-    UT_GetStubCount(UT_KEY(Dummy_chan_action_fn_t));
+    UT_GetStubCount(UT_KEY(Chan_action_fn_t));
     UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, CF_NUM_CHANNELS);
+    UtAssert_STUB_COUNT(Chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (an fn returned 1)", local_result);
 }
@@ -703,25 +703,25 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       arg_cmd    = &utbuf.ua;
     const char *              arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
-    int                       dummy_context;
-    void *                    arg_context = &dummy_context;
+    CF_ChanActionFn_t         arg_fn     = &Chan_action_fn_t;
+    int                       context;
+    void *                    arg_context = &context;
     int                       local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     arg_cmd->byte[0] = CF_ALL_CHANNELS;
 
-    UT_SetDefaultReturnValue(UT_KEY(Dummy_chan_action_fn_t), 0);
+    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 0);
 
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
 
-    UT_GetStubCount(UT_KEY(Dummy_chan_action_fn_t));
+    UT_GetStubCount(UT_KEY(Chan_action_fn_t));
     UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, CF_NUM_CHANNELS);
+    UtAssert_STUB_COUNT(Chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 0, "CF_DoChanAction returned %d and should be 0 (all fn returned 0)", local_result);
 }
@@ -732,25 +732,25 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       arg_cmd    = &utbuf.ua;
     const char *              arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
-    int                       dummy_context;
-    void *                    arg_context = &dummy_context;
+    CF_ChanActionFn_t         arg_fn     = &Chan_action_fn_t;
+    int                       context;
+    void *                    arg_context = &context;
     int                       local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     arg_cmd->byte[0] = Any_cf_channel();
 
-    UT_SetDefaultReturnValue(UT_KEY(Dummy_chan_action_fn_t), 1);
+    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 1);
 
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
 
-    UT_GetStubCount(UT_KEY(Dummy_chan_action_fn_t));
+    UT_GetStubCount(UT_KEY(Chan_action_fn_t));
     UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, 1);
+    UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (fn returned 1)", local_result);
 }
@@ -761,25 +761,25 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       arg_cmd    = &utbuf.ua;
     const char *              arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
-    int                       dummy_context;
-    void *                    arg_context = &dummy_context;
+    CF_ChanActionFn_t         arg_fn     = &Chan_action_fn_t;
+    int                       context;
+    void *                    arg_context = &context;
     int                       local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     arg_cmd->byte[0] = Any_cf_channel();
 
-    UT_SetDefaultReturnValue(UT_KEY(Dummy_chan_action_fn_t), 0);
+    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 0);
 
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
 
-    UT_GetStubCount(UT_KEY(Dummy_chan_action_fn_t));
+    UT_GetStubCount(UT_KEY(Chan_action_fn_t));
     UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, 1);
+    UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 0, "CF_DoChanAction returned %d and should be 0 (fn returned 0)", local_result);
 }
@@ -790,9 +790,9 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       arg_cmd    = &utbuf.ua;
     const char *              arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
-    int                       dummy_context;
-    void *                    arg_context = &dummy_context;
+    CF_ChanActionFn_t         arg_fn     = &Chan_action_fn_t;
+    int                       context;
+    void *                    arg_context = &context;
     int                       local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
@@ -802,11 +802,11 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
 
-    UT_GetStubCount(UT_KEY(Dummy_chan_action_fn_t));
+    UT_GetStubCount(UT_KEY(Chan_action_fn_t));
     UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, 0);
+    UtAssert_STUB_COUNT(Chan_action_fn_t, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
@@ -820,9 +820,9 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       arg_cmd    = &utbuf.ua;
     const char *              arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t         arg_fn     = &Dummy_chan_action_fn_t;
-    int                       dummy_context;
-    void *                    arg_context = &dummy_context;
+    CF_ChanActionFn_t         arg_fn     = &Chan_action_fn_t;
+    int                       context;
+    void *                    arg_context = &context;
     int                       local_result;
     int                       catastrophe_count = 0;
 
@@ -845,11 +845,11 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
 
-    UT_GetStubCount(UT_KEY(Dummy_chan_action_fn_t));
+    UT_GetStubCount(UT_KEY(Chan_action_fn_t));
     UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_STUB_COUNT(Dummy_chan_action_fn_t, 0);
+    UtAssert_STUB_COUNT(Chan_action_fn_t, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
@@ -867,25 +867,25 @@ void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
 {
     /* Arrange */
     uint8                          arg_chan_num = Any_cf_channel();
-    CF_ChanAction_BoolArg_t        dummy_context;
+    CF_ChanAction_BoolArg_t        context;
     const CF_ChanAction_BoolArg_t *arg_context;
     int                            local_result;
 
-    dummy_context.barg = Any_bool_arg_t_barg();
+    context.barg = Any_bool_arg_t_barg();
 
-    arg_context = &dummy_context;
+    arg_context = &context;
 
     /* set frozen to opposite to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
-    CF_AppData.hk.channel_hk[arg_chan_num].frozen = !dummy_context.barg;
+    CF_AppData.hk.channel_hk[arg_chan_num].frozen = !context.barg;
 
     /* Act */
     local_result = CF_DoFreezeThaw(arg_chan_num, arg_context);
 
     /* Assert */
-    UtAssert_True(CF_AppData.hk.channel_hk[arg_chan_num].frozen == dummy_context.barg,
+    UtAssert_True(CF_AppData.hk.channel_hk[arg_chan_num].frozen == context.barg,
                   "CF_DoFreezeThaw set frozen to %d and should be %d (context->barg))",
-                  CF_AppData.hk.channel_hk[arg_chan_num].frozen, dummy_context.barg);
+                  CF_AppData.hk.channel_hk[arg_chan_num].frozen, context.barg);
     UtAssert_True(local_result == 0, "CF_DoFreezeThaw returned %d and should be 0 (only returns 0)", local_result);
 }
 
@@ -899,17 +899,17 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
-    uint8 dummy_chan_num = Any_cf_channel();
+    uint8 chan_num = Any_cf_channel();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_chan_num;
+    msg->byte[0] = chan_num;
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -918,9 +918,9 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.hk.channel_hk[dummy_chan_num].frozen == 1,
+    UtAssert_True(CF_AppData.hk.channel_hk[chan_num].frozen == 1,
                   "CF_DoFreezeThaw set frozen to %d and should be 1 (freeze = 1))",
-                  CF_AppData.hk.channel_hk[dummy_chan_num].frozen);
+                  CF_AppData.hk.channel_hk[chan_num].frozen);
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
                   initial_hk_cmd_counter);
@@ -932,14 +932,14 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       msg     = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg = &utbuf.buf;
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
     CF_AppData.hk.counters.cmd = 0;
 
@@ -962,17 +962,17 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
-    uint8 dummy_chan_num = Any_cf_channel();
+    uint8 chan_num = Any_cf_channel();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_chan_num;
+    msg->byte[0] = chan_num;
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -981,9 +981,9 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.hk.channel_hk[dummy_chan_num].frozen == 0,
+    UtAssert_True(CF_AppData.hk.channel_hk[chan_num].frozen == 0,
                   "CF_DoFreezeThaw set frozen to %d and should be 0 (thaw = 0))",
-                  CF_AppData.hk.channel_hk[dummy_chan_num].frozen);
+                  CF_AppData.hk.channel_hk[chan_num].frozen);
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
                   initial_hk_cmd_counter);
@@ -995,14 +995,14 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       msg     = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg = &utbuf.buf;
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
     CF_AppData.hk.counters.cmd = 0;
 
@@ -1055,9 +1055,9 @@ void Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound(
     CF_TransactionSeq_t arg_ts                   = Any_CF_TransactionSeq_t();
     CF_EntityId_t       arg_eid                  = Any_CF_EntityId_t();
     uint8               number_transaction_match = Any_uint8_LessThan(CF_NUM_CHANNELS);
-    CF_Transaction_t    dummy_return_value;
+    CF_Transaction_t    return_value;
     CF_Transaction_t *  local_result;
-    CF_Transaction_t *  expected_result = &dummy_return_value;
+    CF_Transaction_t *  expected_result = &return_value;
     int                 i               = 0;
 
     CF_FindTransactionBySequenceNumber_context_t contexts_CF_CFDP_FTBSN[CF_NUM_CHANNELS];
@@ -1068,7 +1068,7 @@ void Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound(
         contexts_CF_CFDP_FTBSN[i].forced_return = NULL;
     }
     /* set matching transaction */
-    contexts_CF_CFDP_FTBSN[i].forced_return = &dummy_return_value;
+    contexts_CF_CFDP_FTBSN[i].forced_return = &return_value;
 
     UT_SetDataBuffer(UT_KEY(CF_FindTransactionBySequenceNumber), &contexts_CF_CFDP_FTBSN,
                      sizeof(contexts_CF_CFDP_FTBSN), false);
@@ -1103,18 +1103,18 @@ void Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotF
     /* Arrange */
     CF_UT_cmd_transaction_buf_t utbuf;
     CF_TransactionCmd_t *       arg_cmd = &utbuf.xact;
-    char                        dummy_cmdstr[10]; /* 10 is arbitrary */
-    const char                  arg_cmdstr[10];   /* 10 is arbitrary */
+    char                        cmdstr[10];     /* 10 is arbitrary */
+    const char                  arg_cmdstr[10]; /* 10 is arbitrary */
     CF_TsnChanAction_fn_t       arg_fn = &Dummy_CF_TsnChanAction_fn_t;
-    int                         dummy_context;
-    void *                      arg_context = &dummy_context;
+    int                         context;
+    void *                      arg_context = &context;
     int                         i           = 0;
 
     CF_FindTransactionBySequenceNumber_context_t contexts_CF_CFDP_FTBSN[CF_NUM_CHANNELS];
 
     memset(&utbuf, 0, sizeof(utbuf));
-    AnyRandomStringOfLettersOfLengthCopy(dummy_cmdstr, 10);
-    memcpy((char *)arg_cmdstr, &dummy_cmdstr, 10);
+    AnyRandomStringOfLettersOfLengthCopy(cmdstr, 10);
+    memcpy((char *)arg_cmdstr, &cmdstr, 10);
 
     arg_cmd->chan = CF_COMPOUND_KEY;
 
@@ -1143,30 +1143,30 @@ void Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotF
 void Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_AndReturn_CFE_SUCCESS(void)
 {
     /* Arrange */
-    CF_UT_cmd_transaction_buf_t           utbuf;
-    CF_TransactionCmd_t *                 arg_cmd = &utbuf.xact;
-    char                                  dummy_cmdstr[10]; /* 10 is arbitrary */
-    const char                            arg_cmdstr[10];   /* 10 is arbitrary */
-    CF_TsnChanAction_fn_t                 arg_fn = &Dummy_CF_TsnChanAction_fn_t;
-    int                                   dummy_context;
-    void *                                arg_context = &dummy_context;
-    CF_Transaction_t                      dummy_t;
-    Dummy_CF_TsnChanAction_fn_t_context_t context_Dummy_CF_TsnChanAction_fn_t;
+    CF_UT_cmd_transaction_buf_t     utbuf;
+    CF_TransactionCmd_t *           arg_cmd = &utbuf.xact;
+    char                            cmdstr[10];     /* 10 is arbitrary */
+    const char                      arg_cmdstr[10]; /* 10 is arbitrary */
+    CF_TsnChanAction_fn_t           arg_fn = &Dummy_CF_TsnChanAction_fn_t;
+    int                             context;
+    void *                          arg_context = &context;
+    CF_Transaction_t                t;
+    CF_TsnChanAction_fn_t_context_t context_CF_TsnChanAction_fn_t;
 
     memset(&utbuf, 0, sizeof(utbuf));
-    AnyRandomStringOfLettersOfLengthCopy(dummy_cmdstr, 10);
-    memcpy((char *)arg_cmdstr, &dummy_cmdstr, 10);
+    AnyRandomStringOfLettersOfLengthCopy(cmdstr, 10);
+    memcpy((char *)arg_cmdstr, &cmdstr, 10);
 
     arg_cmd->chan = CF_COMPOUND_KEY;
 
-    UT_SetDataBuffer(UT_KEY(Dummy_CF_TsnChanAction_fn_t), &context_Dummy_CF_TsnChanAction_fn_t,
-                     sizeof(context_Dummy_CF_TsnChanAction_fn_t), false);
+    UT_SetDataBuffer(UT_KEY(Dummy_CF_TsnChanAction_fn_t), &context_CF_TsnChanAction_fn_t,
+                     sizeof(context_CF_TsnChanAction_fn_t), false);
 
     /* Arrange unstubbable: CF_FindTransactionBySequenceNumberAllChannels */
     CF_FindTransactionBySequenceNumber_context_t context_CF_CFDP_FTBSN;
 
     /* set matching transaction */
-    context_CF_CFDP_FTBSN.forced_return = &dummy_t;
+    context_CF_CFDP_FTBSN.forced_return = &t;
 
     UT_SetDataBuffer(UT_KEY(CF_FindTransactionBySequenceNumber), &context_CF_CFDP_FTBSN, sizeof(context_CF_CFDP_FTBSN),
                      false);
@@ -1179,8 +1179,8 @@ void Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_An
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(Dummy_CF_TsnChanAction_fn_t, 1);
-    UtAssert_ADDRESS_EQ(context_Dummy_CF_TsnChanAction_fn_t.t, &dummy_t);
-    UtAssert_ADDRESS_EQ(context_Dummy_CF_TsnChanAction_fn_t.context, arg_context);
+    UtAssert_ADDRESS_EQ(context_CF_TsnChanAction_fn_t.t, &t);
+    UtAssert_ADDRESS_EQ(context_CF_TsnChanAction_fn_t.context, arg_context);
 }
 
 void Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels(void)
@@ -1188,17 +1188,17 @@ void Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTran
     /* Arrange */
     CF_UT_cmd_transaction_buf_t                       utbuf;
     CF_TransactionCmd_t *                             arg_cmd = &utbuf.xact;
-    char                                              dummy_cmdstr[10]; /* 10 is arbitrary */
-    const char                                        arg_cmdstr[10];   /* 10 is arbitrary */
+    char                                              cmdstr[10];     /* 10 is arbitrary */
+    const char                                        arg_cmdstr[10]; /* 10 is arbitrary */
     CF_TsnChanAction_fn_t                             arg_fn = &Dummy_CF_TsnChanAction_fn_t;
-    int                                               dummy_context;
-    void *                                            arg_context     = &dummy_context;
+    int                                               context;
+    void *                                            arg_context     = &context;
     int                                               expected_result = Any_int();
     CF_TraverseAllTransactions_All_Channels_context_t context_CF_TATAC;
 
     memset(&utbuf, 0, sizeof(utbuf));
-    AnyRandomStringOfLettersOfLengthCopy(dummy_cmdstr, 10);
-    memcpy((char *)arg_cmdstr, &dummy_cmdstr, 10);
+    AnyRandomStringOfLettersOfLengthCopy(cmdstr, 10);
+    memcpy((char *)arg_cmdstr, &cmdstr, 10);
 
     context_CF_TATAC.forced_return = expected_result;
 
@@ -1239,8 +1239,8 @@ void Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid(void)
     CF_TransactionCmd_t *       arg_cmd       = &utbuf.xact;
     const char                  arg_cmdstr[1] = "";
     CF_TsnChanAction_fn_t       arg_fn        = &Dummy_CF_TsnChanAction_fn_t;
-    int                         dummy_context;
-    void *                      arg_context = &dummy_context;
+    int                         context;
+    void *                      arg_context = &context;
 
     memset(&utbuf, 0, sizeof(utbuf));
     arg_cmd->chan = Any_uint8_BetweenExcludeMax(CF_NUM_CHANNELS, CF_COMPOUND_KEY);
@@ -1262,10 +1262,10 @@ void Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid(void)
 void Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action(void)
 {
     /* Arrange */
-    CF_Transaction_t            dummy_t;
-    CF_Transaction_t *          arg_t = &dummy_t;
-    CF_ChanAction_SuspResArg_t  dummy_context;
-    CF_ChanAction_SuspResArg_t *arg_context = &dummy_context;
+    CF_Transaction_t            t;
+    CF_Transaction_t *          arg_t = &t;
+    CF_ChanAction_SuspResArg_t  context;
+    CF_ChanAction_SuspResArg_t *arg_context = &context;
 
     /* set same to 0 to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
@@ -1285,10 +1285,10 @@ void Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action(void)
 void Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action(void)
 {
     /* Arrange */
-    CF_Transaction_t            dummy_t;
-    CF_Transaction_t *          arg_t = &dummy_t;
-    CF_ChanAction_SuspResArg_t  dummy_context;
-    CF_ChanAction_SuspResArg_t *arg_context = &dummy_context;
+    CF_Transaction_t            t;
+    CF_Transaction_t *          arg_t = &t;
+    CF_ChanAction_SuspResArg_t  context;
+    CF_ChanAction_SuspResArg_t *arg_context = &context;
 
     /* set same to 0 to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
@@ -1443,8 +1443,8 @@ void Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0(void)
 void Test_CF_CmdCancel_Txn_Call_CF_CFDP_CancelTransaction_WithGiven_t(void)
 {
     /* Arrange */
-    CF_Transaction_t  dummy_t;
-    CF_Transaction_t *arg_t       = &dummy_t;
+    CF_Transaction_t  t;
+    CF_Transaction_t *arg_t       = &t;
     void *            arg_ignored = NULL;
     CF_Transaction_t *context_CF_CFDP_CancelTransaction;
 
@@ -1512,8 +1512,8 @@ void Test_CF_CmdCancel_Failure(void)
 void Test_CF_CmdAbandon_Txn_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void)
 {
     /* Arrange */
-    CF_Transaction_t                   dummy_t;
-    CF_Transaction_t *                 arg_t       = &dummy_t;
+    CF_Transaction_t                   t;
+    CF_Transaction_t *                 arg_t       = &t;
     void *                             arg_ignored = NULL;
     CF_CFDP_ResetTransaction_context_t context_CF_CFDP_ResetTransaction;
 
@@ -1584,23 +1584,23 @@ void Test_CF_CmdAbandon_Failure(void)
 void Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg(void)
 {
     /* Arrange */
-    CF_ConfigTable_t         dummy_config_table;
+    CF_ConfigTable_t         config_table;
     uint8                    arg_chan_num = Any_cf_channel();
-    CF_ChanAction_BoolArg_t  dummy_context;
-    CF_ChanAction_BoolArg_t *arg_context = &dummy_context;
+    CF_ChanAction_BoolArg_t  context;
+    CF_ChanAction_BoolArg_t *arg_context = &context;
 
-    CF_AppData.config_table = &dummy_config_table;
-    dummy_context.barg      = Any_bool_arg_t_barg();
+    CF_AppData.config_table = &config_table;
+    context.barg            = Any_bool_arg_t_barg();
 
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
     /* Act */
     CF_DoEnableDisableDequeue(arg_chan_num, arg_context);
 
     /* Assert */
-    UtAssert_True(CF_AppData.config_table->chan[arg_chan_num].dequeue_enabled == dummy_context.barg,
+    UtAssert_True(CF_AppData.config_table->chan[arg_chan_num].dequeue_enabled == context.barg,
                   "Channel %u dequeue_enabled is %u and should be %u (context->barg)", arg_chan_num,
-                  CF_AppData.config_table->chan[arg_chan_num].dequeue_enabled, dummy_context.barg);
+                  CF_AppData.config_table->chan[arg_chan_num].dequeue_enabled, context.barg);
 }
 
 /*******************************************************************************
@@ -1613,21 +1613,21 @@ void Test_CF_CmdEnableDequeue_Success(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
-    CF_ConfigTable_t dummy_config_table;
-    uint8            dummy_chan_num = Any_cf_channel();
+    CF_ConfigTable_t config_table;
+    uint8            chan_num = Any_cf_channel();
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_chan_num;
+    msg->byte[0] = chan_num;
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1636,9 +1636,9 @@ void Test_CF_CmdEnableDequeue_Success(void)
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.config_table->chan[dummy_chan_num].dequeue_enabled == 1,
+    UtAssert_True(CF_AppData.config_table->chan[chan_num].dequeue_enabled == 1,
                   "CF_CmdEnableDequeue set dequeue_enabled to %d and should be 1 (barg = 1))",
-                  CF_AppData.config_table->chan[dummy_chan_num].dequeue_enabled);
+                  CF_AppData.config_table->chan[chan_num].dequeue_enabled);
     /* Assert for incremented counter */
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d\nACCEPTANCE OF COMMAND (+1) SHOULD BE "
@@ -1652,19 +1652,19 @@ void Test_CF_CmdEnableDequeue_Failure(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       msg     = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg = &utbuf.buf;
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
-    CF_ConfigTable_t dummy_config_table;
+    CF_ConfigTable_t config_table;
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
     CF_AppData.hk.counters.err = 0;
 
@@ -1687,21 +1687,21 @@ void Test_CF_CmdDisableDequeue_Success(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
-    CF_ConfigTable_t dummy_config_table;
-    uint8            dummy_chan_num = Any_cf_channel();
+    CF_ConfigTable_t config_table;
+    uint8            chan_num = Any_cf_channel();
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_chan_num;
+    msg->byte[0] = chan_num;
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1710,9 +1710,9 @@ void Test_CF_CmdDisableDequeue_Success(void)
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.config_table->chan[dummy_chan_num].dequeue_enabled == 0,
+    UtAssert_True(CF_AppData.config_table->chan[chan_num].dequeue_enabled == 0,
                   "CF_CmdEnableDequeue set dequeue_enabled to %d and should be 0 (barg = 0))",
-                  CF_AppData.config_table->chan[dummy_chan_num].dequeue_enabled);
+                  CF_AppData.config_table->chan[chan_num].dequeue_enabled);
     /* Assert for incremented counter */
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
@@ -1725,19 +1725,19 @@ void Test_CF_CmdDisableDequeue_Failure(void)
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       msg     = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg = &utbuf.buf;
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
-    CF_ConfigTable_t dummy_config_table;
+    CF_ConfigTable_t config_table;
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
     CF_AppData.hk.counters.err = 0;
 
@@ -1760,25 +1760,25 @@ void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannel
 {
     /* Arrange */
     CF_UT_cmd_unionargs_buf_t   utbuf;
-    CF_UnionArgsCmd_t *         dummy_msg = &utbuf.ua;
-    CF_ChanAction_BoolMsgArg_t  dummy_context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
-    CF_ConfigTable_t            dummy_config_table;
+    CF_UnionArgsCmd_t *         msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
+    CF_ConfigTable_t            config_table;
     uint8                       arg_chan_num = Any_cf_channel();
     uint8                       expected_enabled;
     uint8                       current_polldir = 0;
     int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
-    dummy_msg->byte[1] = CF_ALL_CHANNELS;
+    msg->byte[1] = CF_ALL_CHANNELS;
 
-    dummy_context.msg  = dummy_msg;
-    dummy_context.barg = Any_bool_arg_t_barg();
-    expected_enabled   = dummy_context.barg;
+    context.msg      = msg;
+    context.barg     = Any_bool_arg_t_barg();
+    expected_enabled = context.barg;
 
     /* Act */
     local_result = CF_DoEnableDisablePolldir(arg_chan_num, arg_context);
@@ -1797,34 +1797,34 @@ void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannel
 void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg(void)
 {
     /* Arrange */
-    uint8                       arg_chan_num  = Any_cf_channel();
-    uint8                       dummy_polldir = Any_cf_polldir();
+    uint8                       arg_chan_num = Any_cf_channel();
+    uint8                       polldir      = Any_cf_polldir();
     CF_UT_cmd_unionargs_buf_t   utbuf;
-    CF_UnionArgsCmd_t *         dummy_msg = &utbuf.ua;
-    CF_ChanAction_BoolMsgArg_t  dummy_context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
-    CF_ConfigTable_t            dummy_config_table;
+    CF_UnionArgsCmd_t *         msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
+    CF_ConfigTable_t            config_table;
     uint8                       expected_enabled;
     int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
-    dummy_msg->byte[1] = dummy_polldir;
+    msg->byte[1] = polldir;
 
-    dummy_context.msg  = dummy_msg;
-    dummy_context.barg = Any_bool_arg_t_barg();
-    expected_enabled   = dummy_context.barg;
+    context.msg      = msg;
+    context.barg     = Any_bool_arg_t_barg();
+    expected_enabled = context.barg;
 
     /* Act */
     local_result = CF_DoEnableDisablePolldir(arg_chan_num, arg_context);
 
     /* Assert */
-    UtAssert_True(CF_AppData.config_table->chan[arg_chan_num].polldir[dummy_polldir].enabled == expected_enabled,
-                  "Channel %u Polldir %u set to %u and should be %u (context->barg)", arg_chan_num, dummy_polldir,
-                  CF_AppData.config_table->chan[arg_chan_num].polldir[dummy_polldir].enabled, expected_enabled);
+    UtAssert_True(CF_AppData.config_table->chan[arg_chan_num].polldir[polldir].enabled == expected_enabled,
+                  "Channel %u Polldir %u set to %u and should be %u (context->barg)", arg_chan_num, polldir,
+                  CF_AppData.config_table->chan[arg_chan_num].polldir[polldir].enabled, expected_enabled);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_True(local_result == 0, "CF_DoEnableDisablePolldir returned %d and should be 0", local_result);
 }
@@ -1834,20 +1834,20 @@ void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_An
     /* Arrange */
     uint8                       arg_chan_num = Any_cf_channel();
     CF_UT_cmd_unionargs_buf_t   utbuf;
-    CF_UnionArgsCmd_t *         dummy_msg = &utbuf.ua;
-    CF_ChanAction_BoolMsgArg_t  dummy_context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
-    CF_ConfigTable_t            dummy_config_table;
+    CF_UnionArgsCmd_t *         msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
+    CF_ConfigTable_t            config_table;
     int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
-    dummy_msg->byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
+    msg->byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
 
-    dummy_context.msg  = dummy_msg;
-    dummy_context.barg = Any_bool_arg_t_barg();
+    context.msg  = msg;
+    context.barg = Any_bool_arg_t_barg();
 
     /* Act */
     local_result = CF_DoEnableDisablePolldir(arg_chan_num, arg_context);
@@ -1863,20 +1863,20 @@ void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
     /* Arrange */
     uint8                       arg_chan_num = Any_cf_channel();
     CF_UT_cmd_unionargs_buf_t   utbuf;
-    CF_UnionArgsCmd_t *         dummy_msg = &utbuf.ua;
-    CF_ChanAction_BoolMsgArg_t  dummy_context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &dummy_context;
-    CF_ConfigTable_t            dummy_config_table;
+    CF_UnionArgsCmd_t *         msg = &utbuf.ua;
+    CF_ChanAction_BoolMsgArg_t  context;
+    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
+    CF_ConfigTable_t            config_table;
     int                         local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
-    dummy_msg->byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
+    msg->byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
 
-    dummy_context.msg  = dummy_msg;
-    dummy_context.barg = Any_bool_arg_t_barg();
+    context.msg  = msg;
+    context.barg = Any_bool_arg_t_barg();
 
     /* Act */
     local_result = CF_DoEnableDisablePolldir(arg_chan_num, arg_context);
@@ -1896,24 +1896,24 @@ void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
 void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
 {
     /* Arrange */
-    CF_ConfigTable_t          dummy_config_table;
-    uint8                     dummy_channel = Any_cf_channel();
-    uint8                     dummy_polldir = Any_cf_polldir();
+    CF_ConfigTable_t          config_table;
+    uint8                     channel = Any_cf_channel();
+    uint8                     polldir = Any_cf_polldir();
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    dummy_msg->byte[1] = dummy_polldir;
+    msg->byte[1] = polldir;
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1922,9 +1922,9 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
 
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
-    UtAssert_True(CF_AppData.config_table->chan[dummy_channel].polldir[dummy_polldir].enabled == 1,
-                  "Channel %u Polldir %u set to %u and should be 1 (context->barg)", dummy_channel, dummy_polldir,
-                  CF_AppData.config_table->chan[dummy_channel].polldir[dummy_polldir].enabled);
+    UtAssert_True(CF_AppData.config_table->chan[channel].polldir[polldir].enabled == 1,
+                  "Channel %u Polldir %u set to %u and should be 1 (context->barg)", channel, polldir,
+                  CF_AppData.config_table->chan[channel].polldir[polldir].enabled);
     /* Assert for incremented counter */
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
@@ -1935,20 +1935,20 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
 void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
 {
     /* Arrange */
-    uint8 dummy_channel = Any_cf_channel();
+    uint8 channel       = Any_cf_channel();
     uint8 error_polldir = Any_uint8_BetweenInclusive(CF_MAX_POLLING_DIR_PER_CHAN, CF_ALL_CHANNELS - 1);
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    dummy_msg->byte[1] = error_polldir;
+    msg->byte[1] = error_polldir;
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -1973,24 +1973,24 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
 void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
 {
     /* Arrange */
-    CF_ConfigTable_t          dummy_config_table;
-    uint8                     dummy_channel = Any_cf_channel();
-    uint8                     dummy_polldir = Any_cf_polldir();
+    CF_ConfigTable_t          config_table;
+    uint8                     channel = Any_cf_channel();
+    uint8                     polldir = Any_cf_polldir();
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    dummy_msg->byte[1] = dummy_polldir;
+    msg->byte[1] = polldir;
 
     CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
 
@@ -1999,9 +1999,9 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
 
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
-    UtAssert_True(CF_AppData.config_table->chan[dummy_channel].polldir[dummy_polldir].enabled == 0,
-                  "Channel %u Polldir %u set to %u and should be 0 (context->barg)", dummy_channel, dummy_polldir,
-                  CF_AppData.config_table->chan[dummy_channel].polldir[dummy_polldir].enabled);
+    UtAssert_True(CF_AppData.config_table->chan[channel].polldir[polldir].enabled == 0,
+                  "Channel %u Polldir %u set to %u and should be 0 (context->barg)", channel, polldir,
+                  CF_AppData.config_table->chan[channel].polldir[polldir].enabled);
     /* Assert for incremented counter */
     UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
@@ -2012,20 +2012,20 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
 void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
 {
     /* Arrange */
-    uint8 dummy_channel = Any_cf_channel();
+    uint8 channel       = Any_cf_channel();
     uint8 error_polldir = Any_uint8_BetweenInclusive(CF_MAX_POLLING_DIR_PER_CHAN, CF_ALL_CHANNELS - 1);
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    dummy_msg->byte[1] = error_polldir;
+    msg->byte[1] = error_polldir;
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2050,10 +2050,10 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
 void Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT(void)
 {
     /* Arrange */
-    CF_History_t                   dummy_h;
-    CF_CListNode_t *               arg_n = &dummy_h.cl_node;
-    CF_Channel_t                   dummy_c;
-    CF_Channel_t *                 arg_c = &dummy_c;
+    CF_History_t                   h;
+    CF_CListNode_t *               arg_n = &h.cl_node;
+    CF_Channel_t                   c;
+    CF_Channel_t *                 arg_c = &c;
     int                            local_result;
     CF_CFDP_ResetHistory_context_t context_CF_CFDP_ResetHistory;
 
@@ -2065,7 +2065,7 @@ void Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT(void)
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetHistory.c, arg_c);
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetHistory.h, &dummy_h);
+    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetHistory.h, &h);
     UtAssert_True(local_result == CF_CLIST_CONT, "CF_PurgeHistory returned %d and should be %d (CF_CLIST_CONT)",
                   local_result, CF_CLIST_CONT);
 }
@@ -2079,10 +2079,10 @@ void Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT(void)
 void Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT(void)
 {
     /* Arrange */
-    CF_Transaction_t                   dummy_t;
-    CF_CListNode_t *                   arg_n = &dummy_t.cl_node;
-    int                                dummy_ignored;
-    void *                             arg_ignored = &dummy_ignored;
+    CF_Transaction_t                   t;
+    CF_CListNode_t *                   arg_n = &t.cl_node;
+    int                                ignored;
+    void *                             arg_ignored = &ignored;
     int                                local_result;
     CF_CFDP_ResetTransaction_context_t context_CF_CFDP_ResetTransaction;
 
@@ -2093,7 +2093,7 @@ void Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT
     local_result = CF_PurgeTransaction(arg_n, arg_ignored);
 
     /* Assert */
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetTransaction.t, &dummy_t);
+    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetTransaction.t, &t);
     UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == 0,
                   "CF_CFDP_ResetTransaction received keep_history %u and should be 0 (constant)",
                   context_CF_CFDP_ResetTransaction.keep_history);
@@ -2113,9 +2113,9 @@ void Test_CF_DoPurgeQueue_PendOnly(void)
     uint8                               arg_chan_num = Any_cf_channel();
     CF_UT_cmd_unionargs_buf_t           utbuf;
     CF_UnionArgsCmd_t *                 arg_cmd = &utbuf.ua;
-    CF_Channel_t *                      dummy_c;
-    CF_CListNode_t                      dummy_start;
-    CF_CListNode_t *                    expected_start = &dummy_start;
+    CF_Channel_t *                      c;
+    CF_CListNode_t                      start;
+    CF_CListNode_t *                    expected_start = &start;
     int                                 local_result;
     CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse;
 
@@ -2125,8 +2125,8 @@ void Test_CF_DoPurgeQueue_PendOnly(void)
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_POINTER,
                           &context_CF_CList_Traverse);
 
-    dummy_c                       = &CF_AppData.engine.channels[arg_chan_num];
-    dummy_c->qs[CF_QueueIdx_PEND] = expected_start;
+    c                       = &CF_AppData.engine.channels[arg_chan_num];
+    c->qs[CF_QueueIdx_PEND] = expected_start;
 
     /* Act */
     local_result = CF_DoPurgeQueue(arg_chan_num, arg_cmd);
@@ -2148,9 +2148,9 @@ void Test_CF_DoPurgeQueue_HistoryOnly(void)
     uint8                               arg_chan_num = Any_cf_channel();
     CF_UT_cmd_unionargs_buf_t           utbuf;
     CF_UnionArgsCmd_t *                 arg_cmd = &utbuf.ua;
-    CF_Channel_t *                      dummy_c;
-    CF_CListNode_t                      dummy_start;
-    CF_CListNode_t *                    expected_start = &dummy_start;
+    CF_Channel_t *                      c;
+    CF_CListNode_t                      start;
+    CF_CListNode_t *                    expected_start = &start;
     int                                 local_result;
     CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse;
 
@@ -2162,8 +2162,8 @@ void Test_CF_DoPurgeQueue_HistoryOnly(void)
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_POINTER,
                           &context_CF_CList_Traverse);
 
-    dummy_c                       = &CF_AppData.engine.channels[arg_chan_num];
-    dummy_c->qs[CF_QueueIdx_HIST] = expected_start;
+    c                       = &CF_AppData.engine.channels[arg_chan_num];
+    c->qs[CF_QueueIdx_HIST] = expected_start;
 
     /* Act */
     local_result = CF_DoPurgeQueue(arg_chan_num, arg_cmd);
@@ -2175,7 +2175,7 @@ void Test_CF_DoPurgeQueue_HistoryOnly(void)
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.start, expected_start);
     UtAssert_True(context_CF_CList_Traverse.fn == (CF_CListFn_t)CF_PurgeHistory,
                   "context_CF_CList_Traverse.fn ==  (CF_CListFn_t )CF_PurgeHistory");
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, dummy_c);
+    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, c);
     UtAssert_True(local_result == 0, "CF_DoPurgeQueue returned %d and should be 0", local_result);
 }
 
@@ -2185,11 +2185,11 @@ void Test_CF_DoPurgeQueue_Both(void)
     uint8                               arg_chan_num = Any_cf_channel();
     CF_UT_cmd_unionargs_buf_t           utbuf;
     CF_UnionArgsCmd_t *                 arg_cmd = &utbuf.ua;
-    CF_Channel_t *                      dummy_c;
-    CF_CListNode_t                      dummy_pend_start;
-    CF_CListNode_t *                    expected_pend_start = &dummy_pend_start;
-    CF_CListNode_t                      dummy_history_start;
-    CF_CListNode_t *                    expected_history_start = &dummy_history_start;
+    CF_Channel_t *                      c;
+    CF_CListNode_t                      pend_start;
+    CF_CListNode_t *                    expected_pend_start = &pend_start;
+    CF_CListNode_t                      history_start;
+    CF_CListNode_t *                    expected_history_start = &history_start;
     int                                 local_result;
     CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse[2];
 
@@ -2202,9 +2202,9 @@ void Test_CF_DoPurgeQueue_Both(void)
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_POINTER, NULL);
     UT_SetDataBuffer(UT_KEY(CF_CList_Traverse), context_CF_CList_Traverse, sizeof(context_CF_CList_Traverse), false);
 
-    dummy_c                       = &CF_AppData.engine.channels[arg_chan_num];
-    dummy_c->qs[CF_QueueIdx_PEND] = expected_pend_start;
-    dummy_c->qs[CF_QueueIdx_HIST] = expected_history_start;
+    c                       = &CF_AppData.engine.channels[arg_chan_num];
+    c->qs[CF_QueueIdx_PEND] = expected_pend_start;
+    c->qs[CF_QueueIdx_HIST] = expected_history_start;
 
     /* Act */
     local_result = CF_DoPurgeQueue(arg_chan_num, arg_cmd);
@@ -2220,7 +2220,7 @@ void Test_CF_DoPurgeQueue_Both(void)
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[1].start, expected_history_start);
     UtAssert_True(context_CF_CList_Traverse[1].fn == (CF_CListFn_t)CF_PurgeHistory,
                   "context_CF_CList_Traverse[1].fn ==  (CF_CListFn_t )CF_PurgeHistory");
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[1].context, dummy_c);
+    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[1].context, c);
     UtAssert_True(local_result == 0, "CF_DoPurgeQueue returned %d and should be 0", local_result);
 }
 
@@ -2281,20 +2281,20 @@ void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
 void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
 {
     /* Arrange */
-    uint8                     dummy_channel = Any_cf_channel();
-    uint8                     error_purge   = 3; /* Shortest return from CF_DoPurgeQueue */
+    uint8                     channel     = Any_cf_channel();
+    uint8                     error_purge = 3; /* Shortest return from CF_DoPurgeQueue */
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg              = &utbuf.ua;
+    CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint16                    initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoPurgeQueue */
-    dummy_msg->byte[1] = error_purge;
+    msg->byte[1] = error_purge;
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2313,15 +2313,15 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
 void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)
 {
     /* Arrange */
-    uint8                     dummy_channel = Any_cf_channel();
+    uint8                     channel = Any_cf_channel();
     CF_UT_cmd_unionargs_buf_t utbuf;
-    CF_UnionArgsCmd_t *       dummy_msg = &utbuf.ua;
-    CFE_SB_Buffer_t *         arg_msg   = &utbuf.buf;
+    CF_UnionArgsCmd_t *       msg     = &utbuf.ua;
+    CFE_SB_Buffer_t *         arg_msg = &utbuf.buf;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    dummy_msg->byte[0] = dummy_channel;
+    msg->byte[0] = channel;
 
     CF_AppData.hk.counters.cmd = 0;
 
@@ -2346,14 +2346,14 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq               = &utbuf.wq;
+    CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
     uint16                  initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
-    dummy_wq->chan = CF_NUM_CHANNELS;
+    wq->chan = CF_NUM_CHANNELS;
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2371,14 +2371,14 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq               = &utbuf.wq;
+    CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
     uint16                  initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
-    dummy_wq->chan = Any_uint8_GreaterThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_GreaterThan(CF_NUM_CHANNELS);
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2397,18 +2397,18 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t utbuf;
-    CF_WriteQueueCmd_t *    dummy_wq               = &utbuf.wq;
+    CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
     uint16                  initial_hk_err_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* invalid combination up direction, pending queue */
-    dummy_wq->type  = CF_Type_up;
-    dummy_wq->queue = CF_Queue_pend;
+    wq->type  = CF_Type_up;
+    wq->queue = CF_Queue_pend;
 
     CF_AppData.hk.counters.err = initial_hk_err_counter;
 
@@ -2428,7 +2428,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CF_WriteQueueCmd_t *           wq = &utbuf.wq;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
     uint16                         initial_hk_err_counter = Any_uint16();
@@ -2436,14 +2436,14 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination up direction, NOT pending queue */
-    dummy_wq->type  = CF_Type_up;
-    dummy_wq->queue = Any_queue_Except_q_pend(); /* 0 is q_pend */
+    wq->type  = CF_Type_up;
+    wq->queue = Any_queue_Except_q_pend(); /* 0 is q_pend */
 
     /* invalid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Negative();
 
@@ -2470,7 +2470,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
+    CF_WriteQueueCmd_t *           wq = &utbuf.wq;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
     uint16                         initial_hk_err_counter = Any_uint16();
@@ -2478,14 +2478,14 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination down direction, pending queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_pend;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_pend;
 
     /* invalid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Negative();
 
@@ -2512,8 +2512,8 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t              utbuf;
-    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *                 wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
@@ -2522,14 +2522,14 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_all;
-    dummy_wq->queue = CF_Queue_all;
+    wq->type  = CF_Type_all;
+    wq->queue = CF_Queue_all;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = 0;
 
@@ -2560,8 +2560,8 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t              utbuf;
-    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *                 wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
@@ -2571,14 +2571,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_up;
-    dummy_wq->queue = CF_Queue_active;
+    wq->type  = CF_Type_up;
+    wq->queue = CF_Queue_active;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2611,8 +2611,8 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t                  utbuf;
-    CF_WriteQueueCmd_t *                     dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *                        arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *                     wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *                        arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t           context_CF_WrappedOpenCreate;
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
@@ -2622,14 +2622,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_up;
-    dummy_wq->queue = CF_Queue_history;
+    wq->type  = CF_Type_up;
+    wq->queue = CF_Queue_history;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2662,8 +2662,8 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t              utbuf;
-    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *                 wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
@@ -2673,14 +2673,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_active;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_active;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2713,8 +2713,8 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t              utbuf;
-    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *                 wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile[2];
     int32                                forced_return_CF_WriteTxnQueueDataToFile_1st_call = 0;
@@ -2725,14 +2725,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_active;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_active;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2766,8 +2766,8 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t              utbuf;
-    CF_WriteQueueCmd_t *                 dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *                    arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *                 wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *                    arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
@@ -2777,14 +2777,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_pend;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_pend;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2817,8 +2817,8 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t                  utbuf;
-    CF_WriteQueueCmd_t *                     dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *                        arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *                     wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *                        arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t           context_CF_WrappedOpenCreate;
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
@@ -2828,14 +2828,14 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_history;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_history;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2867,8 +2867,8 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
@@ -2877,14 +2877,14 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_all;
-    dummy_wq->queue = CF_Queue_all;
+    wq->type  = CF_Type_all;
+    wq->queue = CF_Queue_all;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2916,8 +2916,8 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                       = Any_uint16();
@@ -2925,14 +2925,14 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_all;
-    dummy_wq->queue = CF_Queue_history;
+    wq->type  = CF_Type_all;
+    wq->queue = CF_Queue_history;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -2961,8 +2961,8 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                   = Any_uint16();
@@ -2970,14 +2970,14 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_all;
-    dummy_wq->queue = CF_Queue_active;
+    wq->type  = CF_Type_all;
+    wq->queue = CF_Queue_active;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3006,8 +3006,8 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                   = Any_uint16();
@@ -3015,14 +3015,14 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_all;
-    dummy_wq->queue = CF_Queue_pend;
+    wq->type  = CF_Type_all;
+    wq->queue = CF_Queue_pend;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3051,8 +3051,8 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
@@ -3061,14 +3061,14 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_up;
-    dummy_wq->queue = CF_Queue_all;
+    wq->type  = CF_Type_up;
+    wq->queue = CF_Queue_all;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3100,8 +3100,8 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                       = Any_uint16();
@@ -3109,14 +3109,14 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_up;
-    dummy_wq->queue = CF_Queue_history;
+    wq->type  = CF_Type_up;
+    wq->queue = CF_Queue_history;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3145,8 +3145,8 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                   = Any_uint16();
@@ -3154,14 +3154,14 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_up;
-    dummy_wq->queue = CF_Queue_active;
+    wq->type  = CF_Type_up;
+    wq->queue = CF_Queue_active;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3192,8 +3192,8 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                   = Any_uint16();
@@ -3201,14 +3201,14 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_all;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_all;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3237,8 +3237,8 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                   = Any_uint16();
@@ -3246,14 +3246,14 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_history;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_history;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3282,8 +3282,8 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                   = Any_uint16();
@@ -3291,14 +3291,14 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_active;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_active;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3327,8 +3327,8 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
 {
     /* Arrange */
     CF_UT_cmd_write_q_buf_t        utbuf;
-    CF_WriteQueueCmd_t *           dummy_wq = &utbuf.wq;
-    CFE_SB_Buffer_t *              arg_msg  = &utbuf.buf;
+    CF_WriteQueueCmd_t *           wq      = &utbuf.wq;
+    CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
     uint16                         initial_hk_cmd_counter                   = Any_uint16();
@@ -3336,14 +3336,14 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    dummy_wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    wq->chan = Any_uint8_LessThan(CF_NUM_CHANNELS);
 
     /* valid combination all direction, all queue */
-    dummy_wq->type  = CF_Type_down;
-    dummy_wq->queue = CF_Queue_pend;
+    wq->type  = CF_Type_down;
+    wq->queue = CF_Queue_pend;
 
     /* valid result from CF_WrappedCreat */
-    strncpy(dummy_wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
+    strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
 
     context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
 
@@ -3455,10 +3455,10 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_R
     /* Arrange */
     uint32 arg_val      = 0;
     uint8  arg_chan_num = Any_cf_chan_num(); /* Any_cf_chan_num used here because value matters to this test */
-    CF_ConfigTable_t dummy_config_table;
+    CF_ConfigTable_t config_table;
     int              local_result;
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
     memset(CF_AppData.config_table->chan[arg_chan_num].sem_name, (char)Any_uint8_Except(0), 1);
 
     /* Act */
@@ -3473,10 +3473,10 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Retu
     /* Arrange */
     uint32 arg_val      = 0;
     uint8  arg_chan_num = Any_cf_chan_num(); /* Any_cf_chan_num used here because value matters to this test */
-    CF_ConfigTable_t dummy_config_table;
+    CF_ConfigTable_t config_table;
     int              local_result;
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
     memset(CF_AppData.config_table->chan[arg_chan_num].sem_name, (char)0, 1);
 
     /* Act */
@@ -3568,16 +3568,16 @@ void Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value(void)
 {
     /* Arrange */
     CF_UT_cmd_set_param_args_buf_t utbuf;
-    CF_ConfigTable_t               dummy_config_table;
+    CF_ConfigTable_t               config_table;
 
     memset(&utbuf, 0, sizeof(utbuf));
-    memset(&dummy_config_table, 0, sizeof(dummy_config_table));
+    memset(&config_table, 0, sizeof(config_table));
 
     utbuf.sp.key      = CF_GetSet_ValueID_ticks_per_second;
     utbuf.sp.value    = 1;
     utbuf.sp.chan_num = 0;
 
-    CF_AppData.config_table = &dummy_config_table;
+    CF_AppData.config_table = &config_table;
 
     /* Act */
     CF_CmdSetParam(&utbuf.buf);

--- a/unit-test/cf_timer_tests.c
+++ b/unit-test/cf_timer_tests.c
@@ -46,15 +46,15 @@ void cf_timer_tests_Teardown(void)
 void Test_CF_Timer_Sec2Ticks_ReturnExpectedValue(void)
 {
     /* Arrange */
-    CF_Timer_Seconds_t arg_sec                = Any_uint32();
-    uint32             dummy_ticks_per_second = Any_uint32();
-    CF_ConfigTable_t   dummy_config_table;
+    CF_Timer_Seconds_t arg_sec          = Any_uint32();
+    uint32             ticks_per_second = Any_uint32();
+    CF_ConfigTable_t   config_table;
 
-    CF_AppData.config_table                   = &dummy_config_table;
-    CF_AppData.config_table->ticks_per_second = dummy_ticks_per_second;
+    CF_AppData.config_table                   = &config_table;
+    CF_AppData.config_table->ticks_per_second = ticks_per_second;
 
     /* Act */
-    UtAssert_UINT32_EQ(CF_Timer_Sec2Ticks(arg_sec), arg_sec * dummy_ticks_per_second);
+    UtAssert_UINT32_EQ(CF_Timer_Sec2Ticks(arg_sec), arg_sec * ticks_per_second);
 }
 
 /*******************************************************************************
@@ -67,23 +67,23 @@ void Test_CF_Timer_InitRelSec_ReceiveExpectedValue(void)
 {
     /* Arrange */
     uint32      arg_rel_sec = Any_uint32();
-    CF_Timer_t  dummy_timer;
-    CF_Timer_t *arg_t = &dummy_timer;
+    CF_Timer_t  timer;
+    CF_Timer_t *arg_t = &timer;
 
     /* Arrange unstubbalbe: CF_Timer_Sec2Ticks in same file */
-    uint32           dummy_ticks_per_second = Any_uint32();
-    CF_ConfigTable_t dummy_config_table;
+    uint32           ticks_per_second = Any_uint32();
+    CF_ConfigTable_t config_table;
 
-    CF_AppData.config_table                   = &dummy_config_table;
-    CF_AppData.config_table->ticks_per_second = dummy_ticks_per_second;
+    CF_AppData.config_table                   = &config_table;
+    CF_AppData.config_table->ticks_per_second = ticks_per_second;
 
-    arg_t->tick = dummy_ticks_per_second;
+    arg_t->tick = ticks_per_second;
 
     /* Act */
     CF_Timer_InitRelSec(arg_t, arg_rel_sec);
 
     /* Assert */
-    UtAssert_UINT32_EQ(arg_t->tick, arg_rel_sec * dummy_ticks_per_second);
+    UtAssert_UINT32_EQ(arg_t->tick, arg_rel_sec * ticks_per_second);
 }
 
 /*******************************************************************************
@@ -95,9 +95,9 @@ void Test_CF_Timer_InitRelSec_ReceiveExpectedValue(void)
 void Test_CF_Timer_Expired_When_t_tick_Is_0_Return_1(void)
 {
     /* Arrange */
-    CF_Timer_t dummy_timer;
-    dummy_timer.tick                  = 0;
-    const CF_Timer_t *arg_t           = &dummy_timer;
+    CF_Timer_t timer;
+    timer.tick                        = 0;
+    const CF_Timer_t *arg_t           = &timer;
     int               expected_result = 1;
 
     /* Act */
@@ -107,9 +107,9 @@ void Test_CF_Timer_Expired_When_t_tick_Is_0_Return_1(void)
 void Test_CF_Timer_Expired_When_t_tick_Is_1_Return_0(void)
 {
     /* Arrange */
-    CF_Timer_t dummy_timer;
-    dummy_timer.tick                  = 1;
-    const CF_Timer_t *arg_t           = &dummy_timer;
+    CF_Timer_t timer;
+    timer.tick                        = 1;
+    const CF_Timer_t *arg_t           = &timer;
     int               expected_result = 0;
 
     /* Act */
@@ -119,9 +119,9 @@ void Test_CF_Timer_Expired_When_t_tick_Is_1_Return_0(void)
 void Test_CF_Timer_Expired_When_t_tick_IsAnyIntegerExcept_0_Return_0(void)
 {
     /* Arrange */
-    CF_Timer_t dummy_timer;
-    dummy_timer.tick                  = Any_int_Except(0);
-    const CF_Timer_t *arg_t           = &dummy_timer;
+    CF_Timer_t timer;
+    timer.tick                        = Any_int_Except(0);
+    const CF_Timer_t *arg_t           = &timer;
     int               expected_result = 0;
 
     /* Act */
@@ -138,8 +138,8 @@ void Test_CF_Timer_Tick_When_t_tick_Is_non0_Decrement_t_tick(void)
 {
     /* Arrange */
     uint32      initial_tick = Any_uint32_Except(0);
-    CF_Timer_t  dummy_t;
-    CF_Timer_t *arg_t = &dummy_t;
+    CF_Timer_t  t;
+    CF_Timer_t *arg_t = &t;
 
     arg_t->tick = initial_tick;
 

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -79,7 +79,7 @@ void local_handler_OS_close(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubC
 
 /*******************************************************************************
 **
-**  cf_utils_tests dummy test functions
+**  cf_utils_tests test functions
 **
 *******************************************************************************/
 
@@ -256,7 +256,7 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
 {
     /* Arrange */
     CF_Transaction_t arg_t;
-    uint8            dummy_chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    uint8            chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
     CF_CListNode_t **expected_head;
     CF_CListNode_t * expected_cl_node;
     uint16           initial_q_size = Any_uint16_Except(0); /* 0 will CF_Assert */
@@ -268,7 +268,7 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
 
     UT_SetDataBuffer(UT_KEY(CF_CList_Remove), &context_clist_remove, sizeof(context_clist_remove), false);
 
-    arg_t.chan_num   = dummy_chan_num;
+    arg_t.chan_num   = chan_num;
     expected_head    = &CF_AppData.engine.channels[arg_t.chan_num].qs[arg_t.flags.com.q_index];
     expected_cl_node = &arg_t.cl_node;
 
@@ -291,9 +291,9 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
 void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(void)
 {
     /* Arrange */
-    CF_Transaction_t              dummy_t;
-    CF_Transaction_t *            arg_t          = &dummy_t;
-    uint8                         dummy_chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    CF_Transaction_t              t;
+    CF_Transaction_t *            arg_t    = &t;
+    uint8                         chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
     CF_CListNode_t **             expected_remove_head;
     CF_CListNode_t *              expected_remove_node;
     CF_CListNode_t **             expected_insert_back_head;
@@ -302,9 +302,9 @@ void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(
     CF_CList_Remove_context_t     context_clist_remove;
     CF_CList_InsertBack_context_t context_clist_insert_back;
 
-    memset(&dummy_t, 0, sizeof(dummy_t));
+    memset(&t, 0, sizeof(t));
 
-    arg_t->chan_num = dummy_chan_num;
+    arg_t->chan_num = chan_num;
 
     UT_SetDataBuffer(UT_KEY(CF_CList_Remove), &context_clist_remove, sizeof(context_clist_remove), false);
 
@@ -341,8 +341,8 @@ void Test_CF_CList_Remove_Ex_Call_CF_CList_Remove_AndDecrement_q_size(void)
     /* Arrange */
     CF_Channel_t *   arg_c     = &CF_AppData.engine.channels[Any_uint32_LessThan(CF_NUM_CHANNELS)];
     CF_QueueIdx_t    arg_index = Any_cf_queue_index_t();
-    CF_CListNode_t   dummy_node;
-    CF_CListNode_t * arg_node = &dummy_node;
+    CF_CListNode_t   node;
+    CF_CListNode_t * arg_node = &node;
     CF_CListNode_t **expected_remove_head;
     CF_CListNode_t * expected_remove_node;
     uint16           initial_q_size = Any_uint16_Except(0);
@@ -377,10 +377,10 @@ void Test_CF_CList_InsertAfter_Ex_Call_CF_CList_InsertAfter_AndIncrement_q_size(
     /* Arrange */
     CF_Channel_t *   arg_c     = &CF_AppData.engine.channels[Any_uint32_LessThan(CF_NUM_CHANNELS)];
     CF_QueueIdx_t    arg_index = Any_cf_queue_index_t();
-    CF_CListNode_t   dummy_start;
-    CF_CListNode_t * arg_start = &dummy_start;
-    CF_CListNode_t   dummy_after;
-    CF_CListNode_t * arg_after                  = &dummy_after;
+    CF_CListNode_t   start;
+    CF_CListNode_t * arg_start = &start;
+    CF_CListNode_t   after;
+    CF_CListNode_t * arg_after                  = &after;
     CF_CListNode_t **expected_insert_after_head = &arg_c->qs[arg_index];
     uint16           initial_q_size             = Any_uint16();
     uint16           updated_q_size;
@@ -413,8 +413,8 @@ void Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size(vo
     /* Arrange */
     CF_Channel_t *   arg_c     = &CF_AppData.engine.channels[Any_uint32_LessThan(CF_NUM_CHANNELS)];
     CF_QueueIdx_t    arg_index = Any_cf_queue_index_t();
-    CF_CListNode_t   dummy_node;
-    CF_CListNode_t * arg_node       = &dummy_node;
+    CF_CListNode_t   node;
+    CF_CListNode_t * arg_node       = &node;
     uint16           initial_q_size = Any_uint16();
     CF_CListNode_t **expected_insert_back_head;
     CF_CListNode_t * expected_insert_back_node;
@@ -611,14 +611,14 @@ void Test_CF_WriteHistoryQueueDataToFile(void)
 void Test_CF_PrioSearch_When_t_PrioIsGreaterThanContextPrioReturn_CLIST_CONT(void)
 {
     /* Arrange */
-    CF_Transaction_t          dummy_t;
-    CF_CListNode_t *          arg_node = &dummy_t.cl_node;
-    CF_Traverse_PriorityArg_t dummy_p;
-    void *                    arg_context = (void *)&dummy_p;
+    CF_Transaction_t          t;
+    CF_CListNode_t *          arg_node = &t.cl_node;
+    CF_Traverse_PriorityArg_t p;
+    void *                    arg_context = (void *)&p;
     int32                     result;
 
-    dummy_t.priority = Any_uint8_Except(0);
-    dummy_p.priority = Any_uint8_LessThan(dummy_t.priority);
+    t.priority = Any_uint8_Except(0);
+    p.priority = Any_uint8_LessThan(t.priority);
 
     /* Act */
     result = CF_PrioSearch(arg_node, arg_context);
@@ -630,47 +630,47 @@ void Test_CF_PrioSearch_When_t_PrioIsGreaterThanContextPrioReturn_CLIST_CONT(voi
 void Test_CF_PrioSearch_When_t_PrioIsEqToContextPrio_Set_context_t_To_t_AndReturn_CLIST_EXIT(void)
 {
     /* Arrange */
-    CF_Transaction_t          dummy_t;
-    CF_CListNode_t *          arg_node = &dummy_t.cl_node;
-    CF_Traverse_PriorityArg_t dummy_p;
-    void *                    arg_context = (void *)&dummy_p;
+    CF_Transaction_t          t;
+    CF_CListNode_t *          arg_node = &t.cl_node;
+    CF_Traverse_PriorityArg_t p;
+    void *                    arg_context = (void *)&p;
     int32                     result;
 
-    memset(&dummy_p, 0, sizeof(dummy_p));
+    memset(&p, 0, sizeof(p));
 
     /* NOTE: these are inverted from previous test! */
-    dummy_t.priority = Any_uint8_Except(0);
-    dummy_p.priority = dummy_t.priority;
+    t.priority = Any_uint8_Except(0);
+    p.priority = t.priority;
 
     /* Act */
     result = CF_PrioSearch(arg_node, arg_context);
 
     /* Assert */
     UtAssert_INT32_EQ(result, CF_CLIST_EXIT);
-    UtAssert_ADDRESS_EQ(dummy_p.t, &dummy_t);
+    UtAssert_ADDRESS_EQ(p.t, &t);
 }
 
 void Test_CF_PrioSearch_When_t_PrioIsLessThanContextPrio_Set_context_t_To_t_AndReturn_CLIST_EXIT(void)
 {
     /* Arrange */
-    CF_Transaction_t          dummy_t;
-    CF_CListNode_t *          arg_node = &dummy_t.cl_node;
-    CF_Traverse_PriorityArg_t dummy_p;
-    void *                    arg_context = (void *)&dummy_p;
+    CF_Transaction_t          t;
+    CF_CListNode_t *          arg_node = &t.cl_node;
+    CF_Traverse_PriorityArg_t p;
+    void *                    arg_context = (void *)&p;
     int32                     result;
 
-    memset(&dummy_p, 0, sizeof(dummy_p));
+    memset(&p, 0, sizeof(p));
 
     /* NOTE: these are inverted from previous test! */
-    dummy_p.priority = Any_uint8_Except(0);
-    dummy_t.priority = Any_uint8_LessThan(dummy_p.priority);
+    p.priority = Any_uint8_Except(0);
+    t.priority = Any_uint8_LessThan(p.priority);
 
     /* Act */
     result = CF_PrioSearch(arg_node, arg_context);
 
     /* Assert */
     UtAssert_INT32_EQ(result, CF_CLIST_EXIT);
-    UtAssert_ADDRESS_EQ(dummy_p.t, &dummy_t);
+    UtAssert_ADDRESS_EQ(p.t, &t);
 }
 
 /*******************************************************************************
@@ -682,27 +682,27 @@ void Test_CF_PrioSearch_When_t_PrioIsLessThanContextPrio_Set_context_t_To_t_AndR
 void Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_index_To_q(void)
 {
     /* Arrange */
-    CF_Transaction_t  dummy_t;
-    CF_Transaction_t *arg_t = &dummy_t;
+    CF_Transaction_t  t;
+    CF_Transaction_t *arg_t = &t;
     CF_QueueIdx_t     arg_q = Any_cf_queue_index_t();
-    CF_Channel_t *    dummy_c;
+    CF_Channel_t *    c;
     CF_CListNode_t ** expected_insert_back_head;
     CF_CListNode_t *  expected_insert_back_node;
 
     CF_CList_InsertBack_context_t context_clist_insert_back;
 
-    /* dummy_t settings to bypass CF_Assert */
-    dummy_t.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
-    dummy_t.state    = Any_uint8_Except(CF_TxnState_IDLE);
+    /* t settings to bypass CF_Assert */
+    t.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    t.state    = Any_uint8_Except(CF_TxnState_IDLE);
 
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertBack), &context_clist_insert_back, sizeof(context_clist_insert_back), false);
 
     /* setting (&CF_AppData.engine.channels[arg_t->chan_num])->qs[arg_q] to NULL
      * makes the list empty */
-    dummy_c            = &CF_AppData.engine.channels[arg_t->chan_num];
-    dummy_c->qs[arg_q] = NULL;
+    c            = &CF_AppData.engine.channels[arg_t->chan_num];
+    c->qs[arg_q] = NULL;
 
-    expected_insert_back_head = &dummy_c->qs[arg_q];
+    expected_insert_back_head = &c->qs[arg_q];
     expected_insert_back_node = &arg_t->cl_node;
 
     /* Act */
@@ -720,12 +720,12 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_ind
 void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(void)
 {
     /* Arrange */
-    CF_Transaction_t  dummy_p_t;
-    CF_Transaction_t  dummy_t;
-    CF_Transaction_t *arg_t = &dummy_t;
+    CF_Transaction_t  p_t;
+    CF_Transaction_t  t;
+    CF_Transaction_t *arg_t = &t;
     CF_QueueIdx_t     arg_q = Any_cf_queue_index_t();
-    CF_CListNode_t *  dummy_qs;
-    CF_Channel_t *    dummy_c;
+    CF_CListNode_t *  qs;
+    CF_Channel_t *    c;
     CF_CListNode_t *  expected_end;
     CF_CListFn_t      expected_fn;
     CF_CListNode_t ** expected_insert_after_head;
@@ -738,27 +738,27 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(voi
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse_R), UT_AltHandler_CF_CList_Traverse_R_PRIO,
                           &context_cf_clist_traverse_r);
 
-    /* dummy_t settings to bypass CF_Assert */
-    dummy_t.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
-    dummy_t.state    = Any_uint8_Except(CF_TxnState_IDLE);
+    /* t settings to bypass CF_Assert */
+    t.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    t.state    = Any_uint8_Except(CF_TxnState_IDLE);
 
     /* setting (&CF_AppData.engine.channels[arg_t->chan_num])->qs[arg_q] to
-     * &dummy_qs makes the list NOT empty */
-    dummy_c            = &CF_AppData.engine.channels[arg_t->chan_num];
-    dummy_c->qs[arg_q] = (CF_CListNode_t *)&dummy_qs;
+     * &qs makes the list NOT empty */
+    c            = &CF_AppData.engine.channels[arg_t->chan_num];
+    c->qs[arg_q] = (CF_CListNode_t *)&qs;
 
     /* setup CF_Traverse_PriorityArg_t altered value */
-    context_cf_clist_traverse_r.context_t = &dummy_p_t;
+    context_cf_clist_traverse_r.context_t = &p_t;
 
     /* Arrange for CF_CList_InsertAfter_Ex */
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertAfter), &context_CF_CList_InsertAfter, sizeof(context_CF_CList_InsertAfter),
                      false);
 
     /* set expected values */
-    expected_end                = dummy_c->qs[arg_q];
+    expected_end                = c->qs[arg_q];
     expected_fn                 = CF_PrioSearch;
-    expected_insert_after_head  = (CF_CListNode_t **)&dummy_c->qs[arg_q];
-    expected_insert_after_start = (CF_CListNode_t **)&dummy_p_t.cl_node;
+    expected_insert_after_head  = (CF_CListNode_t **)&c->qs[arg_q];
+    expected_insert_after_start = (CF_CListNode_t **)&p_t.cl_node;
     expected_insert_after_after = (CF_CListNode_t **)&arg_t->cl_node;
 
     /* Act */
@@ -779,11 +779,11 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(voi
 void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
 {
     /* Arrange */
-    CF_Transaction_t  dummy_t;
-    CF_Transaction_t *arg_t = &dummy_t;
+    CF_Transaction_t  t;
+    CF_Transaction_t *arg_t = &t;
     CF_QueueIdx_t     arg_q = Any_cf_queue_index_t();
-    CF_CListNode_t *  dummy_qs;
-    CF_Channel_t *    dummy_c;
+    CF_CListNode_t *  qs;
+    CF_Channel_t *    c;
     CF_CListNode_t *  expected_end;
     CF_CListFn_t      expected_fn;
     CF_CListNode_t ** expected_insert_back_head;
@@ -795,22 +795,22 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     UT_SetDataBuffer(UT_KEY(CF_CList_Traverse_R), &context_cf_clist_traverse_r, sizeof(context_cf_clist_traverse_r),
                      false);
 
-    /* dummy_t settings to bypass CF_Assert */
-    dummy_t.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
-    dummy_t.state    = Any_uint8_Except(CF_TxnState_IDLE);
+    /* t settings to bypass CF_Assert */
+    t.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
+    t.state    = Any_uint8_Except(CF_TxnState_IDLE);
 
     /* setting (&CF_AppData.engine.channels[arg_t->chan_num])->qs[arg_q] to
-     * &dummy_qs makes the list NOT empty */
-    dummy_c            = &CF_AppData.engine.channels[arg_t->chan_num];
-    dummy_c->qs[arg_q] = (CF_CListNode_t *)&dummy_qs;
+     * &qs makes the list NOT empty */
+    c            = &CF_AppData.engine.channels[arg_t->chan_num];
+    c->qs[arg_q] = (CF_CListNode_t *)&qs;
 
     /* setup CF_Traverse_PriorityArg_t altered value */
     context_cf_clist_traverse_r.context_t = NULL;
 
     /* set expected values */
-    expected_end              = dummy_c->qs[arg_q];
+    expected_end              = c->qs[arg_q];
     expected_fn               = CF_PrioSearch;
-    expected_insert_back_head = &dummy_c->qs[arg_q];
+    expected_insert_back_head = &c->qs[arg_q];
     expected_insert_back_node = &arg_t->cl_node;
 
     /* Arrange for CF_CList_InsertBack_Ex */
@@ -840,12 +840,12 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
 void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_ToCounter(void)
 {
     /* Arrange */
-    CF_Transaction_t      dummy_t;
-    CF_CListNode_t *      arg_n = &dummy_t.cl_node;
-    CF_TraverseAll_Arg_t  dummy_args;
+    CF_Transaction_t      t;
+    CF_CListNode_t *      arg_n = &t.cl_node;
+    CF_TraverseAll_Arg_t  args;
     CF_TraverseAll_Arg_t *arg_args;
-    int                   dummy_context_val;
-    void *                dummy_context        = &dummy_context_val;
+    int                   context_val;
+    void *                context              = &context_val;
     int                   initial_args_counter = Any_int();
     CF_Transaction_t *    expected_t;
     void *                expected_context;
@@ -853,15 +853,15 @@ void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_T
 
     UT_Callback_CF_TraverseAllTransactions_context_t func_ptr_context;
 
-    dummy_args.fn      = UT_Callback_CF_TraverseAllTransactions;
-    dummy_args.context = dummy_context;
-    dummy_args.counter = initial_args_counter;
+    args.fn      = UT_Callback_CF_TraverseAllTransactions;
+    args.context = context;
+    args.counter = initial_args_counter;
 
-    arg_args = &dummy_args;
+    arg_args = &args;
 
     /* set expected values */
-    expected_t       = &dummy_t;
-    expected_context = dummy_context;
+    expected_t       = &t;
+    expected_context = context;
 
     UT_SetDataBuffer(UT_KEY(UT_Callback_CF_TraverseAllTransactions), &func_ptr_context, sizeof(func_ptr_context),
                      false);
@@ -887,10 +887,10 @@ void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_T
 void Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_args_counter(void)
 {
     /* Arrange */
-    CF_Channel_t    dummy_c;
+    CF_Channel_t    c;
     CF_Channel_t *  arg_c;
-    int             dummy_context;
-    void *          arg_context    = &dummy_context;
+    int             context;
+    void *          arg_context    = &context;
     uint8           expected_count = CF_QueueIdx_RX - CF_QueueIdx_PEND + 1;
     CF_CListNode_t *expected_qs_nodes[expected_count];
     int             i = 0;
@@ -900,7 +900,7 @@ void Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_ar
 
     for (i = 0; i < expected_count; ++i)
     {
-        dummy_c.qs[i] = (CF_CListNode_t *)&expected_qs_nodes[i];
+        c.qs[i] = (CF_CListNode_t *)&expected_qs_nodes[i];
     }
 
     /* set context */
@@ -909,7 +909,7 @@ void Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_ar
     UT_SetDataBuffer(UT_KEY(CF_CList_Traverse), contexts_cf_clist_traverse, sizeof(contexts_cf_clist_traverse), false);
 
     /* finalize arguments */
-    arg_c = &dummy_c;
+    arg_c = &c;
 
     /* Act */
     UtAssert_INT32_EQ(CF_TraverseAllTransactions(arg_c, arg_fn, arg_context), expected_count);
@@ -941,8 +941,8 @@ void Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_ar
 void Test_CF_TraverseAllTransactions_All_Channels_ReturnTotalTraversals(void)
 {
     /* Arrange */
-    int   dummy_context;
-    void *arg_context       = &dummy_context;
+    int   context;
+    void *arg_context       = &context;
     uint8 per_channel_count = CF_QueueIdx_RX - CF_QueueIdx_PEND + 1;
     int   expected_result   = per_channel_count * CF_NUM_CHANNELS;
 
@@ -962,10 +962,10 @@ void Test_CF_TraverseAllTransactions_All_Channels_ReturnTotalTraversals(void)
 void Test_CF_WrappedOpen_Call_OS_OpenCreate_WithGivenArgumentsAndReturnItsReturnValue(void)
 {
     /* Arrange */
-    osal_id_t  dummy_fd;
-    osal_id_t *arg_fd = &dummy_fd;
-    char       dummy_fname;
-    char *     arg_fname                   = &dummy_fname;
+    osal_id_t  fd;
+    osal_id_t *arg_fd = &fd;
+    char       fname;
+    char *     arg_fname                   = &fname;
     int32      arg_flags                   = Any_uint32();
     int32      arg_access                  = Any_uint32();
     int32      forced_return_OS_OpenCreate = Any_int32();
@@ -1025,8 +1025,8 @@ void Test_CF_WrappedRead_CallsOS_read_WithGivenArgumentsAndReturnItsReturnValue(
 {
     /* Arrange */
     uint32 arg_read_size = Any_uint32_LessThan_or_EqualTo(10); /* 10 is arbitrary to make test fast */
-    uint8  dummy_buf[10] = {0};                                /* 10 to match max read size of 10 (arbitrary) */
-    void * arg_buf       = &dummy_buf;
+    uint8  buf[10]       = {0};                                /* 10 to match max read size of 10 (arbitrary) */
+    void * arg_buf       = &buf;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), arg_read_size);
 
@@ -1043,8 +1043,8 @@ void Test_CF_WrappedRead_CallsOS_read_WithGivenArgumentsAndReturnItsReturnValue(
 void Test_CF_WrappedWrite_Call_OS_write_WithGivenArgumentsAndReturnItsReturnValue(void)
 {
     /* Arrange */
-    uint8  dummy_buf;
-    void * arg_buf         = &dummy_buf;
+    uint8  buf;
+    void * arg_buf         = &buf;
     uint32 test_write_size = Any_uint32();
     int32  expected_result = Any_int32();
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #105
**_Resubmission of https://github.com/nasa/CF/pull/367
Somehow I tied myself in a few knots trying to squash the merge commit and some clang-format corrections into a single commit.
Anyway, this new PR is from an updated branch so there should be no merge commits I believe._**
Removed (unnecessary) use of 'dummy' in several variable names and corresponding function names for completeness - e.g. `cf_config_table_tests_set_table_to_nominal()`). Note `Dummy_CF_TsnChanAction_fn_t()` left as is due to conflicting type defined with the exact same name as this function.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully (except cppcheck convert to sarif issue - already documented here: https://github.com/nasa/cFS/pull/657)

**Expected behavior changes**
None

**Contributor Info**
Avi Weiss @thnkslprpt