### PR TITLE
Fix #57, Remove local error return codes in CF_ValidateConfigTable()

### DIFF
--- a/fsw/inc/cf_tbldefs.h
+++ b/fsw/inc/cf_tbldefs.h
@@ -90,8 +90,9 @@ typedef struct CF_ConfigTable
 
     CF_ChannelConfig_t chan[CF_NUM_CHANNELS]; /**< \brief Channel configuration */
 
-    uint16 outgoing_file_chunk_size;      /**< maximum size of outgoing file data PDUs */
-    char   tmp_dir[CF_FILENAME_MAX_PATH]; /**< directory to put temp files */
+    uint16 outgoing_file_chunk_size;    /**< maximum size of outgoing file data PDUs - must be
+                                         *   smaller than file data character array */
+    char tmp_dir[CF_FILENAME_MAX_PATH]; /**< directory to put temp files */
 } CF_ConfigTable_t;
 
 #endif /* !CF_TBLDEFS_H */

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -111,28 +111,22 @@ void CF_CheckTables(void)
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_ValidateConfigTable(void *tbl_ptr)
 {
-    CF_ConfigTable_t * tbl = (CF_ConfigTable_t *)tbl_ptr;
-    CFE_Status_t       ret; /* initialized below */
-    static const int32 no_ticks_per_second = -1;
-    static const int32 crc_alignment       = -2;
-    static const int32 outgoing_chunk_size = -3;
+    CF_ConfigTable_t *tbl = (CF_ConfigTable_t *)tbl_ptr;
+    CFE_Status_t      ret = CFE_STATUS_VALIDATION_FAILURE;
 
     if (!tbl->ticks_per_second)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_INIT_TPS, CFE_EVS_EventType_ERROR, "CF: config table has zero ticks per second");
-        ret = no_ticks_per_second;
     }
     else if (!tbl->rx_crc_calc_bytes_per_wakeup || (tbl->rx_crc_calc_bytes_per_wakeup & 0x3ff))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_INIT_CRC_ALIGN, CFE_EVS_EventType_ERROR,
                           "CF: config table has rx CRC size not aligned with 1024");
-        ret = crc_alignment; /* must be 1024-byte aligned */
     }
     else if (tbl->outgoing_file_chunk_size > sizeof(CF_CFDP_PduFileDataContent_t))
     {
         CFE_EVS_SendEvent(CF_EID_ERR_INIT_OUTGOING_SIZE, CFE_EVS_EventType_ERROR,
                           "CF: config table has outgoing file chunk size too large");
-        ret = outgoing_chunk_size; /* must be smaller than file data character array */
     }
     else
     {

--- a/fsw/src/cf_app.h
+++ b/fsw/src/cf_app.h
@@ -139,7 +139,7 @@ void CF_CheckTables(void);
  *
  *
  * @retval #CFE_SUCCESS \copydoc CFE_SUCCESS
- * @retval Returns anything else on error.
+ * @retval CFE_STATUS_VALIDATION_FAILURE if the config table fails one of the validation checks
  *
  */
 CFE_Status_t CF_ValidateConfigTable(void *tbl_ptr);

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -201,7 +201,7 @@ void Test_CF_ValidateConfigTable_FailBecauseTableTicksPerSecondIs0(void)
     result = CF_ValidateConfigTable(arg_table);
 
     /* Assert */
-    UtAssert_INT32_EQ(result, -1);
+    UtAssert_INT32_EQ(result, CFE_STATUS_VALIDATION_FAILURE);
 }
 
 void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIs0(void)
@@ -217,7 +217,7 @@ void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIs0(void)
     result = CF_ValidateConfigTable(arg_table);
 
     /* Assert */
-    UtAssert_INT32_EQ(result, -2);
+    UtAssert_INT32_EQ(result, CFE_STATUS_VALIDATION_FAILURE);
 }
 
 void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIsNot1024ByteAligned(void)
@@ -236,7 +236,7 @@ void Test_CF_ValidateConfigTable_FailBecauseCalcBytesPerWakeupIsNot1024ByteAlign
     result = CF_ValidateConfigTable(arg_table);
 
     /* Assert */
-    UtAssert_INT32_EQ(result, -2);
+    UtAssert_INT32_EQ(result, CFE_STATUS_VALIDATION_FAILURE);
 }
 
 void Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArray(void)
@@ -254,7 +254,7 @@ void Test_CF_ValidateConfigTable_FailBecauseOutgoingFileChunkSmallerThanDataArra
     result = CF_ValidateConfigTable(arg_table);
 
     /* Assert */
-    UtAssert_INT32_EQ(result, -3);
+    UtAssert_INT32_EQ(result, CFE_STATUS_VALIDATION_FAILURE);
 }
 
 void Test_CF_ValidateConfigTable_Success(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #57
  - Removed the local error return codes and replaced with one of the new CFE macros indicating validation failure.

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
`CF_ValidateConfigTable()` will now return a relevant error code that is intelligible to outside functions, if they want to take action on it.
The function is noticeably simpler/cleaner now.

**Contributor Info**
Avi Weiss @thnkslprpt