### PR TITLE
Fix #373, Optionally move files when complete

### DIFF
--- a/fsw/inc/cf_tbldefs.h
+++ b/fsw/inc/cf_tbldefs.h
@@ -73,6 +73,7 @@ typedef struct CF_ChannelConfig
 
     char  sem_name[OS_MAX_API_NAME]; /**< \brief name of throttling semaphore in TO */
     uint8 dequeue_enabled;           /**< \brief if 1, then the channel will make pending transactions active */
+    char  move_dir[OS_MAX_PATH_LEN]; /**< \brief Move directory if not empty */
 } CF_ChannelConfig_t;
 
 /**

--- a/fsw/tables/cf_def_config.c
+++ b/fsw/tables/cf_def_config.c
@@ -56,28 +56,28 @@ CF_ConfigTable_t CF_config_table = {
           {
               0 /* zero fill unused polling directory slots */
           }},
-         "", /* throttle sem, empty string means no throttle */
-         1,  /* dequeue enable flag (1 = enabled) */
+         "",            /* throttle sem, empty string means no throttle */
+         1,             /* dequeue enable flag (1 = enabled) */
+         .move_dir = "" /* If not empty, will attempt move instead of delete on TX file complete */
      },
-     {
-         /* channel 1 */
-         5,      /* max number of outgoing messages per wakeup */
-         5,      /* max number of rx messages per wakeup */
-         3,      /* ack timer */
-         3,      /* nak timer */
-         30,     /* inactivity timer */
-         4,      /* ack limit */
-         4,      /* nak limit */
-         0x18c9, /* input message id */
-         0x08c3, /* output message id */
-         16,     /* input pipe depth */
-         {       /* polling directory configuration for CF_MAX_POOLING_DIR_PER_CHAN */
-          {
-              0 /* zero fill unused polling directory slots */
-          }},
-         "", /* throttle sem, empty string means no throttle */
-         1   /* dequeue enable flag (1 = enabled) */
-     }},
+     {        /* channel 1 */
+      5,      /* max number of outgoing messages per wakeup */
+      5,      /* max number of rx messages per wakeup */
+      3,      /* ack timer */
+      3,      /* nak timer */
+      30,     /* inactivity timer */
+      4,      /* ack limit */
+      4,      /* nak limit */
+      0x18c9, /* input message id */
+      0x08c3, /* output message id */
+      16,     /* input pipe depth */
+      {       /* polling directory configuration for CF_MAX_POOLING_DIR_PER_CHAN */
+       {
+           0 /* zero fill unused polling directory slots */
+       }},
+      "", /* throttle sem, empty string means no throttle */
+      1,  /* dequeue enable flag (1 = enabled) */
+      .move_dir = ""}},
     480,       /* outgoing_file_chunk_size */
     "/cf/tmp", /* temporary file directory */
 };


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Most trivial implementation I could think of.  Just adds entry to the table, if it's filled in moves the file instead of delete, falls back to a delete if the mv fails.  This moves on every TX complete for all styles... good enough for our required use-case but may not work for everyone.  If the use case is to support either move or delete, you can set up two channels (one w/ the move dir defined).
- Fix #373

**Testing performed**
Tested use case in project code.  CI (updated unit tests)

**Expected behavior changes**
If move_dir is filled it, attempts to move instead of remove (remove is performed if move fails).

**System(s) tested on**
Ubuntu 20.04

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC