### PR TITLE
Fix #380, Support polling with no delay

### DIFF
--- a/fsw/inc/cf_tbldefs.h
+++ b/fsw/inc/cf_tbldefs.h
@@ -33,11 +33,7 @@
  */
 typedef struct CF_PollDir
 {
-    uint32 interval_sec; /**<
-                          * \brief number of seconds to wait before trying a new directory.
-                          *
-                          * Must be >0 or slot is inactive.
-                          */
+    uint32 interval_sec; /**< \brief number of seconds to wait before trying a new directory */
 
     uint8           priority;   /**< \brief priority to use when placing transactions on the pending queue */
     CF_CFDP_Class_t cfdp_class; /**< \brief the CFDP class to send */

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -1510,12 +1510,11 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c)
         pd          = &cc->polldir[i];
         count_check = 0;
 
-        if (pd->enabled && pd->interval_sec)
+        if (pd->enabled)
         {
-            /* only handle polling for polldirs configured with a non-zero interval */
             if (!p->pb.busy && !p->pb.num_ts)
             {
-                if (!p->timer_set)
+                if (!p->timer_set && pd->interval_sec)
                 {
                     /* timer was not set, so set it now */
                     CF_Timer_InitRelSec(&p->interval_timer, pd->interval_sec);
@@ -1539,7 +1538,9 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c)
                     }
                 }
                 else
+                {
                     CF_Timer_Tick(&p->interval_timer);
+                }
             }
             else
             {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #380 

**Testing performed**
CI and custom distro with zero delay, confirmed faster than 1 second polling

**Expected behavior changes**
Supports polling with zero timeout

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Project request

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC