### PR TITLE
Fix #139, Remove use of message storage in CF_AppData global

### DIFF
--- a/docs/dox_src/cfs_cf.dox
+++ b/docs/dox_src/cfs_cf.dox
@@ -24,7 +24,7 @@
   This document provides a design and operational overview along with a complete specification
   for the commands and telemetry associated with the CFS CFDP (CF) application software.
 
-  The document is intended primarily for users of the software (operations personal, test
+  The document is intended primarily for users of the software (operations personnel, test
   engineers, and maintenance personnel).  The deployment guide section, is intended for mission
   developers when deploying and configuring the CF application software for a mission
   flight software build environment.
@@ -110,7 +110,7 @@
 
   The CFS CFDP application is a CFDP implementation written specifically for CFS.
   The goal was bounded, small,
-  time and space efficent implementation of the CFDP features necessary for flight.
+  time and space-efficient implementation of the CFDP features necessary for flight.
   CF implements Class 1 and 2 send and receive, as well as logic to cancel, suspend,
   resume, abandon, freeze, etc.  Messages utilize "zero-copy" software bus buffers.
   CF configuration is mainly through the configuration table.
@@ -130,7 +130,7 @@
   The CF Application has an operational interface consisting of one table, two
   different telemetry messages and twenty commands.
 
-  CF is an event driven, single threaded application that wakes up when one of
+  CF is an event-driven, single-threaded application that wakes up when one of
   the following four messages are received on its software bus pipe. Ground
   command, Housekeeping Request command, Incoming PDU or the Wake-up command.
   The Wake-up command tells CF to do file transaction processing. This command
@@ -145,9 +145,9 @@
     config for static memory limits and the configuration table for dynamic timing and functionality limits.
   - Much smaller code footprint. CF 3.0 is light-weight flight-only app. It does not provide any ground engine support.
 
-  For simplicity, the examples through-out this document refer to a typical
+  For simplicity, the examples throughout this document refer to a typical
   operational scenario whereby the peer to the CF application is located on the
-  ground. The CF applications knows only of incoming file transactions and
+  ground. The CF application knows only of incoming file transactions and
   outgoing file transactions. The terms uplink, downlink and playback are
   often used, but only apply when the peer is located on the ground. CF may be
   configured to have more than one peer. One peer may be located onboard the
@@ -164,7 +164,7 @@
   <H2> Initialization </H2>
 
   CF initialization is the same for Power On Resets and Processor Resets.
-  Standard application initialization activites are performed such as status and
+  Standard application initialization activities are performed such as status and
   tracking initialization, message initialization and subscription, table
   initialization and registering with event services.
 
@@ -174,7 +174,7 @@
 
   -# Send any pending message required for RX transaction
   -# Re-send any message required for TX transaction if timer expired (for example,
-     send EOF, or re-send EOF if ack timer expired)
+     send EOF, or re-send EOF if ACK timer expired)
   -# Send a filedata PDU in response to a NAK request. Per wakeup, one will be sent
      per each transaction in the TX wait state.
   -# Once all TX wait transactions have processed their needs to send, the currently
@@ -196,7 +196,7 @@
    When/if the metadata is received for that transaction, OS_mv is used to transition
    the temporary file to the desired destination location.  Note that OS_mv attempts
    a rename first (faster but does not work across file systems), and if that
-   fails then attempts a copy/delete (slower).  Due to this the most efficent
+   fails then attempts a copy/delete (slower).  Due to this the most efficient
    temporary directory configuration is for it to be on the same file system as the
    destination.  Note that currently this only impacts class 2 RX with an out
    of order metadata packet, but there's future work being considered to
@@ -208,7 +208,7 @@
 
   The CF application has a single internal core referred to as the engine. The
   engine is capable of transmitting and receiving a configurable number of
-  transactions simultaneously.The engine builds outgoing Protocol Data Units
+  transactions simultaneously. The engine builds outgoing Protocol Data Units
   (PDUs) and interprets the incoming PDUs. It handles all details regarding the
   CFDP standard protocol which is defined in the CCSDS 727.0-B-4 Blue Book. The
   engine processes the file transactions when it is 'cycled'. The number of
@@ -331,7 +331,7 @@
   moved to the active queue when the transaction begins. After the transaction
   is complete the queue entry is moved to the history queue. The queues may be
   viewed by command at any time. The pending queue reads may be enabled or
-  disabled at anytime. Each channel has a dedicated throttling semaphore, peer
+  disabled at any time. Each channel has a dedicated throttling semaphore, peer
   entity ID, message ID for outgoing PDUs and a configurable number of polling
   directories. File output transactions may occur simultaneously on different
   channels. The engine processes all active outgoing transactions in a
@@ -443,7 +443,7 @@
   the transaction begins, then moves to the history queue when the transaction is
   complete.
 
-  The history queue has a sliding window affect. When the queue is full and a
+  The history queue has a sliding window effect. When the queue is full and a
   new transaction needs to be added, the oldest transaction will be removed,
   making room for the new transaction.
 
@@ -452,7 +452,7 @@
   the memory for the queue will be available.
 
   For incoming file transactions, CF uses a statically allocated buffer for the
-  incoming pdu. The size of this buffer is defined by the platform configuration
+  incoming PDU. The size of this buffer is defined by the platform configuration
   parameter, CF_MAX_PDU_SIZE. The incoming PDU's are copied from the Software Bus
   into this buffer and then passed to the engine.
 
@@ -622,7 +622,7 @@ CF_UnionArgs_Payload_t;
 \endverbatim
 
     The command parameter byte[0] identifies which category of counters to
-        reset.counters.The value should be set to one of five possible values defined in the reset enumeration.
+        reset.counters. The value should be set to one of five possible values defined in the reset enumeration.
 
   \verbatim typedef enum {
             CF_Reset_all     = 0, 
@@ -823,7 +823,7 @@ CF_UnionArgs_Payload_t;
   suspended. Canceling is always a better option than abandoning. 
   
   NOTE: When a suspended transaction is cancelled, the cancel does not take 
-  affect until the transaction is resumed.
+  effect until the transaction is resumed.
 
   \verbatim 
   typedef struct CF_TransactionCmd
@@ -894,7 +894,7 @@ CF_UnionArgs_Payload_t;
   indicating the reason for failure.
   
   NOTE: If a Cancel command is received by CF on an outgoing transaction that 
-  is suspended, the cancel does not take affect until the transaction is 
+  is suspended, the cancel does not take effect until the transaction is 
   resumed.  
 
 
@@ -1095,7 +1095,7 @@ CF_UnionArgs_Payload_t;
   This command is used to enable reading from the pending queue on a particular
   channel. It has one parameter (channel) and is sent when the pending queue
   reads are disabled for that channel. The pending queue holds the names of the
-  files that are waiting to be sent out by CF. This command has no affect on
+  files that are waiting to be sent out by CF. This command has no effect on
   incoming file transactions.
 
   When the command is executed successfully, the command counter is incremented
@@ -1137,7 +1137,7 @@ CF_UnionArgs_Payload_t;
   
 
   When the command is executed successfully, the command counter is incremented
-  and the an event message will be generated.
+  and then an event message will be generated.
 
   If the command is not successful, the command error counter will increment and
   an error event will be generated indicating the reason for failure.  
@@ -1227,7 +1227,7 @@ CF_UnionArgs_Payload_t;
   keep polling directories disabled when they are not actively receiving files.
   
   When the command is executed successfully, the command counter is incremented
-  and and event message will be generated.
+  and an event message will be generated.
 
   If the command is not successful, the command error counter will increment and
   an error event will be generated indicating the reason for failure.  
@@ -1322,7 +1322,7 @@ CF_UnionArgs_Payload_t;
 #CF_CMD_MID with command code #CF_DISABLE_ENGINE_CC. The command has no
   command parameters and is used to disable engine processing.  
   Note configuration table updates can be performed while the engine is disabled, 
-  and when the engine is re-enabled the new configuration will take affect.
+  and when the engine is re-enabled the new configuration will take effect.
   
   Prev: \ref cfscfcfgpg <BR>
   Next: \ref cfscftlmpg
@@ -1390,7 +1390,7 @@ CF_UnionArgs_Payload_t;
   the application is started. CF supports table updates during runtime only when
   the engine is disabled.
       
-  CF utilzes a CFS table for run-time configuration defined by #CF_ConfigTable_t.  The channel
+  CF utilizes a CFS table for run-time configuration defined by #CF_ConfigTable_t.  The channel
   configuration is in #CF_ConfigTable_t.chan which contains a polling element defined by
   #CF_PollDir_t.
 
@@ -1414,7 +1414,7 @@ CF_UnionArgs_Payload_t;
 
   The stack size for the CF application must be monitored and must be no less
   than 16384 bytes. Depending on the CF configuration, the stack size may need
-  to be set higher than 16384. The stack size is specified int he cfe_es_startup.scr
+  to be set higher than 16384. The stack size is specified in the cfe_es_startup.scr
   file that is located in the /mission/build/xxx/exe area.
   
   Poll directories must not have subdirectories, otherwise errors will occur

--- a/fsw/inc/cf_events.h
+++ b/fsw/inc/cf_events.h
@@ -512,7 +512,7 @@
  *
  *  \par Cause:
  *
- *  Condition that triggers a ACK occurred that would meet or exceed the ACK limit
+ *  Condition that triggers an ACK occurred that would meet or exceed the ACK limit
  */
 #define CF_EID_ERR_CFDP_R_ACK_LIMIT (73)
 
@@ -798,7 +798,7 @@
  *
  *  \par Cause:
  *
- *  Bad segment request values in recived NAK PDU relating
+ *  Bad segment request values in received NAK PDU relating
  *  to a current transaction
  */
 #define CF_EID_ERR_CFDP_S_INVALID_SR (100)
@@ -810,7 +810,7 @@
  *
  *  \par Cause:
  *
- *  Failure processing recived NAK PDU relating
+ *  Failure processing received NAK PDU relating
  *  to a current transaction
  */
 #define CF_EID_ERR_CFDP_S_PDU_NAK (101)

--- a/fsw/inc/cf_msg.h
+++ b/fsw/inc/cf_msg.h
@@ -823,7 +823,7 @@ typedef enum
      *  \par Description
      *       Disable engine processing.  Note configuration table updates
      *       can be performed while the engine is disabled, and when the engine is
-     *       re-enabled the new configuration will take affect.
+     *       re-enabled the new configuration will take effect.
      *
      *  \par Command Structure
      *       #CF_NoArgsCmd_t

--- a/fsw/inc/cf_platform_cfg.h
+++ b/fsw/inc/cf_platform_cfg.h
@@ -104,12 +104,12 @@ typedef uint32 CF_TransactionSeq_t;
 #define CF_NUM_CHANNELS (2)
 
 /**
- *  @brief Max NAK segments supported in a NAK pdu
+ *  @brief Max NAK segments supported in a NAK PDU
  *
  *  @par Description:
- *       When a NAK pdu is sent or received, this is the max number of
+ *       When a NAK PDU is sent or received, this is the max number of
  *       segment requests supported. This number should match the ground
- *       cfdp engine configuration as well.
+ *       CFDP engine configuration as well.
  *
  *  @par Limits:
  *
@@ -123,14 +123,14 @@ typedef uint32 CF_TransactionSeq_t;
  *       Number of chunks per transaction per channel (RX).
  *
  * CHUNKS -
- * A chunk is a representation of a range range (offset, size) of data received by a receiver.
+ * A chunk is a representation of a range (offset, size) of data received by a receiver.
  *
  * Class 2 CFDP deals with NAK, so received data must be tracked for receivers in order to generate
  * the NAK. The sender must also keep track of NAK requests and send new file data PDUs as a result.
  * (array size must be CF_NUM_CHANNELS)
  * CF_CHANNEL_NUM_RX_CHUNKS_PER_TRANSACTION is an array for each channel indicating the number of chunks per transaction
- * CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION is an array for each channel indicate the number of chunks to keep track of
- * NAK requests from the receiver per transaction
+ * CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION is an array for each channel indicating the number of chunks to keep track
+ * of NAK requests from the receiver per transaction
  *
  *  @par Limits:
  *
@@ -244,7 +244,7 @@ typedef uint32 CF_TransactionSeq_t;
  *
  *  @par Description:
  *       The max PDU size across all channels in the system. Keep in mind that
- *       the max filedata pdu will be smaller than this. This size includes
+ *       the max filedata PDU will be smaller than this. This size includes
  *       the PDU headers and everything. While this is the max value for all
  *       channels, the outgoing_file_chunk_size in the configuration table
  *       is different for each channel so a smaller size can be used.
@@ -304,10 +304,10 @@ typedef uint32 CF_TransactionSeq_t;
 #define CF_FILENAME_MAX_LEN (CF_FILENAME_MAX_NAME + CF_FILENAME_MAX_PATH)
 
 /**
- *  @brief R2 crc calc chunk size
+ *  @brief R2 CRC calc chunk size
  *
  *  @par Description
- *       R2 performs crc calculation upon file completion in chunks. This is the size
+ *       R2 performs CRC calculation upon file completion in chunks. This is the size
  *       of the buffer. The larger the size the more stack will be used, but
  *       the faster it can go. The overall number of bytes calculated per wakeup
  *       is set in the configuration table.

--- a/fsw/inc/cf_tbldefs.h
+++ b/fsw/inc/cf_tbldefs.h
@@ -61,13 +61,13 @@ typedef struct CF_ChannelConfig
     uint32 nak_timer_s;        /**< \brief Non-acknowledge timer in seconds */
     uint32 inactivity_timer_s; /**< \brief Inactivity timer in seconds */
 
-    uint8 ack_limit; /**< number of times to retry ACK (for ex, send fin and wait for fin-ack) */
+    uint8 ack_limit; /**< number of times to retry ACK (for ex, send FIN and wait for fin-ack) */
     uint8 nak_limit; /**< number of times to retry NAK before giving up (resets on a single response */
 
     CFE_SB_MsgId_Atom_t mid_input;  /**< \brief msgid integer value for incoming messages */
     CFE_SB_MsgId_Atom_t mid_output; /**< \brief msgid integer value for outgoing messages */
 
-    uint16 pipe_depth_input; /**< \brief depth of pipe to receive incoming pdu */
+    uint16 pipe_depth_input; /**< \brief depth of pipe to receive incoming PDU */
 
     CF_PollDir_t polldir[CF_MAX_POLLING_DIR_PER_CHAN]; /**< \brief Configuration for polled directories */
 
@@ -81,9 +81,9 @@ typedef struct CF_ChannelConfig
  */
 typedef struct CF_ConfigTable
 {
-    uint32 ticks_per_second;             /**< \brief expected ticks per second to cfdp app */
+    uint32 ticks_per_second;             /**< \brief expected ticks per second to CFDP app */
     uint32 rx_crc_calc_bytes_per_wakeup; /**< \brief max number of bytes per wakeup to calculate
-                                          * r2 crc for recvd file (must be 1024-byte aligned)
+                                          * r2 CRC for recvd file (must be 1024-byte aligned)
                                           */
 
     CF_EntityId_t local_eid; /**< \brief the local entity ID of the CF app */

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -125,7 +125,7 @@ CFE_Status_t CF_ValidateConfigTable(void *tbl_ptr)
     else if (!tbl->rx_crc_calc_bytes_per_wakeup || (tbl->rx_crc_calc_bytes_per_wakeup & 0x3ff))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_INIT_CRC_ALIGN, CFE_EVS_EventType_ERROR,
-                          "CF: config table has rx crc size not aligned with 1024");
+                          "CF: config table has rx CRC size not aligned with 1024");
         ret = crc_alignment; /* must be 1024-byte aligned */
     }
     else if (tbl->outgoing_file_chunk_size > sizeof(CF_CFDP_PduFileDataContent_t))

--- a/fsw/src/cf_app.h
+++ b/fsw/src/cf_app.h
@@ -162,7 +162,7 @@ CFE_Status_t CF_TableInit(void);
  *
  * @par Description
  *       Initializes all aspects of the CF application. Messages,
- *       pipes, events, table, and the cfdp engine.
+ *       pipes, events, table, and the CFDP engine.
  *
  * @par Assumptions, External Events, and Notes:
  *       This must only be called once.

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -20,7 +20,7 @@
 /**
  * @file
  *
- *  The CF Application main cfdp engine and pdu parsing implementation
+ *  The CF Application main CFDP engine and PDU parsing implementation
  *
  *  This file contains two sets of functions. The first is what is needed
  *  to deal with CFDP PDUs. Specifically validating them for correctness
@@ -251,7 +251,7 @@ CF_Logical_PduBuffer_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *t, CF
         hdr = &ph->pdu_header;
 
         hdr->version   = 1;
-        hdr->pdu_type  = (directive_code == 0); /* set to '1' for file data pdu, '0' for a directive pdu */
+        hdr->pdu_type  = (directive_code == 0); /* set to '1' for file data PDU, '0' for a directive PDU */
         hdr->direction = (towards_sender != 0); /* set to '1' for toward sender, '0' for toward receiver */
         hdr->txm_mode  = (CF_CFDP_GetClass(t) == CF_CFDP_CLASS_1); /* set to '1' for class 1 data, '0' for class 2 */
 
@@ -284,8 +284,8 @@ CF_Logical_PduBuffer_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *t, CF
          */
         CF_CFDP_EncodeHeaderWithoutSize(ph->penc, hdr);
 
-        /* If directive code is zero, the pdu is a file data pdu which has no directive code field.
-         * So only set if non-zero, otherwise it will write a 0 to a byte in a file data pdu where we
+        /* If directive code is zero, the PDU is a file data PDU which has no directive code field.
+         * So only set if non-zero, otherwise it will write a 0 to a byte in a file data PDU where we
          * don't necessarily want a 0. */
         if (directive_code)
         {
@@ -370,7 +370,7 @@ CFE_Status_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
     /* this should check if any encoding error occurred */
 
-    /* update pdu length */
+    /* update PDU length */
     CF_CFDP_SetPduLength(ph);
     CF_CFDP_Send(t->chan_num, ph);
 
@@ -597,7 +597,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
     if (CF_CFDP_DecodeHeader(ph->pdec, &ph->pdu_header) != CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_TRUNCATION, CFE_EVS_EventType_ERROR,
-                          "CF: pdu rejected due to eid/seq number field truncation");
+                          "CF: PDU rejected due to EID/seq number field truncation");
         ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
@@ -610,7 +610,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
     else if (CF_CODEC_IS_OK(ph->pdec) && ph->pdu_header.large_flag)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_LARGE_FILE, CFE_EVS_EventType_ERROR,
-                          "CF: pdu with large file bit received (unsupported)");
+                          "CF: PDU with large file bit received (unsupported)");
         ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
@@ -623,14 +623,14 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
 
         if (!CF_CODEC_IS_OK(ph->pdec))
         {
-            CFE_EVS_SendEvent(CF_EID_ERR_PDU_SHORT_HEADER, CFE_EVS_EventType_ERROR, "CF: pdu too short (%lu received)",
+            CFE_EVS_SendEvent(CF_EID_ERR_PDU_SHORT_HEADER, CFE_EVS_EventType_ERROR, "CF: PDU too short (%lu received)",
                               (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
             ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
             ret = CF_SHORT_PDU_ERROR;
         }
         else
         {
-            /* pdu is ok, so continue processing */
+            /* PDU is ok, so continue processing */
             ++CF_AppData.hk.channel_hk[chan_num].counters.recv.pdu;
         }
     }
@@ -676,7 +676,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         if (lv_ret < 0)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_SRC_LEN, CFE_EVS_EventType_ERROR,
-                              "CF: metadata pdu rejected due to invalid length in source filename of 0x%02x",
+                              "CF: metadata PDU rejected due to invalid length in source filename of 0x%02x",
                               md->source_filename.length);
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
             ret = CF_PDU_METADATA_ERROR;
@@ -688,7 +688,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
             if (lv_ret < 0)
             {
                 CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_DST_LEN, CFE_EVS_EventType_ERROR,
-                                  "CF: metadata pdu rejected due to invalid length in dest filename of 0x%02x",
+                                  "CF: metadata PDU rejected due to invalid length in dest filename of 0x%02x",
                                   md->dest_filename.length);
                 ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
                 ret = CF_PDU_METADATA_ERROR;
@@ -733,7 +733,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: filedata pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: filedata PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         CF_CFDP_SetTxnStatus(t, CF_TxnStatus_PROTOCOL_ERROR);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
         ret = CF_SHORT_PDU_ERROR;
@@ -742,7 +742,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     {
         /* If recv PDU has the "segment_meta_flag" set, this is not currently handled in CF. */
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_UNSUPPORTED, CFE_EVS_EventType_ERROR,
-                          "CF: filedata pdu with segment metadata received");
+                          "CF: filedata PDU with segment metadata received");
         CF_CFDP_SetTxnStatus(t, CF_TxnStatus_PROTOCOL_ERROR);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
         ret = CF_ERROR;
@@ -766,7 +766,7 @@ CFE_Status_t CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_EOF_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: eof pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: EOF PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
 
@@ -788,7 +788,7 @@ CFE_Status_t CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_ACK_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: ack pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: ACK PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
 
@@ -811,7 +811,7 @@ CFE_Status_t CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FIN_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: fin pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: FIN PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
 
@@ -835,7 +835,7 @@ CFE_Status_t CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_NAK_SHORT, CFE_EVS_EventType_ERROR,
-                          "CF: nak pdu too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
+                          "CF: NAK PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
 
@@ -917,7 +917,7 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                 else
                 {
                     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_IDLE_MD, CFE_EVS_EventType_ERROR,
-                                      "CF: got invalid md pdu -- abandoning transaction");
+                                      "CF: got invalid md PDU -- abandoning transaction");
                     ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
                     /* leave state as idle, which will reset below */
                 }
@@ -1068,7 +1068,7 @@ CFE_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
         CF_Assert(t->flags.com.q_index == CF_QueueIdx_TXA); /* huh? */
 
         /* if no more messages, then c->cur will be set.
-         * If the transaction sent the last filedata pdu and eof, it will move itself
+         * If the transaction sent the last filedata PDU and EOF, it will move itself
          * off the active queue. Run until either of these occur. */
         while (!args->c->cur && t->flags.com.q_index == CF_QueueIdx_TXA)
         {
@@ -1098,9 +1098,9 @@ void CF_CFDP_CycleTx(CF_Channel_t *c)
     {
         args = (CF_CFDP_CycleTx_args_t) {c, 0};
 
-        /* loop through as long as there are pending transactions, and a message buffer to send their pdus on */
+        /* loop through as long as there are pending transactions, and a message buffer to send their PDUs on */
 
-        /* NOTE: tick processing is higher priority than sending new filedata pdus, so only send however many
+        /* NOTE: tick processing is higher priority than sending new filedata PDUs, so only send however many
          * PDUs that can be sent once we get to here */
         if (!c->cur)
         { /* don't enter if cur is set, since we need to pick up where we left off on tick processing next wakeup */
@@ -1186,7 +1186,7 @@ void CF_CFDP_TickTransactions(CF_Channel_t *c)
             if (args.early_exit)
             {
                 /* early exit means we ran out of available outgoing messages this wakeup.
-                 * If current tick type is nak response, then reset tick type. It would be
+                 * If current tick type is NAK response, then reset tick type. It would be
                  * bad to let NAK response starve out RX or TXW ticks on the next cycle.
                  *
                  * If RX ticks use up all available messages, then we pick up where we left

--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -20,7 +20,7 @@
 /**
  * @file
  *
- *  The CF Application cfdp engine and packet parsing header file
+ *  The CF Application CFDP engine and packet parsing header file
  */
 
 #ifndef CF_CFDP_H
@@ -118,7 +118,7 @@ void CF_CFDP_SetTxnStatus(CF_Transaction_t *t, CF_TxnStatus_t txn_stat);
 void CF_CFDP_SendEotPkt(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Initialization function for the cfdp engine
+/** @brief Initialization function for the CFDP engine
  *
  * @par Description
  *       Performs all initialization of the CFDP engine
@@ -142,7 +142,7 @@ CFE_Status_t CF_CFDP_InitEngine(void);
 void CF_CFDP_CycleEngine(void);
 
 /************************************************************************/
-/** @brief Disables the cfdp engine and resets all state in it.
+/** @brief Disables the CFDP engine and resets all state in it.
  *
  * @par Assumptions, External Events, and Notes:
  *       None
@@ -253,7 +253,7 @@ CFE_Status_t CF_CFDP_SendMd(CF_Transaction_t *t);
 CFE_Status_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief Build a eof PDU for transmit.
+/** @brief Build an EOF PDU for transmit.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -267,7 +267,7 @@ CFE_Status_t CF_CFDP_SendFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 CFE_Status_t CF_CFDP_SendEof(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Build a ack PDU for transmit.
+/** @brief Build an ACK PDU for transmit.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -291,7 +291,7 @@ CFE_Status_t CF_CFDP_SendAck(CF_Transaction_t *t, CF_CFDP_AckTxnStatus_t ts, CF_
                              CF_CFDP_ConditionCode_t cc, CF_EntityId_t peer_eid, CF_TransactionSeq_t tsn);
 
 /************************************************************************/
-/** @brief Build a fin PDU for transmit.
+/** @brief Build a FIN PDU for transmit.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -309,7 +309,7 @@ CFE_Status_t CF_CFDP_SendFin(CF_Transaction_t *t, CF_CFDP_FinDeliveryCode_t dc, 
                              CF_CFDP_ConditionCode_t cc);
 
 /************************************************************************/
-/** @brief Send a previously-assembled nak PDU for transmit.
+/** @brief Send a previously-assembled NAK PDU for transmit.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -401,7 +401,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief Unpack an eof PDU from a received message.
+/** @brief Unpack an EOF PDU from a received message.
  *
  * This should only be invoked for buffers that have been identified
  * as an end of file PDU.
@@ -419,7 +419,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 CFE_Status_t CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief Unpack an ack PDU from a received message.
+/** @brief Unpack an ACK PDU from a received message.
  *
  * This should only be invoked for buffers that have been identified
  * as an acknowledgment PDU.
@@ -437,10 +437,10 @@ CFE_Status_t CF_CFDP_RecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 CFE_Status_t CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief Unpack an fin PDU from a received message.
+/** @brief Unpack an FIN PDU from a received message.
  *
  * This should only be invoked for buffers that have been identified
- * as an final PDU.
+ * as a final PDU.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -455,10 +455,10 @@ CFE_Status_t CF_CFDP_RecvAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 CFE_Status_t CF_CFDP_RecvFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief Unpack a nak PDU from a received message.
+/** @brief Unpack a NAK PDU from a received message.
  *
  * This should only be invoked for buffers that have been identified
- * as an negative/non-acknowledgment PDU.
+ * as a negative/non-acknowledgment PDU.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -516,7 +516,7 @@ void CF_CFDP_CancelTransaction(CF_Transaction_t *t);
  */
 void CF_CFDP_InitTxnTxFile(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan, uint8 priority);
 
-/* functions to handle LVs (length-value, cfdp spec) */
+/* functions to handle LVs (length-value, CFDP spec) */
 /* returns number of bytes copied, or -1 on error */
 
 /************************************************************************/
@@ -543,10 +543,10 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *t, CF_CFDP_Class_t cfdp_class, uint
 int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t *src_lv);
 
 /************************************************************************/
-/** @brief Arm the ack timer
+/** @brief Arm the ACK timer
  *
  * @par Description
- *       Helper function to arm the ack timer and set the flag.
+ *       Helper function to arm the ACK timer and set the flag.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -576,8 +576,8 @@ void CF_CFDP_RecvDrop(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  * @par Description
  *       An idle transaction has never had message processing performed on it.
  *       Typically, the first packet received for a transaction would be
- *       the metadata pdu. There's a special case for R2 where the metadata
- *       pdu could be missed, and filedata comes in instead. In that case,
+ *       the metadata PDU. There's a special case for R2 where the metadata
+ *       PDU could be missed, and filedata comes in instead. In that case,
  *       an R2 transaction must still be started.
  *
  * @par Assumptions, External Events, and Notes:
@@ -628,7 +628,7 @@ void CF_CFDP_CycleTx(CF_Channel_t *c);
  * @par Description
  *       There can only be one active tx transaction per engine cycle.
  *       This function finds the first active, and then sends file
- *       data pdus until there are no outgoing message buffers.
+ *       data PDUs until there are no outgoing message buffers.
  *
  * @par Assumptions, External Events, and Notes:
  *       node must not be NULL. Context must not be NULL.

--- a/fsw/src/cf_cfdp_dispatch.c
+++ b/fsw/src/cf_cfdp_dispatch.c
@@ -46,7 +46,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
 
     selected_handler = NULL;
 
-    /* the CF_CFDP_R_SubstateDispatchTable_t is only used with file directive pdu */
+    /* the CF_CFDP_R_SubstateDispatchTable_t is only used with file directive PDU */
     if (ph->pdu_header.pdu_type == 0)
     {
         fdh = &ph->fdirective;
@@ -61,7 +61,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
         {
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_DC_INV, CFE_EVS_EventType_ERROR,
-                              "CF R%d(%lu:%lu): received pdu with invalid directive code %d for sub-state %d",
+                              "CF R%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                               (unsigned long)t->history->seq_num, fdh->directive_code, t->state_data.r.sub_state);
         }
@@ -120,7 +120,7 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
         {
             ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_DC_INV, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%lu:%lu): received pdu with invalid directive code %d for sub-state %d",
+                              "CF S%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,
                               (unsigned long)t->history->seq_num, fdh->directive_code, t->state_data.s.sub_state);
         }
@@ -128,7 +128,7 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_NON_FD_PDU, CFE_EVS_EventType_ERROR,
-                          "CF S%d(%lu:%lu): received non-file directive pdu", (t->state == CF_TxnState_S2),
+                          "CF S%d(%lu:%lu): received non-file directive PDU", (t->state == CF_TxnState_S2),
                           (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
     }
 

--- a/fsw/src/cf_cfdp_r.h
+++ b/fsw/src/cf_cfdp_r.h
@@ -43,7 +43,7 @@ typedef struct
 } CF_GapComputeArgs_t;
 
 /************************************************************************/
-/** @brief R1 receive pdu processing.
+/** @brief R1 receive PDU processing.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -54,7 +54,7 @@ typedef struct
 void CF_CFDP_R1_Recv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief R2 receive pdu processing.
+/** @brief R2 receive PDU processing.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -71,7 +71,7 @@ void CF_CFDP_R2_Recv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
  *       This function is called on every transaction by the engine on
  *       every CF wakeup. This is where flags are checked to send ACK,
  *       NAK, and FIN. It checks for inactivity timer and processes the
- *       ack timer. The ack timer is what triggers re-sends of PDUs
+ *       ACK timer. The ACK timer is what triggers re-sends of PDUs
  *       that require acknowledgment.
  *
  * @par Assumptions, External Events, and Notes:
@@ -196,7 +196,7 @@ CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph
 /** @brief Processing receive EOF common functionality for R1/R2.
  *
  * @par Description
- *       This function is used for both R1 and R2 eof receive. It calls
+ *       This function is used for both R1 and R2 EOF receive. It calls
  *       the unmarshaling function and then checks known transaction
  *       data against the PDU.
  *
@@ -216,7 +216,7 @@ CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer
 /** @brief Process receive EOF for R1.
  *
  * @par Description
- *       Only need to confirm crc for R1.
+ *       Only need to confirm CRC for R1.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL. ph must not be NULL.
@@ -265,7 +265,7 @@ void CF_CFDP_R1_SubstateRecvFileData(CF_Transaction_t *t, CF_Logical_PduBuffer_t
  *       since there may be gaps. Instead, insert file received range
  *       data into chunks. Once NAK has been received, this function
  *       always checks for completion. This function also re-arms
- *       the ack timer.
+ *       the ACK timer.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL. ph must not be NULL.
@@ -291,13 +291,13 @@ void CF_CFDP_R2_SubstateRecvFileData(CF_Transaction_t *t, CF_Logical_PduBuffer_t
 void CF_CFDP_R2_GapCompute(const CF_ChunkList_t *chunks, const CF_Chunk_t *c, void *opaque);
 
 /************************************************************************/
-/** @brief Send a NAK pdu for R2.
+/** @brief Send a NAK PDU for R2.
  *
  * @par Description
- *       NAK pdu is sent when there are gaps in the received data. The
- *       chunks class tracks this and generates the nak pdu by calculating
+ *       NAK PDU is sent when there are gaps in the received data. The
+ *       chunks class tracks this and generates the NAK PDU by calculating
  *       gaps internally and calling CF_CFDP_R2_GapCompute(). There is a special
- *       case where if a metadata pdu has not been received, then a nak
+ *       case where if a metadata PDU has not been received, then a NAK
  *       packet will be sent to request another.
  *
  * @par Assumptions, External Events, and Notes:
@@ -316,10 +316,10 @@ CFE_Status_t CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t);
  *       The configuration table has a number of bytes to calculate per
  *       transaction per wakeup. At each wakeup, the file is read and
  *       this number of bytes are calculated. This function will set
- *       the checksum error condition code if the final crc does not match.
+ *       the checksum error condition code if the final CRC does not match.
  *
  * @par PTFO
- *       Increase throughput by consuming all crc bytes per wakeup in
+ *       Increase throughput by consuming all CRC bytes per wakeup in
  *       transaction-order. This would require a change to the meaning
  *       of the value in the configuration table.
  *
@@ -333,7 +333,7 @@ CFE_Status_t CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t);
 CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Send a FIN pdu.
+/** @brief Send a FIN PDU.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -346,7 +346,7 @@ CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t);
 CFE_Status_t CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Process receive FIN-ACK pdu.
+/** @brief Process receive FIN-ACK PDU.
  *
  * @par Description
  *       This is the end of an R2 transaction. Simply reset the transaction
@@ -361,14 +361,14 @@ CFE_Status_t CF_CFDP_R2_SubstateSendFin(CF_Transaction_t *t);
 void CF_CFDP_R2_Recv_fin_ack(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief Process receive metadata pdu for R2.
+/** @brief Process receive metadata PDU for R2.
  *
  * @par Description
  *       It's possible that metadata PDU was missed in cf_cfdp.c, or that
  *       it was re-sent. This function checks if it was already processed,
  *       and if not, handles it. If there was a temp file opened due to
- *       missed metadata pdu, it will move the file to the correct
- *       destination according to the metadata pdu.
+ *       missed metadata PDU, it will move the file to the correct
+ *       destination according to the metadata PDU.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL. ph must not be NULL.

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -461,7 +461,7 @@ void CF_CFDP_S2_EarlyFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
     /* received early fin, so just cancel */
     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_EARLY_FIN, CFE_EVS_EventType_ERROR,
-                      "CF S%d(%lu:%lu): got early fin -- cancelling", (t->state == CF_TxnState_S2),
+                      "CF S%d(%lu:%lu): got early FIN -- cancelling", (t->state == CF_TxnState_S2),
                       (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
     CF_CFDP_SetTxnStatus(t, CF_TxnStatus_EARLY_FIN);
     CF_CFDP_S_Reset(t);
@@ -505,7 +505,7 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 
             if (sr->offset_start == 0 && sr->offset_end == 0)
             {
-                /* need to re-send metadata pdu */
+                /* need to re-send metadata PDU */
                 t->flags.tx.md_need_send = 1;
             }
             else
@@ -532,14 +532,14 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         if (bad_sr)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INVALID_SR, CFE_EVS_EventType_ERROR,
-                              "CF S%d(%lu:%lu): received %d invalid nak segment requests", (t->state == CF_TxnState_S2),
+                              "CF S%d(%lu:%lu): received %d invalid NAK segment requests", (t->state == CF_TxnState_S2),
                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, bad_sr);
         }
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_NAK, CFE_EVS_EventType_ERROR,
-                          "CF S%d(%lu:%lu): received invalid nak pdu", (t->state == CF_TxnState_S2),
+                          "CF S%d(%lu:%lu): received invalid NAK PDU", (t->state == CF_TxnState_S2),
                           (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
     }
@@ -567,7 +567,7 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
     if (!CF_CFDP_RecvAck(t, ph))
     {
-        /* don't send fin if error. Don't check the eof CC, just go with
+        /* don't send FIN if error. Don't check the EOF CC, just go with
          * the stored one we sent before */
         if (CF_TxnStatus_IsError(t->history->txn_stat))
         {
@@ -576,13 +576,13 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         else
         {
             t->state_data.s.sub_state    = CF_TxSubState_WAIT_FOR_FIN;
-            t->flags.com.ack_timer_armed = 0; /* just wait for fin now, nothing to re-send */
+            t->flags.com.ack_timer_armed = 0; /* just wait for FIN now, nothing to re-send */
         }
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_EOF, CFE_EVS_EventType_ERROR,
-                          "CF S%d(%lu:%lu): received invalid eof pdu", (t->state == CF_TxnState_S2),
+                          "CF S%d(%lu:%lu): received invalid EOF PDU", (t->state == CF_TxnState_S2),
                           (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
         ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
     }

--- a/fsw/src/cf_cfdp_s.h
+++ b/fsw/src/cf_cfdp_s.h
@@ -32,7 +32,7 @@
 #include "cf_cfdp_types.h"
 
 /************************************************************************/
-/** @brief S1 receive pdu processing.
+/** @brief S1 receive PDU processing.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -43,7 +43,7 @@
 void CF_CFDP_S1_Recv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief S2 receive pdu processing.
+/** @brief S2 receive PDU processing.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -102,7 +102,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont);
  *       t must not be NULL. cont must not be NULL.
  *
  * @param t  Pointer to the transaction object
- * @param cont Set to 1 if a nak was generated
+ * @param cont Set to 1 if a NAK was generated
  */
 void CF_CFDP_S_Tick_Nak(CF_Transaction_t *t, int *cont);
 
@@ -124,7 +124,7 @@ void CF_CFDP_S_Cancel(CF_Transaction_t *t);
  ************************************************************************/
 
 /************************************************************************/
-/** @brief Send an eof pdu.
+/** @brief Send an EOF PDU.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -138,7 +138,7 @@ void CF_CFDP_S_Cancel(CF_Transaction_t *t);
 CFE_Status_t CF_CFDP_S_SendEof(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Sends an eof for S1.
+/** @brief Sends an EOF for S1.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -158,12 +158,12 @@ void CF_CFDP_S1_SubstateSendEof(CF_Transaction_t *t);
 void CF_CFDP_S2_SubstateSendEof(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Helper function to populate the pdu with file data and send it.
+/** @brief Helper function to populate the PDU with file data and send it.
  *
  * @par Description
  *       This function checks the file offset cache and if the desired
  *       location is where the file offset is, it can skip a seek() call.
- *       The file is read into the filedata pdu and then the pdu is sent.
+ *       The file is read into the filedata PDU and then the PDU is sent.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL.
@@ -183,7 +183,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 by
 /** @brief Standard state function to send the next file data PDU for active transaction.
  *
  * @par Description
- *       During the transfer of active transaction file data pdus, the file
+ *       During the transfer of active transaction file data PDUs, the file
  *       offset is saved. This function sends the next chunk of data. If
  *       the file offset equals the file size, then transition to the EOF
  *       state.
@@ -196,10 +196,10 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 by
 void CF_CFDP_S_SubstateSendFileData(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief Respond to a nak by sending filedata pdus as response.
+/** @brief Respond to a NAK by sending filedata PDUs as response.
  *
  * @par Description
- *       Checks to see if a metadata pdu or filedata re-transmits must
+ *       Checks to see if a metadata PDU or filedata re-transmits must
  *       occur.
  *
  * @par Assumptions, External Events, and Notes:
@@ -252,7 +252,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t);
 void CF_CFDP_S_SubstateSendFinAck(CF_Transaction_t *t);
 
 /************************************************************************/
-/** @brief A fin was received before file complete, so abandon the transaction.
+/** @brief A FIN was received before file complete, so abandon the transaction.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL. ph must not be NULL.
@@ -274,7 +274,7 @@ void CF_CFDP_S2_EarlyFin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 void CF_CFDP_S2_Fin(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief S2 NAK pdu received handling.
+/** @brief S2 NAK PDU received handling.
  *
  * @par Description
  *       Stores the segment requests from the NAK packet in the chunks
@@ -301,11 +301,11 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 void CF_CFDP_S2_Nak_Arm(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief S2 received ack pdu in wait for EOF-ACK state.
+/** @brief S2 received ACK PDU in wait for EOF-ACK state.
  *
  * @par Description
  *       This function will trigger a state transition to CF_TxSubState_WAIT_FOR_FIN,
- *       which waits for a FIN pdu.
+ *       which waits for a FIN PDU.
  *
  * @par Assumptions, External Events, and Notes:
  *       t must not be NULL. ph must not be NULL.

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -192,12 +192,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
             break; /* no more messages */
         }
 
-        /* NOTE: this code originally stored current msg buffer in a global, but
-           going forward this should _NOT_ be used.  It is still set just in case
-           some code depends on it (mostly just UT at this point).  FSW should pass
-           the pointer to the current PDU to any function that needs it (ph here). */
-        CF_AppData.engine.in.msg = bufptr;
-        ph                       = &CF_AppData.engine.in.rx_pdudata;
+        ph = &CF_AppData.engine.in.rx_pdudata;
         CFE_ES_PerfLogEntry(CF_PERF_ID_PDURCVD(chan_num));
         CFE_MSG_GetSize(&bufptr->Msg, &msg_size);
         CFE_MSG_GetType(&bufptr->Msg, &msg_type);
@@ -221,7 +216,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
         }
         if (!CF_CFDP_RecvPh(chan_num, ph))
         {
-            /* got a valid pdu -- look it up by sequence number */
+            /* got a valid PDU -- look it up by sequence number */
             t = CF_FindTransactionBySequenceNumber(c, ph->pdu_header.sequence_num, ph->pdu_header.source_eid);
             if (t)
             {
@@ -285,7 +280,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
                         CF_Assert(t);
                         t->history->dir = CF_Direction_RX;
 
-                        /* set default fin status */
+                        /* set default FIN status */
                         t->state_data.r.r2.dc = CF_CFDP_FinDeliveryCode_INCOMPLETE;
                         t->state_data.r.r2.fs = CF_CFDP_FinFileStatus_DISCARDED;
 
@@ -305,5 +300,4 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
 
         CFE_ES_PerfLogExit(CF_PERF_ID_PDURCVD(chan_num));
     }
-    CF_AppData.engine.in.msg = NULL;
 }

--- a/fsw/src/cf_cfdp_sbintf.h
+++ b/fsw/src/cf_cfdp_sbintf.h
@@ -34,7 +34,7 @@
 /**
  * @brief PDU command encapsulation structure
  *
- * This encapsulates a CFDP pdu into a format that is sent or received over the
+ * This encapsulates a CFDP PDU into a format that is sent or received over the
  * software bus, adding "command" encapsulation (even though these are not really
  * commands).
  *
@@ -50,7 +50,7 @@ typedef struct CF_PduCmdMsg
 /**
  * @brief PDU send encapsulation structure
  *
- * This encapsulates a CFDP pdu into a format that is sent or received over the
+ * This encapsulates a CFDP PDU into a format that is sent or received over the
  * software bus, adding "telemetry" encapsulation (even though these are not really
  * telemetry items).
  *

--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -229,7 +229,7 @@ typedef struct CF_Poll
  */
 typedef struct CF_TxS2_Data
 {
-    uint8 fin_cc; /**< \brief remember the cc in the received fin pdu to echo in eof-fin */
+    uint8 fin_cc; /**< \brief remember the cc in the received FIN PDU to echo in eof-fin */
     uint8 acknak_count;
 } CF_TxS2_Data_t;
 
@@ -254,7 +254,7 @@ typedef struct CF_RxS2_Data
     uint32                    rx_crc_calc_bytes;
     CF_CFDP_FinDeliveryCode_t dc;
     CF_CFDP_FinFileStatus_t   fs;
-    uint8                     eof_cc; /**< \brief remember the cc in the received eof pdu to echo in eof-ack */
+    uint8                     eof_cc; /**< \brief remember the cc in the received EOF PDU to echo in eof-ack */
     uint8                     acknak_count;
 } CF_RxS2_Data_t;
 
@@ -295,7 +295,7 @@ typedef struct CF_Flags_Rx
     bool send_ack;
     bool inactivity_fired; /**< \brief used for r2 */
     bool complete;         /**< \brief r2 */
-    bool fd_nak_sent;      /**< \brief latches that at least one nak has been sent for file data */
+    bool fd_nak_sent;      /**< \brief latches that at least one NAK has been sent for file data */
 } CF_Flags_Rx_t;
 
 /**

--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -459,7 +459,7 @@ void CF_CmdPurgeQueue(CFE_SB_Buffer_t *msg);
 void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg);
 
 /************************************************************************/
-/** @brief Checks if the value is less than or equal to the max pdu size.
+/** @brief Checks if the value is less than or equal to the max PDU size.
  *
  * @par Assumptions, External Events, and Notes:
  *       None

--- a/fsw/src/cf_codec.h
+++ b/fsw/src/cf_codec.h
@@ -54,7 +54,7 @@ typedef struct CF_EncoderState
 } CF_EncoderState_t;
 
 /**
- * @brief Current state of an decode operation
+ * @brief Current state of a decode operation
  *
  * State structure for decodes
  */

--- a/fsw/src/cf_crc.h
+++ b/fsw/src/cf_crc.h
@@ -49,7 +49,7 @@ typedef struct CF_Crc
 void CF_CRC_Start(CF_Crc_t *c);
 
 /************************************************************************/
-/** @brief Digest a chunk for crc calculation.
+/** @brief Digest a chunk for CRC calculation.
  *
  * @par Description
  *       Does the CRC calculation, and stores an index into the given
@@ -66,7 +66,7 @@ void CF_CRC_Start(CF_Crc_t *c);
 void CF_CRC_Digest(CF_Crc_t *c, const uint8 *data, int len);
 
 /************************************************************************/
-/** @brief Finalize a crc calculation.
+/** @brief Finalize a CRC calculation.
  *
  * @par Description
  *       Checks the index and if it isn't 0, does the final calculations

--- a/fsw/src/cf_logical_pdu.h
+++ b/fsw/src/cf_logical_pdu.h
@@ -251,7 +251,7 @@ typedef struct CF_Logical_PduFin
  */
 typedef struct CF_Logical_PduAck
 {
-    uint8                   ack_directive_code; /**< \brief directive code of the PDU being ack'ed */
+    uint8                   ack_directive_code; /**< \brief directive code of the PDU being ACK'ed */
     uint8                   ack_subtype_code;   /**< \brief depends on ack_directive_code  */
     CF_CFDP_ConditionCode_t cc;
     CF_CFDP_AckTxnStatus_t  txn_status;

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -512,7 +512,7 @@ CF_TxnStatus_t CF_TxnStatus_From_ConditionCode(CF_CFDP_ConditionCode_t cc);
  * @param txn_stat   Transaction status
  *
  * @returns Boolean value indicating if the transaction is in an errorred state
- * @retval true if the an error has occurred during the transaction
+ * @retval true if an error has occurred during the transaction
  * @retval false if no error has occurred during the transaction yet
  */
 bool CF_TxnStatus_IsError(CF_TxnStatus_t txn_stat);

--- a/fsw/tables/cf_def_config.c
+++ b/fsw/tables/cf_def_config.c
@@ -27,18 +27,18 @@
 
 CF_ConfigTable_t CF_config_table = {
     10,    /* ticks_per_second */
-    16384, /* max number of bytes per wakeup to calculate r2 recv file crc */
+    16384, /* max number of bytes per wakeup to calculate r2 recv file CRC */
     25,    /* local entity id */
     {      /* channel configuration for CF_NUM_CHANNELS */
      {
          /* channel 0 */
          5,      /* max number of outgoing messages per wakeup */
          5,      /* max number of rx messages per wakeup */
-         3,      /* ack timer */
-         3,      /* nak timer */
+         3,      /* ACK timer */
+         3,      /* NAK timer */
          30,     /* inactivity timer */
-         4,      /* ack limit */
-         4,      /* nak limit */
+         4,      /* ACK limit */
+         4,      /* NAK limit */
          0x18c8, /* input message id */
          0x08c2, /* output message id */
          16,     /* input pipe depth */

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -458,7 +458,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
      */
     CF_Transaction_t *t;
 
-    /* crc mismatch, class 1 */
+    /* CRC mismatch, class 1 */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, NULL);
     t->state      = CF_TxnState_R1;
     t->crc.result = 0xdeadbeef;
@@ -466,7 +466,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.crc_mismatch, 1);
 
-    /* crc mismatch, class 2 */
+    /* CRC mismatch, class 2 */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, NULL);
     t->state      = CF_TxnState_R2;
     t->crc.result = 0xdeadbeef;
@@ -474,7 +474,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.crc_mismatch, 2);
 
-    /* crc match */
+    /* CRC match */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, NULL);
     t->crc.result = 0xc0ffee;
     UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(t, 0xc0ffee), 0);
@@ -499,7 +499,7 @@ void Test_CF_CFDP_R2_Complete(void)
     UT_SetDeferredRetcode(UT_KEY(CF_TxnStatus_IsError), 1, true);
     UtAssert_VOIDCALL(CF_CFDP_R2_Complete(t, 0));
 
-    /* nominal, send nak */
+    /* nominal, send NAK */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, &config);
     config->chan[t->chan_num].nak_limit = 2;
     UtAssert_VOIDCALL(CF_CFDP_R2_Complete(t, 1));
@@ -528,7 +528,7 @@ void Test_CF_CFDP_R2_Complete(void)
     UtAssert_BOOL_TRUE(t->flags.rx.send_fin);
     UtAssert_BOOL_TRUE(t->flags.rx.complete);
 
-    /* with gaps, this should send nak */
+    /* with gaps, this should send NAK */
     UT_SetDeferredRetcode(UT_KEY(CF_ChunkList_ComputeGaps), 1, 1);
     UtAssert_VOIDCALL(CF_CFDP_R2_Complete(t, 1));
     UtAssert_BOOL_TRUE(t->flags.rx.send_nak);
@@ -992,7 +992,7 @@ void Test_CF_CFDP_R2_SubstateSendFin(void)
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
     UtAssert_INT32_EQ(CF_CFDP_R2_SubstateSendFin(t), 0);
 
-    /* crc failure - can get this by having rx_crc_calc_bytes_per_wakeup less than fsize */
+    /* CRC failure - can get this by having rx_crc_calc_bytes_per_wakeup less than fsize */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
     t->fsize = 100;
     UtAssert_INT32_EQ(CF_CFDP_R2_SubstateSendFin(t), -1);
@@ -1007,7 +1007,7 @@ void Test_CF_CFDP_R2_SubstateSendFin(void)
     UT_SetDeferredRetcode(UT_KEY(CF_TxnStatus_IsError), 1, true);
     UtAssert_INT32_EQ(CF_CFDP_R2_SubstateSendFin(t), 0);
 
-    /* already calculated crc */
+    /* already calculated CRC */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
     t->flags.com.crc_calc = true;
     UtAssert_INT32_EQ(CF_CFDP_R2_SubstateSendFin(t), 0);
@@ -1056,14 +1056,14 @@ void Test_CF_CFDP_R2_RecvMd(void)
     t->flags.rx.md_recv = true;
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
 
-    /* eof already received, file size match */
+    /* EOF already received, file size match */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     t->fsize                    = 100;
     t->state_data.r.r2.eof_size = 100;
     t->flags.rx.eof_recv        = true;
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
 
-    /* eof already received, file size different */
+    /* EOF already received, file size different */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     t->fsize                    = 100;
     t->state_data.r.r2.eof_size = 120;

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -432,7 +432,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), 0);
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
-    /* nominal, smaller than chunk, no crc */
+    /* nominal, smaller than chunk, no CRC */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
     config->outgoing_file_chunk_size = 150;
     t->fsize                         = 300;
@@ -441,7 +441,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     cumulative_read += read_size;
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
-    /* nominal, larger than PDU, no crc */
+    /* nominal, larger than PDU, no CRC */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
     config->outgoing_file_chunk_size = CF_MAX_PDU_SIZE * 2;
     t->fsize                         = CF_MAX_PDU_SIZE * 2;
@@ -452,7 +452,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
     UtAssert_STUB_COUNT(CF_CRC_Digest, 0);
 
-    /* nominal, larger than chunk, with crc */
+    /* nominal, larger than chunk, with CRC */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
     config->outgoing_file_chunk_size = 50;
     read_size                        = 100;

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -341,11 +341,11 @@ void Test_CF_CFDP_RecvFd(void)
     CF_Transaction_t *      t;
     CF_Logical_PduBuffer_t *ph;
 
-    /* nominal call, no crc */
+    /* nominal call, no CRC */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     UtAssert_INT32_EQ(CF_CFDP_RecvFd(t, ph), 0);
 
-    /* nominal call, with crc */
+    /* nominal call, with CRC */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     ph->pdu_header.crc_flag    = 1;
     ph->int_header.fd.data_len = 10 + sizeof(CF_CFDP_uint32_t);
@@ -359,7 +359,7 @@ void Test_CF_CFDP_RecvFd(void)
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_PROTOCOL_ERROR);
     UT_CF_AssertEventID(CF_EID_ERR_PDU_FD_SHORT);
 
-    /* decode errors: crc part */
+    /* decode errors: CRC part */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     ph->pdu_header.crc_flag    = 1;
     ph->int_header.fd.data_len = sizeof(CF_CFDP_uint32_t) - 1;

--- a/unit-test/stubs/cf_cfdp_handlers.c
+++ b/unit-test/stubs/cf_cfdp_handlers.c
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *  @brief Stubs file for the CF Application main cfdp engine and pdu parsing file
+ *  @brief Stubs file for the CF Application main CFDP engine and PDU parsing file
  *
  *  This file contains two sets of functions. The first is what is needed
  *  to deal with CFDP PDUs. Specifically validating them for correctness

--- a/unit-test/stubs/cf_cfdp_sbintf_handlers.c
+++ b/unit-test/stubs/cf_cfdp_sbintf_handlers.c
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *  @brief Stubs file for the CF Application main cfdp engine and pdu parsing file
+ *  @brief Stubs file for the CF Application main CFDP engine and PDU parsing file
  *
  *  This file contains two sets of functions. The first is what is needed
  *  to deal with CFDP PDUs. Specifically validating them for correctness

--- a/unit-test/stubs/cf_chunk_handlers.c
+++ b/unit-test/stubs/cf_chunk_handlers.c
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *  @brief Stubs file for the CF Application main cfdp engine and pdu parsing file
+ *  @brief Stubs file for the CF Application main CFDP engine and PDU parsing file
  *
  *  This file contains two sets of functions. The first is what is needed
  *  to deal with CFDP PDUs. Specifically validating them for correctness

--- a/unit-test/utilities/cf_test_alt_handler.c
+++ b/unit-test/utilities/cf_test_alt_handler.c
@@ -133,7 +133,7 @@ void UT_AltHandler_CF_CList_Traverse_R_PRIO(void *UserObj, UT_EntryKey_t FuncKey
 /*----------------------------------------------------------------
  *
  * A handler for CF_TraverseAllTransactions which _sets_ the opaque context
- * pointer as a int* object.  The value is taken from the UserObj opaque pointer.
+ * pointer as an int* object.  The value is taken from the UserObj opaque pointer.
  *
  *-----------------------------------------------------------------*/
 void UT_AltHandler_CF_TraverseAllTransactions_All_Channels_Set_Context(void *UserObj, UT_EntryKey_t FuncKey,


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #139 
Removed the only remaining use of the global data structure to store the message buffer. No longer required and all tests passing without need for it.
Some typos and capitalizations of acronyms added along with this PR.
Code changes are in `cf_cfdp_sbintf.c`. The rest are typos/comments amendments.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt