### PR TITLE
Fix #288, Remove unnecessary CF_UnionArgs_Payload_t union

### DIFF
--- a/fsw/inc/cf_msg.h
+++ b/fsw/inc/cf_msg.h
@@ -871,16 +871,6 @@ typedef struct CF_NoArgsCmd
 } CF_NoArgsCmd_t;
 
 /**
- * \brief Command payload argument union to support 4 uint8's, 2 uint16's or 1 uint32
- */
-typedef union CF_UnionArgs_Payload
-{
-    uint32 dword;    /**< \brief Generic uint32 argument */
-    uint16 hword[2]; /**< \brief Generic uint16 array of arguments */
-    uint8  byte[4];  /**< \brief Generic uint8 array of arguments */
-} CF_UnionArgs_Payload_t;
-
-/**
  * \brief Generic command structure with arguments supports common handling on multiple command types
  *
  * For command details see #CF_RESET_CC, #CF_FREEZE_CC, #CF_THAW_CC, #CF_ENABLE_DEQUEUE_CC,
@@ -889,7 +879,7 @@ typedef union CF_UnionArgs_Payload
 typedef struct
 {
     CFE_MSG_CommandHeader_t cmd_header; /**< \brief Command header */
-    CF_UnionArgs_Payload_t  data;       /**< \brief Generic command arguments */
+    uint8                   byte[4];    /**< \brief Generic uint8 array of arguments */
 } CF_UnionArgsCmd_t;
 
 /**

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -62,7 +62,7 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
     CF_UnionArgsCmd_t *cmd      = (CF_UnionArgsCmd_t *)msg;
     static const char *names[5] = {"all", "cmd", "fault", "up", "down"};
     /* 0=all, 1=cmd, 2=fault 3=up 4=down */
-    uint8 param = cmd->data.byte[0];
+    uint8 param = cmd->byte[0];
     int   i;
     int   acc = 1;
 
@@ -220,22 +220,22 @@ CFE_Status_t CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_Chan
     /* this function is generic for any ground command that takes a single channel
      * argument which must be less than CF_NUM_CHANNELS or 255 which is a special
      * value that means apply command to all channels */
-    if (cmd->data.byte[0] == CF_ALL_CHANNELS)
+    if (cmd->byte[0] == CF_ALL_CHANNELS)
     {
         /* apply to all channels */
         for (i = 0; i < CF_NUM_CHANNELS; ++i)
             ret |= fn(i, context);
     }
-    else if (cmd->data.byte[0] < CF_NUM_CHANNELS)
+    else if (cmd->byte[0] < CF_NUM_CHANNELS)
     {
-        ret = fn(cmd->data.byte[0], context);
+        ret = fn(cmd->byte[0], context);
     }
     else
     {
         /* bad parameter */
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_CHAN_PARAM, CFE_EVS_EventType_ERROR,
-                          "CF: %s: channel parameter out of range. received %d", errstr, cmd->data.byte[0]);
-        ret = -1;
+                          "CF: %s: channel parameter out of range. received %d", errstr, cmd->byte[0]);
+        ret = CF_ERROR;
     }
 
     return ret;
@@ -591,20 +591,20 @@ CFE_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolM
     int          i;
     CFE_Status_t ret = CFE_SUCCESS;
     /* no need to bounds check chan_num, done in caller */
-    if (context->msg->data.byte[1] == CF_ALL_POLLDIRS)
+    if (context->msg->byte[1] == CF_ALL_POLLDIRS)
     {
         /* all polldirs in channel */
         for (i = 0; i < CF_MAX_POLLING_DIR_PER_CHAN; ++i)
             CF_AppData.config_table->chan[chan_num].polldir[i].enabled = context->barg;
     }
-    else if (context->msg->data.byte[1] < CF_MAX_POLLING_DIR_PER_CHAN)
+    else if (context->msg->byte[1] < CF_MAX_POLLING_DIR_PER_CHAN)
     {
-        CF_AppData.config_table->chan[chan_num].polldir[context->msg->data.byte[1]].enabled = context->barg;
+        CF_AppData.config_table->chan[chan_num].polldir[context->msg->byte[1]].enabled = context->barg;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_POLLDIR_INVALID, CFE_EVS_EventType_ERROR,
-                          "CF: enable/disable polldir: invalid polldir %d on channel %d", context->msg->data.byte[1],
+                          "CF: enable/disable polldir: invalid polldir %d on channel %d", context->msg->byte[1],
                           chan_num);
         ret = CF_ERROR;
     }
@@ -703,7 +703,7 @@ CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
     int pend = 0;
     int hist = 0;
 
-    switch (cmd->data.byte[1])
+    switch (cmd->byte[1])
     {
         case 0: /* pend */
             pend = 1;
@@ -720,8 +720,8 @@ CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
 
         default:
             CFE_EVS_SendEvent(CF_EID_ERR_CMD_PURGE_ARG, CFE_EVS_EventType_ERROR, "CF: purge queue invalid arg %d",
-                              cmd->data.byte[1]);
-            ret = -1;
+                              cmd->byte[1]);
+            ret = CF_ERROR;
             break;
     }
 

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -175,9 +175,9 @@ void Test_CF_CmdNoop_SendNoopEventAndAcceptCommand(void)
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg = NULL;
 
-    uint16 initial_hk_cmd_counter = Any_uint16();
+    uint8 initial_hk_cmd_counter = Any_uint8();
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdNoop(arg_msg);
@@ -186,7 +186,7 @@ void Test_CF_CmdNoop_SendNoopEventAndAcceptCommand(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 /*******************************************************************************
@@ -201,13 +201,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    msg->data.byte[0] = 5; /* 5 is size of 'names' */
+    msg->byte[0] = 5; /* 5 is size of 'names' */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -216,7 +216,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCommand(void)
@@ -225,13 +225,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    msg->data.byte[0] = Any_uint8_GreaterThan(5); /* 5 is size of 'names' */
+    msg->byte[0] = Any_uint8_GreaterThan(5); /* 5 is size of 'names' */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -240,7 +240,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSendEvent(void)
@@ -252,9 +252,10 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    msg->data.byte[0] = CF_Reset_command;
-    CF_AppData.hk.counters.cmd = Any_uint16_Except(0);
-    CF_AppData.hk.counters.err = Any_uint16_Except(0);
+    msg->byte[0] = CF_Reset_command;
+
+    CF_AppData.HkPacket.CommandCounter      = Any_uint16_Except(0);
+    CF_AppData.HkPacket.CommandErrorCounter = Any_uint16_Except(0);
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -262,8 +263,8 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
-    UtAssert_ZERO(CF_AppData.hk.counters.cmd);
-    UtAssert_ZERO(CF_AppData.hk.counters.err);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandCounter);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandErrorCounter);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEventAndAcceptCommand(void)
@@ -273,29 +274,29 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     int                       i                      = 0;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    msg->data.byte[0] = CF_Reset_fault;
+    msg->byte[0] = CF_Reset_fault;
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
     }
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -306,24 +307,24 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_open);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_read);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_seek);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_write);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_rename);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.directory_read);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.nak_limit);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.ack_limit);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.spare);
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.fault, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.fault),
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_open);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_read);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_seek);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_write);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_rename);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.directory_read);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.crc_mismatch);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_size_mismatch);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.nak_limit);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.ack_limit);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.inactivity_timer);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.spare);
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.fault, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.fault),
                              "fault channel %d was completely cleared to 0", i);
     }
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEventAndAcceptCommand(void)
@@ -333,23 +334,23 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     int                       i                      = 0;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    msg->data.byte[0] = CF_Reset_up;
+    msg->byte[0] = CF_Reset_up;
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
     }
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -360,18 +361,18 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.pdu);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.error);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.spurious);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.pdu);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests);
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.recv, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.recv),
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.file_data_bytes);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.error);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.spurious);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.nak_segment_requests);
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.recv, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.recv),
                              "recv channel %d was completely cleared to 0", i);
     }
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEventAcceptCommand(void)
@@ -381,20 +382,20 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint8                     i                      = 0;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    msg->data.byte[0] = CF_Reset_down;
+    msg->byte[0] = CF_Reset_down;
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
     }
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -405,15 +406,15 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.pdu);
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.sent, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.sent),
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.sent.file_data_bytes);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.sent.nak_segment_requests);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.sent.pdu);
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.sent, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.sent),
                              "sent channel %d was completely cleared to 0", i);
     }
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(void)
@@ -426,42 +427,42 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    msg->data.byte[0] = CF_Reset_all;
+    msg->byte[0] = CF_Reset_all;
 
-    CF_AppData.hk.counters.cmd = Any_uint16_Except(0);
-    CF_AppData.hk.counters.err = Any_uint16_Except(0);
+    CF_AppData.HkPacket.CommandCounter      = Any_uint16_Except(0);
+    CF_AppData.HkPacket.CommandErrorCounter = Any_uint16_Except(0);
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
     }
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
     }
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
     }
 
     /* Act */
@@ -471,24 +472,24 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
 
-    UtAssert_ZERO(CF_AppData.hk.counters.cmd);
-    UtAssert_ZERO(CF_AppData.hk.counters.err);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandCounter);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandErrorCounter);
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.fault, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.fault),
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.fault, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.fault),
                              "fault channel %d was completely cleared to 0", i);
     }
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.recv, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.recv),
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.recv, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.recv),
                              "recv channel %d was completely cleared to 0", i);
     }
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.sent, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.sent),
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.sent, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.sent),
                              "sent channel %d was completely cleared to 0", i);
     }
 }
@@ -507,13 +508,14 @@ void Test_CF_CmdTxFile(void)
     CF_UT_cmd_tx_file_buf_t utbuf;
     CF_TxFileCmd_t *        msg = &utbuf.tf;
 
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* nominal, all zero should pass checks, just calls CF_CFDP_TxFile */
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_1;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_TX_FILE);
 
@@ -521,7 +523,7 @@ void Test_CF_CmdTxFile(void)
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_2;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_TX_FILE);
 
@@ -531,14 +533,14 @@ void Test_CF_CmdTxFile(void)
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* out of range arguments: bad channel */
     UT_CF_ResetEventCapture();
@@ -546,7 +548,7 @@ void Test_CF_CmdTxFile(void)
     msg->chan_num = CF_NUM_CHANNELS;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 3);
 
     /* out of range arguments: bad keep */
     UT_CF_ResetEventCapture();
@@ -554,7 +556,7 @@ void Test_CF_CmdTxFile(void)
     msg->keep = 15;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 4);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 4);
 
     /* CF_CFDP_TxFile fails*/
     UT_CF_ResetEventCapture();
@@ -562,7 +564,7 @@ void Test_CF_CmdTxFile(void)
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_TX_FILE);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 5);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 5);
 }
 
 /*******************************************************************************
@@ -579,32 +581,33 @@ void Test_CF_CmdPlaybackDir(void)
     CF_UT_cmd_playback_dir_buf_t utbuf;
     CF_PlaybackDirCmd_t *        msg = &utbuf.pd;
 
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* nominal, all zero should pass checks, just calls CF_CFDP_PlaybackDir */
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_1;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_2;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 2);
 
     /* out of range arguments: bad class */
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* out of range arguments: bad channel */
     UT_CF_ResetEventCapture();
@@ -612,7 +615,7 @@ void Test_CF_CmdPlaybackDir(void)
     msg->chan_num = CF_NUM_CHANNELS;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 3);
 
     /* out of range arguments: bad keep */
     UT_CF_ResetEventCapture();
@@ -620,7 +623,7 @@ void Test_CF_CmdPlaybackDir(void)
     msg->keep = 15;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 4);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 4);
 
     /* CF_CFDP_PlaybackDir fails*/
     UT_CF_ResetEventCapture();
@@ -628,7 +631,7 @@ void Test_CF_CmdPlaybackDir(void)
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PLAYBACK_DIR);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 5);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 5);
 }
 
 /*******************************************************************************
@@ -651,7 +654,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[0] = CF_ALL_CHANNELS;
+    arg_cmd->byte[0] = CF_ALL_CHANNELS;
 
     UT_SetDeferredRetcode(UT_KEY(Chan_action_fn_t), random_fn_call, 1);
 
@@ -680,7 +683,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[0] = CF_ALL_CHANNELS;
+    arg_cmd->byte[0] = CF_ALL_CHANNELS;
 
     UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 1);
 
@@ -709,7 +712,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[0] = CF_ALL_CHANNELS;
+    arg_cmd->byte[0] = CF_ALL_CHANNELS;
 
     UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 0);
 
@@ -738,7 +741,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[0] = Any_cf_channel();
+    arg_cmd->byte[0] = Any_cf_channel();
 
     UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 1);
 
@@ -767,7 +770,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[0] = Any_cf_channel();
+    arg_cmd->byte[0] = Any_cf_channel();
 
     UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 0);
 
@@ -796,7 +799,7 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[0] = CF_NUM_CHANNELS;
+    arg_cmd->byte[0] = CF_NUM_CHANNELS;
 
     /* Act */
     local_result = CF_DoChanAction(arg_cmd, arg_errstr, arg_fn, arg_context);
@@ -809,8 +812,9 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
-    UtAssert_True(local_result == -1,
-                  "CF_DoChanAction returned %d and should be -1 (cmd->data.byte[0] >= CF_NUM_CHANNELS)", local_result);
+    UtAssert_True(local_result == CF_ERROR,
+                  "CF_DoChanAction returned %d and should be -1 (CF_ERROR) (cmd->byte[0] >= CF_NUM_CHANNELS)",
+                  local_result);
 }
 
 void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
@@ -828,16 +832,16 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* force CF_ALL_CHANNELS to not be a selection possibility */
-    arg_cmd->data.byte[0] = CF_ALL_CHANNELS;
-    while (arg_cmd->data.byte[0] == CF_ALL_CHANNELS)
+    arg_cmd->byte[0] = CF_ALL_CHANNELS;
+    while (arg_cmd->byte[0] == CF_ALL_CHANNELS)
     {
         if (catastrophe_count == 10) /* 10 is arbitrary */
         {
             UtAssert_Message(UTASSERT_CASETYPE_ABORT, __FILE__, __LINE__,
-                             "CANNOT make arg_cmd->data.byte[0] != CF_ALL_CHANNELS in 10 tries");
+                             "CANNOT make arg_cmd->byte[0] != CF_ALL_CHANNELS in 10 tries");
         }
 
-        arg_cmd->data.byte[0] = Any_uint8_GreaterThan_or_EqualTo(CF_NUM_CHANNELS);
+        arg_cmd->byte[0] = Any_uint8_GreaterThan_or_EqualTo(CF_NUM_CHANNELS);
         ++catastrophe_count;
     }
 
@@ -852,8 +856,9 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
-    UtAssert_True(local_result == -1,
-                  "CF_DoChanAction returned %d and should be -1 (cmd->data.byte[0] >= CF_NUM_CHANNELS)", local_result);
+    UtAssert_True(local_result == CF_ERROR,
+                  "CF_DoChanAction returned %d and should be -1 (CF_ERROR) (cmd->byte[0] >= CF_NUM_CHANNELS)",
+                  local_result);
 }
 
 /*******************************************************************************
@@ -876,15 +881,15 @@ void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
 
     /* set frozen to opposite to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
-    CF_AppData.hk.channel_hk[arg_chan_num].frozen = !context.barg;
+    CF_AppData.HkPacket.channel_hk[arg_chan_num].frozen = !context.barg;
 
     /* Act */
     local_result = CF_DoFreezeThaw(arg_chan_num, arg_context);
 
     /* Assert */
-    UtAssert_True(CF_AppData.hk.channel_hk[arg_chan_num].frozen == context.barg,
+    UtAssert_True(CF_AppData.HkPacket.channel_hk[arg_chan_num].frozen == context.barg,
                   "CF_DoFreezeThaw set frozen to %d and should be %d (context->barg))",
-                  CF_AppData.hk.channel_hk[arg_chan_num].frozen, context.barg);
+                  CF_AppData.HkPacket.channel_hk[arg_chan_num].frozen, context.barg);
     UtAssert_True(local_result == CFE_SUCCESS,
                   "CF_DoFreezeThaw returned %d and should be 0 (CFE_SUCCESS) (only returns 0)", local_result);
 }
@@ -901,7 +906,7 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     uint8 chan_num = Any_cf_channel();
@@ -909,21 +914,21 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = chan_num;
+    msg->byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdFreeze(arg_msg);
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.hk.channel_hk[chan_num].frozen == 1,
+    UtAssert_True(CF_AppData.HkPacket.channel_hk[chan_num].frozen == 1,
                   "CF_DoFreezeThaw set frozen to %d and should be 1 (freeze = 1))",
-                  CF_AppData.hk.channel_hk[chan_num].frozen);
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+                  CF_AppData.HkPacket.channel_hk[chan_num].frozen);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_FREEZE);
 }
@@ -939,16 +944,16 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.cmd = 0;
+    CF_AppData.HkPacket.CommandCounter = 0;
 
     /* Act */
     CF_CmdFreeze(arg_msg);
 
     /* Assert */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_FREEZE);
 }
 
@@ -964,7 +969,7 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     uint8 chan_num = Any_cf_channel();
@@ -972,21 +977,21 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = chan_num;
+    msg->byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdThaw(arg_msg);
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.hk.channel_hk[chan_num].frozen == 0,
+    UtAssert_True(CF_AppData.HkPacket.channel_hk[chan_num].frozen == 0,
                   "CF_DoFreezeThaw set frozen to %d and should be 0 (thaw = 0))",
-                  CF_AppData.hk.channel_hk[chan_num].frozen);
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+                  CF_AppData.HkPacket.channel_hk[chan_num].frozen);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_THAW);
 }
@@ -1002,16 +1007,16 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.cmd = 0;
+    CF_AppData.HkPacket.CommandCounter = 0;
 
     /* Act */
     CF_CmdThaw(arg_msg);
 
     /* Assert */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_THAW);
 }
 
@@ -1336,7 +1341,8 @@ void Test_CF_DoSuspRes(void)
     CF_TransactionCmd_t *       cmd = &utbuf.xact;
     CF_ChanAction_SuspResArg_t  utargs;
 
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
     memset(&utargs, 0, sizeof(utargs));
     memset(cmd, 0, sizeof(*cmd));
 
@@ -1344,7 +1350,7 @@ void Test_CF_DoSuspRes(void)
     /* With no setup, CF_TsnChanAction() invokes CF_TraverseAllTransactions stub, which returns 0 */
     /* this should increment the reject counter because it did not match any transactions */
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 0));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     /* set up to match 1 transaction, should be accepted, but should not generate an event */
     UT_CF_ResetEventCapture();
@@ -1352,7 +1358,7 @@ void Test_CF_DoSuspRes(void)
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_SUSPRES);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 
     /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
     /* this gets the case where it attempts to set to the same value, and is rejected due to that */
@@ -1363,7 +1369,7 @@ void Test_CF_DoSuspRes(void)
                           &utargs);
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 0));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_SUSPRES_SAME);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
     /* however this time CF_TraverseAllTransactions reports it matched multiple transactions, so it should NOT reject it
@@ -1373,7 +1379,7 @@ void Test_CF_DoSuspRes(void)
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_SUSPRES);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 2);
 }
 
 /*******************************************************************************
@@ -1402,7 +1408,7 @@ void Test_CF_CmdSuspend_Call_CF_DoSuspRes_WithGiven_msg_And_action_1(void)
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_CMD_SUSPRES_CHAN);
 
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 /*******************************************************************************
@@ -1431,7 +1437,7 @@ void Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0(void)
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_CMD_SUSPRES_CHAN);
 
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 /*******************************************************************************
@@ -1479,7 +1485,7 @@ void Test_CF_CmdCancel_Success(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_CANCEL);
 }
@@ -1499,7 +1505,7 @@ void Test_CF_CmdCancel_Failure(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CANCEL_CHAN);
 }
 
@@ -1551,7 +1557,7 @@ void Test_CF_CmdAbandon_Success(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ABANDON);
 }
@@ -1571,7 +1577,7 @@ void Test_CF_CmdAbandon_Failure(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ABANDON_CHAN);
 }
 
@@ -1615,7 +1621,7 @@ void Test_CF_CmdEnableDequeue_Success(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
     CF_ConfigTable_t config_table;
@@ -1627,9 +1633,9 @@ void Test_CF_CmdEnableDequeue_Success(void)
     CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = chan_num;
+    msg->byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdEnableDequeue(arg_msg);
@@ -1640,10 +1646,11 @@ void Test_CF_CmdEnableDequeue_Success(void)
                   "CF_CmdEnableDequeue set dequeue_enabled to %d and should be 1 (barg = 1))",
                   CF_AppData.config_table->chan[chan_num].dequeue_enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d\nACCEPTANCE OF COMMAND (+1) SHOULD BE "
-                  "THE BEHAVIOR BUT IT IS NOT",
-                  CF_AppData.hk.counters.cmd, initial_hk_cmd_counter);
+    UtAssert_True(
+        CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+        "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d\nACCEPTANCE OF COMMAND (+1) SHOULD BE "
+        "THE BEHAVIOR BUT IT IS NOT",
+        CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_DEQUEUE);
 }
@@ -1664,16 +1671,16 @@ void Test_CF_CmdEnableDequeue_Failure(void)
     CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.err = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* Act */
     CF_CmdEnableDequeue(arg_msg);
 
     /* Assert */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_DEQUEUE);
 }
 
@@ -1689,7 +1696,7 @@ void Test_CF_CmdDisableDequeue_Success(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
     CF_ConfigTable_t config_table;
@@ -1701,9 +1708,9 @@ void Test_CF_CmdDisableDequeue_Success(void)
     CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = chan_num;
+    msg->byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdDisableDequeue(arg_msg);
@@ -1714,9 +1721,9 @@ void Test_CF_CmdDisableDequeue_Success(void)
                   "CF_CmdEnableDequeue set dequeue_enabled to %d and should be 0 (barg = 0))",
                   CF_AppData.config_table->chan[chan_num].dequeue_enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_DEQUEUE);
 }
@@ -1737,16 +1744,16 @@ void Test_CF_CmdDisableDequeue_Failure(void)
     CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = CF_NUM_CHANNELS + 1;
+    msg->byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.err = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* Act */
     CF_CmdDisableDequeue(arg_msg);
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_DEQUEUE);
 }
 
@@ -1774,7 +1781,7 @@ void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannel
 
     CF_AppData.config_table = &config_table;
 
-    msg->data.byte[1] = CF_ALL_CHANNELS;
+    msg->byte[1] = CF_ALL_CHANNELS;
 
     context.msg      = msg;
     context.barg     = Any_bool_arg_t_barg();
@@ -1813,7 +1820,7 @@ void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_conte
 
     CF_AppData.config_table = &config_table;
 
-    msg->data.byte[1] = polldir;
+    msg->byte[1] = polldir;
 
     context.msg      = msg;
     context.barg     = Any_bool_arg_t_barg();
@@ -1845,7 +1852,7 @@ void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_An
 
     CF_AppData.config_table = &config_table;
 
-    msg->data.byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
+    msg->byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
 
     context.msg  = msg;
     context.barg = Any_bool_arg_t_barg();
@@ -1875,7 +1882,7 @@ void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
 
     CF_AppData.config_table = &config_table;
 
-    msg->data.byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
+    msg->byte[1] = CF_MAX_POLLING_DIR_PER_CHAN;
 
     context.msg  = msg;
     context.barg = Any_bool_arg_t_barg();
@@ -1905,7 +1912,7 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&config_table, 0, sizeof(config_table));
@@ -1913,12 +1920,12 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
     CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    msg->data.byte[1] = polldir;
+    msg->byte[1] = polldir;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdEnablePolldir(arg_msg);
@@ -1929,9 +1936,9 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
                   "Channel %u Polldir %u set to %u and should be 1 (context->barg)", channel, polldir,
                   CF_AppData.config_table->chan[channel].polldir[polldir].enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_POLLDIR);
 }
 
@@ -1943,16 +1950,17 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    msg->data.byte[1] = error_polldir;
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    msg->byte[1] = error_polldir;
+
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdEnablePolldir(arg_msg);
@@ -1960,9 +1968,9 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_POLLDIR);
 }
 
@@ -1981,7 +1989,7 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&config_table, 0, sizeof(config_table));
@@ -1989,12 +1997,12 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
     CF_AppData.config_table = &config_table;
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    msg->data.byte[1] = polldir;
+    msg->byte[1] = polldir;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdDisablePolldir(arg_msg);
@@ -2005,9 +2013,9 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
                   "Channel %u Polldir %u set to %u and should be 0 (context->barg)", channel, polldir,
                   CF_AppData.config_table->chan[channel].polldir[polldir].enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_POLLDIR);
 }
 
@@ -2019,17 +2027,17 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
-    msg->data.byte[1] = error_polldir;
+    msg->byte[1] = error_polldir;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdDisablePolldir(arg_msg);
@@ -2037,9 +2045,9 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter*/
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_POLLDIR);
 }
 
@@ -2123,7 +2131,7 @@ void Test_CF_DoPurgeQueue_PendOnly(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[1] = 0; /* pend */
+    arg_cmd->byte[1] = 0; /* pend */
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_POINTER,
                           &context_CF_CList_Traverse);
 
@@ -2159,7 +2167,7 @@ void Test_CF_DoPurgeQueue_HistoryOnly(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[1] = 1; /* history */
+    arg_cmd->byte[1] = 1; /* history */
 
     /* set correct context type for CF_CList_Traverse stub */
     UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_POINTER,
@@ -2199,7 +2207,7 @@ void Test_CF_DoPurgeQueue_Both(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[1] = 2; /* both */
+    arg_cmd->byte[1] = 2; /* both */
 
     /* set correct context type for CF_CList_Traverse stub */
     /* this must use data buffer hack to pass multiple contexts */
@@ -2239,7 +2247,7 @@ void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[1] = 3; /* 3 is first default value */
+    arg_cmd->byte[1] = 3; /* 3 is first default value */
 
     /* Act */
     local_result = CF_DoPurgeQueue(arg_chan_num, arg_cmd);
@@ -2263,7 +2271,7 @@ void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    arg_cmd->data.byte[1] = Any_uint8_GreaterThan_or_EqualTo(3);
+    arg_cmd->byte[1] = Any_uint8_GreaterThan_or_EqualTo(3);
 
     /* Act */
     local_result = CF_DoPurgeQueue(arg_chan_num, arg_cmd);
@@ -2291,17 +2299,17 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = channel;
+    msg->byte[0] = channel;
 
     /* Arrange unstubbable: CF_DoPurgeQueue */
-    msg->data.byte[1] = error_purge;
+    msg->byte[1] = error_purge;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdPurgeQueue(arg_msg);
@@ -2309,9 +2317,9 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_QUEUE);
 }
 
@@ -2326,9 +2334,9 @@ void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    msg->data.byte[0] = channel;
+    msg->byte[0] = channel;
 
-    CF_AppData.hk.counters.cmd = 0;
+    CF_AppData.HkPacket.CommandCounter = 0;
 
     /* Act */
     CF_CmdPurgeQueue(arg_msg);
@@ -2336,7 +2344,7 @@ void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_PURGE_QUEUE);
 }
@@ -2353,14 +2361,14 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
     CF_UT_cmd_write_q_buf_t utbuf;
     CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
-    uint16                  initial_hk_err_counter = Any_uint16();
+    uint8                   initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
     wq->chan = CF_NUM_CHANNELS;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2369,7 +2377,7 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand(void)
@@ -2378,14 +2386,14 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
     CF_UT_cmd_write_q_buf_t utbuf;
     CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
-    uint16                  initial_hk_err_counter = Any_uint16();
+    uint8                   initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
     wq->chan = Any_uint8_GreaterThan(CF_NUM_CHANNELS);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2395,7 +2403,7 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
@@ -2404,7 +2412,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     CF_UT_cmd_write_q_buf_t utbuf;
     CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
-    uint16                  initial_hk_err_counter = Any_uint16();
+    uint8                   initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2415,7 +2423,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     wq->type  = CF_Type_up;
     wq->queue = CF_Queue_pend;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2425,7 +2433,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_ARGS);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_IsNot_q_pend_SendEventAndRejectCommand(
@@ -2436,7 +2444,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     CF_WriteQueueCmd_t *           wq = &utbuf.wq;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
-    uint16                         initial_hk_err_counter = Any_uint16();
+    uint8                          initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2455,7 +2463,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2467,7 +2475,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_queue_Is_q_pend_SendEventAndRejectCommand(
@@ -2478,7 +2486,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     CF_WriteQueueCmd_t *           wq = &utbuf.wq;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
-    uint16                         initial_hk_err_counter = Any_uint16();
+    uint8                          initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2497,7 +2505,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2509,7 +2517,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails(
@@ -2522,7 +2530,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
-    uint16                               initial_hk_err_counter                   = Any_uint16();
+    uint8                                initial_hk_err_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2546,7 +2554,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
                      sizeof(context_CF_WriteTxnQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2557,7 +2565,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand(
@@ -2571,7 +2579,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2597,7 +2605,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2608,7 +2616,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2622,7 +2630,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
     int32                                    context_CF_WrappedClose_fd;
-    uint16                                   initial_hk_err_counter = Any_uint16();
+    uint8                                    initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2648,7 +2656,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2659,7 +2667,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2673,7 +2681,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2699,7 +2707,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2710,7 +2718,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2725,7 +2733,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     int32                                forced_return_CF_WriteTxnQueueDataToFile_1st_call = 0;
     int32                                forced_return_CF_WriteTxnQueueDataToFile_2nd_call = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2752,7 +2760,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2763,7 +2771,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsPend_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2777,7 +2785,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2803,7 +2811,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2814,7 +2822,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_PEND);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2828,7 +2836,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
     int32                                    context_CF_WrappedClose_fd;
-    uint16                                   initial_hk_err_counter = Any_uint16();
+    uint8                                    initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2854,7 +2862,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2865,7 +2873,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
@@ -2877,7 +2885,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2902,7 +2910,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2914,7 +2922,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
@@ -2925,7 +2933,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2947,7 +2955,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2959,7 +2967,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
@@ -2970,7 +2978,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2992,7 +3000,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3004,7 +3012,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
@@ -3015,7 +3023,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3037,7 +3045,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3049,7 +3057,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
@@ -3061,7 +3069,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3086,7 +3094,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3098,7 +3106,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
@@ -3109,7 +3117,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3131,7 +3139,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3143,7 +3151,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
@@ -3154,7 +3162,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3176,7 +3184,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3188,7 +3196,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 /* Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Pend IS an error and is handled by a previous test */
@@ -3201,7 +3209,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3223,7 +3231,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3235,7 +3243,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
@@ -3246,7 +3254,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3268,7 +3276,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3280,7 +3288,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
@@ -3291,7 +3299,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3313,7 +3321,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3325,7 +3333,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
@@ -3336,7 +3344,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3358,7 +3366,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3370,7 +3378,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 /*******************************************************************************
@@ -3516,9 +3524,10 @@ void Test_CF_CmdGetSetParam(void)
     uint16              expected_count;
 
     memset(&ut_config_table, 0, sizeof(ut_config_table));
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
-    CF_AppData.config_table = &ut_config_table;
-    expected_count          = 0;
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
+    CF_AppData.config_table                 = &ut_config_table;
+    expected_count                          = 0;
 
     /* Nominal: "set" for each parameter */
     for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
@@ -3526,7 +3535,7 @@ void Test_CF_CmdGetSetParam(void)
         UT_CF_ResetEventCapture();
         UtAssert_VOIDCALL(CF_CmdGetSetParam(1, param_id, 1 + param_id, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET1);
-        UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, ++expected_count);
+        UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, ++expected_count);
     }
 
     /* each of the config parameters should have actually been set to a different value */
@@ -3547,27 +3556,27 @@ void Test_CF_CmdGetSetParam(void)
         UT_CF_ResetEventCapture();
         UtAssert_VOIDCALL(CF_CmdGetSetParam(0, param_id, 1, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET2);
-        UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, ++expected_count);
+        UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, ++expected_count);
     }
 
     /* Bad param ID */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_CmdGetSetParam(0, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     /* Bad channel ID */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_CmdGetSetParam(0, 0, 0, CF_NUM_CHANNELS + 1));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_CHAN);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* Validation fail */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_CmdGetSetParam(1, CF_GetSet_ValueID_outgoing_file_chunk_size,
                                         100 + sizeof(CF_CFDP_PduFileDataContent_t), UT_CFDP_CHANNEL));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_VALIDATE);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 3);
 }
 
 /*******************************************************************************
@@ -3599,7 +3608,7 @@ void Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET1);
     /* Assert for incremented counter() */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 }
 
 /*******************************************************************************
@@ -3630,7 +3639,7 @@ void Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstant
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET2);
     /* Assert for incremented counter() */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 }
 
 /*******************************************************************************
@@ -3644,13 +3653,13 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                          = NULL;
     uint32           forced_return_CF_CFDP_InitEngine = CFE_SUCCESS;
-    uint16           initial_hk_cmd_counter           = Any_uint16();
+    uint8            initial_hk_cmd_counter           = Any_uint8();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdEnableEngine(arg_msg);
@@ -3662,7 +3671,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementErrCounter(void)
@@ -3670,13 +3679,13 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                          = NULL;
     uint32           forced_return_CF_CFDP_InitEngine = Any_uint32_Except(CFE_SUCCESS);
-    uint16           initial_hk_err_counter           = Any_uint16();
+    uint8            initial_hk_err_counter           = Any_uint8();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdEnableEngine(arg_msg);
@@ -3688,18 +3697,18 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounter(void)
 {
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                = NULL;
-    uint16           initial_hk_err_counter = Any_uint16();
+    uint8            initial_hk_err_counter = Any_uint8();
 
     CF_AppData.engine.enabled = 1; /* 1 is enabled */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdEnableEngine(arg_msg);
@@ -3711,7 +3720,7 @@ void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounte
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_ENA);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 /*******************************************************************************
@@ -3724,11 +3733,11 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
 {
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                = NULL;
-    uint16           initial_hk_cmd_counter = Any_uint16();
+    uint8            initial_hk_cmd_counter = Any_uint8();
 
     CF_AppData.engine.enabled = 1; /* 1 is enabled */
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdDisableEngine(arg_msg);
@@ -3739,18 +3748,18 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_ENGINE);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(void)
 {
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                = NULL;
-    uint16           initial_hk_err_counter = Any_uint16();
+    uint8            initial_hk_err_counter = Any_uint8();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdDisableEngine(arg_msg);
@@ -3760,10 +3769,10 @@ void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(v
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_DIS);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
 }
 
 /*******************************************************************************
@@ -3794,7 +3803,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_EqTo_CF_NUM_COMMANDS_FailAndSendEvent
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSendEvent(void)
@@ -3819,7 +3828,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSe
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForThatCommandSendEventAndFailure(void)
@@ -3846,7 +3855,7 @@ void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForT
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_LEN);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_msg(void)
@@ -3874,7 +3883,7 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_m
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 }
 
 /* Hit a NULL entry to exercise that conditional and no action */
@@ -3900,8 +3909,8 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x0C_AndDoNothingBecause_fns_1
     UtAssert_STUB_COUNT(CFE_MSG_GetSize, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 0);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 0);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 0);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 0);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #288 
`CF_UnionArgs_Payload_t` has been removed, given that only a single member of the 3 is used in CF. That member variable - `byte` - has been moved into the `CF_UnionArgsCmd_t` struct, which was the only place where `CF_UnionArgs_Payload_t` was used.
Re-introduced from #341. #393, #395 reverted this PR.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on logic.

**Contributor Info**
@thnkslprpt