### PR TITLE
Fix #390, Update size variables to `size_t` and `CF_ChunkSize_t` typedefs

### DIFF
--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -946,7 +946,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num /* ignored */)
+CF_ChanAction_Status_t CF_CmdValidateChunkSize(CF_ChunkSize_t val, uint8 chan_num /* ignored */)
 {
     CF_ChanAction_Status_t ret = CF_ChanAction_Status_SUCCESS;
     if (val > sizeof(CF_CFDP_PduFileDataContent_t))
@@ -989,7 +989,7 @@ void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
     struct
     {
         void * ptr;
-        uint32 size;
+        size_t size;
         CF_ChanAction_Status_t (*fn)(uint32, uint8 chan_num);
     } item;
 

--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -524,7 +524,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg);
  * @retval CF_ChanAction_Status_ERROR if failed (val is greater than max PDU)
  *
  */
-CF_ChanAction_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num);
+CF_ChanAction_Status_t CF_CmdValidateChunkSize(CF_ChunkSize_t val, uint8 chan_num);
 
 /************************************************************************/
 /** @brief Checks if the value is within allowable range as outgoing packets per wakeup

--- a/fsw/src/cf_crc.c
+++ b/fsw/src/cf_crc.c
@@ -50,9 +50,9 @@ void CF_CRC_Start(CF_Crc_t *crc)
  * See description in cf_crc.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CF_CRC_Digest(CF_Crc_t *crc, const uint8 *data, int len)
+void CF_CRC_Digest(CF_Crc_t *crc, const uint8 *data, size_t len)
 {
-    int i = 0;
+    size_t i = 0;
 
     for (; i < len; ++i)
     {

--- a/fsw/src/cf_crc.h
+++ b/fsw/src/cf_crc.h
@@ -63,7 +63,7 @@ void CF_CRC_Start(CF_Crc_t *crc);
  * @param len  Length of data to digest
  *
  */
-void CF_CRC_Digest(CF_Crc_t *crc, const uint8 *data, int len);
+void CF_CRC_Digest(CF_Crc_t *crc, const uint8 *data, size_t len);
 
 /************************************************************************/
 /** @brief Finalize a CRC calculation.

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -175,7 +175,7 @@ CFE_Status_t CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *histor
 
     int          i;
     CFE_Status_t ret;
-    int32        len;
+    size_t       len;
     char         linebuf[(CF_FILENAME_MAX_LEN * 2) + 128]; /* buffer for line data */
 
     for (i = 0; i < 3; ++i)

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -3304,7 +3304,7 @@ void Test_CF_CmdValidateChunkSize_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(
 {
     /* Arrange */
     uint8                  arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
-    uint32                 arg_val      = sizeof(CF_CFDP_PduFileDataContent_t) + 1;
+    size_t                 arg_val      = sizeof(CF_CFDP_PduFileDataContent_t) + 1;
     CF_ChanAction_Status_t local_result;
 
     /* Act */
@@ -3332,7 +3332,7 @@ void Test_CF_CmdValidateChunkSize_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0(vo
 {
     /* Arrange */
     uint8                  arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
-    uint32                 arg_val      = sizeof(CF_CFDP_PduFileDataContent_t);
+    size_t                 arg_val      = sizeof(CF_CFDP_PduFileDataContent_t);
     CF_ChanAction_Status_t local_result;
 
     /* Act */

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -89,11 +89,11 @@ void CF_CmdCancel_Txn(CF_Transaction_t *txn, void *ignored)
  * Generated stub function for CF_CmdValidateChunkSize()
  * ----------------------------------------------------
  */
-CF_ChanAction_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num)
+CF_ChanAction_Status_t CF_CmdValidateChunkSize(CF_ChunkSize_t val, uint8 chan_num)
 {
     UT_GenStub_SetupReturnBuffer(CF_CmdValidateChunkSize, CF_ChanAction_Status_t);
 
-    UT_GenStub_AddParam(CF_CmdValidateChunkSize, uint32, val);
+    UT_GenStub_AddParam(CF_CmdValidateChunkSize, CF_ChunkSize_t, val);
     UT_GenStub_AddParam(CF_CmdValidateChunkSize, uint8, chan_num);
 
     UT_GenStub_Execute(CF_CmdValidateChunkSize, Basic, NULL);

--- a/unit-test/stubs/cf_crc_stubs.c
+++ b/unit-test/stubs/cf_crc_stubs.c
@@ -31,11 +31,11 @@
  * Generated stub function for CF_CRC_Digest()
  * ----------------------------------------------------
  */
-void CF_CRC_Digest(CF_Crc_t *crc, const uint8 *data, int len)
+void CF_CRC_Digest(CF_Crc_t *crc, const uint8 *data, size_t len)
 {
     UT_GenStub_AddParam(CF_CRC_Digest, CF_Crc_t *, crc);
     UT_GenStub_AddParam(CF_CRC_Digest, const uint8 *, data);
-    UT_GenStub_AddParam(CF_CRC_Digest, int, len);
+    UT_GenStub_AddParam(CF_CRC_Digest, size_t, len);
 
     UT_GenStub_Execute(CF_CRC_Digest, Basic, NULL);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #390
  - Updates a few identifiable variables/parameters representing size to the more expressive typedefs

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt