### PR TITLE
Fix #377, Remove error event on nominal semaphore timeout

### DIFF
--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -107,7 +107,7 @@ CF_Logical_PduBuffer_t *CF_CFDP_MsgOutGet(const CF_Transaction_t *t, bool silent
         if (!CF_AppData.engine.out.msg)
         {
             c->cur = t; /* remember where we were for next time */
-            if (!silent)
+            if (!silent && (os_status == OS_SUCCESS))
             {
                 CFE_EVS_SendEvent(CF_EID_ERR_CFDP_NO_MSG, CFE_EVS_EventType_ERROR,
                                   "CF: no output message buffer available");

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -372,18 +372,18 @@ void Test_CF_CFDP_MsgOutGet(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, &c, NULL, &t, NULL);
     c->sem_id = OS_ObjectIdFromInteger(123);
     UtAssert_NOT_NULL(CF_CFDP_MsgOutGet(t, false));
-    UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTimedWait), OS_ERROR_TIMEOUT);
+    UT_SetDeferredRetcode(UT_KEY(OS_CountSemTimedWait), 1, OS_ERROR_TIMEOUT);
     UtAssert_NULL(CF_CFDP_MsgOutGet(t, false));
-    UT_CF_AssertEventID(CF_EID_ERR_CFDP_NO_MSG);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
     /* transaction is suspended */
-    UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
+    UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
     t->flags.com.suspended = 1;
     UtAssert_NULL(CF_CFDP_MsgOutGet(t, false));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
     /* channel is frozen */
-    UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
+    UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
     CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
     UtAssert_NULL(CF_CFDP_MsgOutGet(t, false));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -394,7 +394,7 @@ void Test_CF_CFDP_MsgOutGet(void)
     UtAssert_NULL(CF_CFDP_MsgOutGet(t, false));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_NO_MSG);
 
-    /* same, but the silent flag should supress the event */
+    /* same, but the silent flag should suppress the event */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
     UtAssert_NULL(CF_CFDP_MsgOutGet(t, true));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #377 

**Testing performed**
Updated unit tests and functionally in prototype code

**Expected behavior changes**
No error event for nominal semaphore timeout (flow control)

**System(s) tested on**
Ubuntu 20.04

**Additional context**
- Added #378

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC