### PR TITLE
Fix #382, Align CF Command Counter implementation to cFS standard

### DIFF
--- a/fsw/inc/cf_msg.h
+++ b/fsw/inc/cf_msg.h
@@ -41,15 +41,6 @@
  */
 
 /**
- * \brief Housekeeping command counters
- */
-typedef struct CF_HkCmdCounters
-{
-    uint16 cmd; /**< \brief Command success counter */
-    uint16 err; /**< \brief Command error counter */
-} CF_HkCmdCounters_t;
-
-/**
  * \brief Housekeeping sent counters
  */
 typedef struct CF_HkSent
@@ -122,9 +113,10 @@ typedef struct CF_HkChannel_Data
  */
 typedef struct CF_HkPacket
 {
-    CFE_MSG_TelemetryHeader_t tlm_header; /**< \brief Telemetry header */
-    CF_HkCmdCounters_t        counters;   /**< \brief Command counters */
-    uint8                     spare[4];   /**< \brief Alignment spare (CF_HkCmdCounters_t is 4 bytes) */
+    CFE_MSG_TelemetryHeader_t tlm_header;          /**< \brief Telemetry header */
+    uint8                     CommandCounter;      /**< \brief Command success counter */
+    uint8                     CommandErrorCounter; /**< \brief Command error counter */
+    uint8                     spare[6];            /**< \brief Alignment spare */
 
     CF_HkChannel_Data_t channel_hk[CF_NUM_CHANNELS]; /**< \brief Per channel housekeeping data */
 } CF_HkPacket_t;
@@ -179,7 +171,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_NOOP
      *
      *  \par Error Conditions
@@ -187,7 +179,7 @@ typedef enum
      *       - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -211,7 +203,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_RESET
      *
      *  \par Error Conditions
@@ -220,7 +212,7 @@ typedef enum
      *       - Invalid counter type, #CF_EID_ERR_CMD_RESET_INVALID
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -239,7 +231,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_TX_FILE
      *
      *  \par Error Conditions
@@ -249,7 +241,7 @@ typedef enum
      *       - Transaction initialization failure, #CF_EID_ERR_CMD_TX_FILE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -271,7 +263,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_PLAYBACK_DIR
      *
      *  \par Error Conditions
@@ -281,7 +273,7 @@ typedef enum
      *       - Playback initialization failure, #CF_EID_ERR_CMD_PLAYBACK_DIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -306,7 +298,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_FREEZE
      *
      *  \par Error Conditions
@@ -316,7 +308,7 @@ typedef enum
      *       - Command processing failure, #CF_EID_ERR_CMD_FREEZE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -340,7 +332,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_THAW
      *
      *  \par Error Conditions
@@ -350,7 +342,7 @@ typedef enum
      *       - Command processing failure, #CF_EID_ERR_CMD_THAW
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -374,7 +366,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_SUSPRES
      *
      *  \par Error Conditions
@@ -386,7 +378,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -410,7 +402,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_SUSPRES
      *
      *  \par Error Conditions
@@ -422,7 +414,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -445,7 +437,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_CANCEL
      *
      *  \par Error Conditions
@@ -456,7 +448,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_CANCEL_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -479,7 +471,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_ABANDON
      *
      *  \par Error Conditions
@@ -490,7 +482,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_ABANDON_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -511,7 +503,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_GETSET1
      *
      *  \par Error Conditions
@@ -522,7 +514,7 @@ typedef enum
      *       - Parameter value failed validation, #CF_EID_ERR_CMD_GETSET_VALIDATE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -543,7 +535,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_GETSET2
      *
      *  \par Error Conditions
@@ -553,7 +545,7 @@ typedef enum
      *       - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -574,7 +566,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_WQ
      *
      *  \par Error Conditions
@@ -589,7 +581,7 @@ typedef enum
      *       - Write TX history data failed, #CF_EID_ERR_CMD_WQ_WRITEHIST_TX
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -612,7 +604,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_ENABLE_DEQUEUE
      *
      *  \par Error Conditions
@@ -622,7 +614,7 @@ typedef enum
      *       - Enable dequeue failed, #CF_EID_ERR_CMD_ENABLE_DEQUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -645,7 +637,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_DISABLE_DEQUEUE
      *
      *  \par Error Conditions
@@ -655,7 +647,7 @@ typedef enum
      *       - Disable dequeue failed, #CF_EID_INF_CMD_DISABLE_DEQUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -684,7 +676,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_ENABLE_POLLDIR
      *
      *  \par Error Conditions
@@ -695,7 +687,7 @@ typedef enum
      *       - Enable directory polling failed, #CF_EID_ERR_CMD_ENABLE_POLLDIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -724,7 +716,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_DISABLE_POLLDIR
      *
      *  \par Error Conditions
@@ -735,7 +727,7 @@ typedef enum
      *       - Disable directory polling failed, #CF_EID_ERR_CMD_DISABLE_POLLDIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -765,7 +757,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_PURGE_QUEUE
      *
      *  \par Error Conditions
@@ -776,7 +768,7 @@ typedef enum
      *       - Purge queue failed, #CF_EID_ERR_CMD_PURGE_QUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -798,7 +790,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_ENABLE_ENGINE
      *
      *  \par Error Conditions
@@ -808,7 +800,7 @@ typedef enum
      *       - Engine already enabled, #CF_EID_ERR_CMD_ENG_ALREADY_ENA
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None
@@ -831,7 +823,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_t.CommandCounter will increment
      *       - #CF_EID_INF_CMD_DISABLE_ENGINE
      *
      *  \par Error Conditions
@@ -840,7 +832,7 @@ typedef enum
      *       - Engine already disabled, #CF_EID_ERR_CMD_ENG_ALREADY_DIS
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_t.CommandErrorCounter will increment
      *
      *  \par Criticality
      *       None

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -46,8 +46,8 @@ CF_AppData_t CF_AppData;
  *-----------------------------------------------------------------*/
 void CF_HkCmd(void)
 {
-    CFE_MSG_SetMsgTime(&CF_AppData.hk.tlm_header.Msg, CFE_TIME_GetTime());
-    /* return value ignored */ CFE_SB_TransmitMsg(&CF_AppData.hk.tlm_header.Msg, true);
+    CFE_MSG_SetMsgTime(&CF_AppData.HkPacket.tlm_header.Msg, CFE_TIME_GetTime());
+    /* return value ignored */ CFE_SB_TransmitMsg(&CF_AppData.HkPacket.tlm_header.Msg, true);
 }
 
 /*----------------------------------------------------------------
@@ -205,7 +205,7 @@ CFE_Status_t CF_Init(void)
 
     CF_AppData.run_status = CFE_ES_RunStatus_APP_RUN;
 
-    CFE_MSG_Init(&CF_AppData.hk.tlm_header.Msg, CFE_SB_ValueToMsgId(CF_HK_TLM_MID), sizeof(CF_AppData.hk));
+    CFE_MSG_Init(&CF_AppData.HkPacket.tlm_header.Msg, CFE_SB_ValueToMsgId(CF_HK_TLM_MID), sizeof(CF_AppData.HkPacket));
 
     status = CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY);
     if (status != CFE_SUCCESS)
@@ -301,7 +301,7 @@ void CF_ProcessMsg(CFE_SB_Buffer_t *msg)
             break;
 
         default:
-            ++CF_AppData.hk.counters.err;
+            ++CF_AppData.HkPacket.CommandErrorCounter;
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_CMD_LENGTH, CFE_EVS_EventType_ERROR,
                               "CF: invalid command packet id=0x%lx", (unsigned long)CFE_SB_MsgIdToValue(msg_id));
             break;

--- a/fsw/src/cf_app.h
+++ b/fsw/src/cf_app.h
@@ -77,7 +77,7 @@
  */
 typedef struct
 {
-    CF_HkPacket_t hk;
+    CF_HkPacket_t HkPacket;
 
     uint32 run_status;
 

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -598,7 +598,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_TRUNCATION, CFE_EVS_EventType_ERROR,
                           "CF: PDU rejected due to EID/seq number field truncation");
-        ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
     /*
@@ -611,7 +611,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_LARGE_FILE, CFE_EVS_EventType_ERROR,
                           "CF: PDU with large file bit received (unsupported)");
-        ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
     else
@@ -625,13 +625,13 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_PDU_SHORT_HEADER, CFE_EVS_EventType_ERROR, "CF: PDU too short (%lu received)",
                               (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-            ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
+            ++CF_AppData.HkPacket.channel_hk[chan_num].counters.recv.error;
             ret = CF_SHORT_PDU_ERROR;
         }
         else
         {
             /* PDU is ok, so continue processing */
-            ++CF_AppData.hk.channel_hk[chan_num].counters.recv.pdu;
+            ++CF_AppData.HkPacket.channel_hk[chan_num].counters.recv.pdu;
         }
     }
 
@@ -656,7 +656,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_MD_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: metadata packet too short: %lu bytes received",
                           (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
         ret = CF_PDU_METADATA_ERROR;
     }
     else
@@ -678,7 +678,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
             CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_SRC_LEN, CFE_EVS_EventType_ERROR,
                               "CF: metadata PDU rejected due to invalid length in source filename of 0x%02x",
                               md->source_filename.length);
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
             ret = CF_PDU_METADATA_ERROR;
         }
         else
@@ -690,7 +690,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                 CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_DST_LEN, CFE_EVS_EventType_ERROR,
                                   "CF: metadata PDU rejected due to invalid length in dest filename of 0x%02x",
                                   md->dest_filename.length);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
                 ret = CF_PDU_METADATA_ERROR;
             }
             else
@@ -735,7 +735,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: filedata PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         CF_CFDP_SetTxnStatus(t, CF_TxnStatus_PROTOCOL_ERROR);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
         ret = CF_SHORT_PDU_ERROR;
     }
     else if (ph->pdu_header.segment_meta_flag)
@@ -744,7 +744,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_UNSUPPORTED, CFE_EVS_EventType_ERROR,
                           "CF: filedata PDU with segment metadata received");
         CF_CFDP_SetTxnStatus(t, CF_TxnStatus_PROTOCOL_ERROR);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
 
@@ -850,7 +850,7 @@ CFE_Status_t CF_CFDP_RecvNak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
  *-----------------------------------------------------------------*/
 void CF_CFDP_RecvDrop(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
 {
-    ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.dropped;
+    ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.dropped;
 }
 
 /*----------------------------------------------------------------
@@ -918,14 +918,14 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                 {
                     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_IDLE_MD, CFE_EVS_EventType_ERROR,
                                       "CF: got invalid md PDU -- abandoning transaction");
-                    ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+                    ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
                     /* leave state as idle, which will reset below */
                 }
                 break;
             default:
                 CFE_EVS_SendEvent(CF_EID_ERR_CFDP_FD_UNHANDLED, CFE_EVS_EventType_ERROR,
                                   "CF: unhandled file directive code 0x%02x in idle state", fdh->directive_code);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
                 break;
         }
     }
@@ -1327,7 +1327,7 @@ static CFE_Status_t CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *p, const char *s
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_OPENDIR, CFE_EVS_EventType_ERROR,
                           "CF: failed to open playback directory %s, error=%ld", src_filename, (long)ret);
-        ++CF_AppData.hk.channel_hk[chan].counters.fault.directory_read;
+        ++CF_AppData.HkPacket.channel_hk[chan].counters.fault.directory_read;
     }
     else
     {
@@ -1482,7 +1482,7 @@ static void CF_CFDP_ProcessPlaybackDirectories(CF_Channel_t *c)
     {
         CF_CFDP_ProcessPlaybackDirectory(c, &c->playback[i]);
         CF_CFDP_UpdatePollPbCounted(&c->playback[i], c->playback[i].busy,
-                                    &CF_AppData.hk.channel_hk[chan_index].playback_counter);
+                                    &CF_AppData.HkPacket.channel_hk[chan_index].playback_counter);
     }
 }
 
@@ -1551,7 +1551,7 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *c)
             count_check = 1;
         }
 
-        CF_CFDP_UpdatePollPbCounted(&p->pb, count_check, &CF_AppData.hk.channel_hk[chan_index].poll_counter);
+        CF_CFDP_UpdatePollPbCounted(&p->pb, count_check, &CF_AppData.HkPacket.channel_hk[chan_index].poll_counter);
     }
 }
 
@@ -1576,7 +1576,7 @@ void CF_CFDP_CycleEngine(void)
             /* consume all received messages, even if channel is frozen */
             CF_CFDP_ReceiveMessage(c);
 
-            if (!CF_AppData.hk.channel_hk[i].frozen)
+            if (!CF_AppData.HkPacket.channel_hk[i].frozen)
             {
                 /* handle ticks before tx cycle. Do this because there may be a limited number of TX messages available
                  * this cycle, and it's important to respond to class 2 ACK/NAK more than it is to send new filedata
@@ -1829,7 +1829,7 @@ void CF_CFDP_DisableEngine(void)
         }
 
         /* finally all queue counters must be reset */
-        memset(&CF_AppData.hk.channel_hk[i].q_size, 0, sizeof(CF_AppData.hk.channel_hk[i].q_size));
+        memset(&CF_AppData.HkPacket.channel_hk[i].q_size, 0, sizeof(CF_AppData.HkPacket.channel_hk[i].q_size));
 
         CFE_SB_DeletePipe(c->pipe);
     }

--- a/fsw/src/cf_cfdp_dispatch.c
+++ b/fsw/src/cf_cfdp_dispatch.c
@@ -59,7 +59,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
         }
         else
         {
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_DC_INV, CFE_EVS_EventType_ERROR,
                               "CF R%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
@@ -74,7 +74,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
         }
         else
         {
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.dropped;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.dropped;
         }
     }
 
@@ -118,7 +118,7 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph,
         }
         else
         {
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_DC_INV, CFE_EVS_EventType_ERROR,
                               "CF S%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -99,7 +99,7 @@ CFE_Status_t CF_CFDP_R_CheckCrc(CF_Transaction_t *t, uint32 expected_crc)
                           (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                           (unsigned long)t->history->seq_num, (unsigned long)t->crc.result,
                           (unsigned long)expected_crc);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.crc_mismatch;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.crc_mismatch;
         ret = 1;
     }
 
@@ -156,7 +156,7 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *t, int ok_to_send_nak)
                                   "CF R%d(%lu:%lu): NAK limited reach", (t->state == CF_TxnState_R2),
                                   (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
                 send_fin = 1;
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.nak_limit;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.nak_limit;
                 /* don't use CF_CFDP_R2_SetFinTxnStatus because many places in this function set send_fin */
                 CF_CFDP_SetTxnStatus(t, CF_TxnStatus_NAK_LIMIT_REACHED);
                 t->state_data.r.r2.acknak_count = 0; /* reset for fin/ack */
@@ -213,7 +213,7 @@ CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph
                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, (long)fd->offset,
                               (long)fret);
             CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek;
             ret = CF_ERROR; /* connection will reset in caller */
         }
     }
@@ -228,13 +228,13 @@ CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph
                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
                               (long)fd->data_len, (long)fret);
             CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_write;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_write;
             ret = CF_ERROR; /* connection will reset in caller */
         }
         else
         {
             t->state_data.r.cached_pos = fd->data_len + fd->offset;
-            CF_AppData.hk.channel_hk[t->chan_num].counters.recv.file_data_bytes += fd->data_len;
+            CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.file_data_bytes += fd->data_len;
         }
     }
 
@@ -264,7 +264,7 @@ CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer
                               "CF R%d(%lu:%lu): EOF file size mismatch: got %lu expected %lu",
                               (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                               (unsigned long)t->history->seq_num, (unsigned long)eof->size, (unsigned long)t->fsize);
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_size_mismatch;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_size_mismatch;
             ret = CF_REC_PDU_FSIZE_MISMATCH_ERROR;
         }
     }
@@ -273,7 +273,7 @@ CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *t, CF_Logical_PduBuffer
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_EOF, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid EOF packet",
                           (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                           (unsigned long)t->history->seq_num);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
         ret = CF_REC_PDU_BAD_EOF_ERROR;
     }
 
@@ -524,7 +524,7 @@ CFE_Status_t CF_CFDP_R_SubstateSendNak(CF_Transaction_t *t)
                                                      that function we need to test handling it here */
                 if (sret == CFE_SUCCESS)
                 {
-                    CF_AppData.hk.channel_hk[t->chan_num].counters.sent.nak_segment_requests += cret;
+                    CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.nak_segment_requests += cret;
                     ret = CFE_SUCCESS;
                 }
             }
@@ -593,7 +593,7 @@ void CF_CFDP_R_Init(CF_Transaction_t *t)
                           "CF R%d(%lu:%lu): failed to create file %s for writing, error=%ld",
                           (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                           (unsigned long)t->history->seq_num, t->history->fnames.dst_filename, (long)ret);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open;
         t->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
         if (t->state == CF_TxnState_R2)
         {
@@ -660,7 +660,7 @@ CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
                                   (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
                                   (unsigned long)t->state_data.r.r2.rx_crc_calc_bytes, (long)fret);
                 CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek;
                 success = false;
                 break;
             }
@@ -674,7 +674,7 @@ CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *t)
                               (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                               (unsigned long)t->history->seq_num, (unsigned long)read_size, (long)fret);
             CF_CFDP_SetTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_read;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_read;
             success = false;
             break;
         }
@@ -765,7 +765,7 @@ void CF_CFDP_R2_Recv_fin_ack(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_FINACK, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid fin-ack",
                           (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                           (unsigned long)t->history->seq_num);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
     }
 }
 
@@ -807,7 +807,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                                       (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                                       (unsigned long)t->history->seq_num, (unsigned long)t->fsize,
                                       (unsigned long)t->state_data.r.r2.eof_size);
-                    ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_size_mismatch;
+                    ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_size_mismatch;
                     CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILE_SIZE_ERROR);
                     success = false;
                 }
@@ -831,7 +831,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                                       (unsigned long)t->history->seq_num, (long)status);
                     t->fd = OS_OBJECT_ID_UNDEFINED;
                     CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
-                    ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_rename;
+                    ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_rename;
                     success = false;
                 }
                 else
@@ -845,7 +845,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
                                           (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                                           (unsigned long)t->history->seq_num, (long)ret);
                         CF_CFDP_R2_SetFinTxnStatus(t, CF_TxnStatus_FILESTORE_REJECTION);
-                        ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
+                        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open;
                         t->fd   = OS_OBJECT_ID_UNDEFINED; /* just in case */
                         success = false;
                     }
@@ -865,7 +865,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_MD, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid md received",
                               (t->state == CF_TxnState_R2), (unsigned long)t->history->src_eid,
                               (unsigned long)t->history->seq_num);
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
             /* do nothing here, since it will be NAK'd again later */
         }
     }
@@ -945,7 +945,7 @@ void CF_CFDP_R_SendInactivityEvent(CF_Transaction_t *t)
     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_INACT_TIMER, CFE_EVS_EventType_ERROR,
                       "CF R%d(%lu:%lu): inactivity timer expired", (t->state == CF_TxnState_R2),
                       (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
-    ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.inactivity_timer;
+    ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.inactivity_timer;
 }
 
 /*----------------------------------------------------------------
@@ -1036,7 +1036,7 @@ void CF_CFDP_R_Tick(CF_Transaction_t *t, int *cont /* unused */)
                                           "CF R2(%lu:%lu): ACK limit reached, no fin-ack",
                                           (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
                         CF_CFDP_SetTxnStatus(t, CF_TxnStatus_ACK_LIMIT_NO_FIN);
-                        ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit;
+                        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.ack_limit;
                         CF_CFDP_R2_Reset(t);
                         success = false;
                     }

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -171,7 +171,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 by
                                   "CF S%d(%lu:%lu): error seeking to offset %ld, got %ld", (t->state == CF_TxnState_S2),
                                   (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num, (long)foffs,
                                   (long)status);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek;
                 success = false;
             }
         }
@@ -185,7 +185,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 by
                                   "CF S%d(%lu:%lu): error reading bytes: expected %ld, got %ld",
                                   (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,
                                   (unsigned long)t->history->seq_num, (long)actual_bytes, (long)status);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_read;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_read;
                 success = false;
             }
         }
@@ -207,7 +207,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *t, uint32 foffs, uint32 by
             }
             else
             {
-                CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes += actual_bytes;
+                CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes += actual_bytes;
 
                 CF_Assert((foffs + actual_bytes) <= t->fsize); /* sanity check */
                 if (calc_crc)
@@ -355,7 +355,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
                               "CF S%d(%lu:%lu): file %s already open", (t->state == CF_TxnState_S2),
                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
                               t->history->fnames.src_filename);
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open;
             success = false;
         }
 
@@ -368,7 +368,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
                                   "CF S%d(%lu:%lu): failed to open file %s, error=%ld", (t->state == CF_TxnState_S2),
                                   (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num,
                                   t->history->fnames.src_filename, (long)ret);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open;
                 t->fd   = OS_OBJECT_ID_UNDEFINED; /* just in case */
                 success = false;
             }
@@ -383,7 +383,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
                                   "CF S%d(%lu:%lu): failed to seek end file %s, error=%ld",
                                   (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,
                                   (unsigned long)t->history->seq_num, t->history->fnames.src_filename, (long)status);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek;
                 success = false;
             }
         }
@@ -399,7 +399,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *t)
                                   "CF S%d(%lu:%lu): failed to seek begin file %s, got %ld",
                                   (t->state == CF_TxnState_S2), (unsigned long)t->history->src_eid,
                                   (unsigned long)t->history->seq_num, t->history->fnames.src_filename, (long)status);
-                ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek;
+                ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek;
                 success = false;
             }
         }
@@ -528,7 +528,8 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
             }
         }
 
-        CF_AppData.hk.channel_hk[t->chan_num].counters.recv.nak_segment_requests += nak->segment_list.num_segments;
+        CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.nak_segment_requests +=
+            nak->segment_list.num_segments;
         if (bad_sr)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INVALID_SR, CFE_EVS_EventType_ERROR,
@@ -541,7 +542,7 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_NAK, CFE_EVS_EventType_ERROR,
                           "CF S%d(%lu:%lu): received invalid NAK PDU", (t->state == CF_TxnState_S2),
                           (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
     }
 }
 
@@ -584,7 +585,7 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *t, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_EOF, CFE_EVS_EventType_ERROR,
                           "CF S%d(%lu:%lu): received invalid EOF PDU", (t->state == CF_TxnState_S2),
                           (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
-        ++CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error;
+        ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error;
     }
 }
 
@@ -713,7 +714,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
                               (unsigned long)t->history->seq_num);
             CF_CFDP_SetTxnStatus(t, CF_TxnStatus_INACTIVITY_DETECTED);
 
-            ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.inactivity_timer;
+            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.inactivity_timer;
             CF_CFDP_S_Reset(t);
         }
         else
@@ -736,7 +737,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *t, int *cont /* unused */)
                                               "CF S2(%lu:%lu), ack limit reached, no eof-ack",
                                               (unsigned long)t->history->src_eid, (unsigned long)t->history->seq_num);
                             CF_CFDP_SetTxnStatus(t, CF_TxnStatus_ACK_LIMIT_NO_EOF);
-                            ++CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit;
+                            ++CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.ack_limit;
 
                             /* no reason to reset this timer, as it isn't used again */
                             CF_CFDP_S_Reset(t);

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -85,7 +85,7 @@ CF_Logical_PduBuffer_t *CF_CFDP_MsgOutGet(const CF_Transaction_t *t, bool silent
         success = false;
     }
 
-    if (success && !CF_AppData.hk.channel_hk[t->chan_num].frozen && !t->flags.com.suspended)
+    if (success && !CF_AppData.HkPacket.channel_hk[t->chan_num].frozen && !t->flags.com.suspended)
     {
         /* first, check if there's room in the pipe for the message we want to build */
         if (OS_ObjectIdDefined(c->sem_id))
@@ -160,7 +160,7 @@ void CF_CFDP_Send(uint8 chan_num, const CF_Logical_PduBuffer_t *ph)
     CFE_MSG_SetMsgTime(&CF_AppData.engine.out.msg->Msg, CFE_TIME_GetTime());
     CFE_SB_TransmitBuffer(CF_AppData.engine.out.msg, true);
 
-    ++CF_AppData.hk.channel_hk[chan_num].counters.sent.pdu;
+    ++CF_AppData.HkPacket.channel_hk[chan_num].counters.sent.pdu;
 
     CF_AppData.engine.out.msg = NULL;
 }
@@ -252,7 +252,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
                         }
 
                         /* NOTE: recv and recv_spurious will both be incremented */
-                        ++CF_AppData.hk.channel_hk[chan_num].counters.recv.spurious;
+                        ++CF_AppData.HkPacket.channel_hk[chan_num].counters.recv.spurious;
                     }
 
                     CFE_ES_PerfLogExit(CF_PERF_ID_PDURCVD(chan_num));
@@ -264,7 +264,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *c)
                 if (ph->pdu_header.destination_eid == CF_AppData.config_table->local_eid)
                 {
                     /* we didn't find a match, so assign it to a transaction */
-                    if (CF_AppData.hk.channel_hk[chan_num].q_size[CF_QueueIdx_RX] == CF_MAX_SIMULTANEOUS_RX)
+                    if (CF_AppData.HkPacket.channel_hk[chan_num].q_size[CF_QueueIdx_RX] == CF_MAX_SIMULTANEOUS_RX)
                     {
                         CFE_EVS_SendEvent(
                             CF_EID_ERR_CFDP_RX_DROPPED, CFE_EVS_EventType_ERROR,

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -48,7 +48,7 @@ void CF_CmdNoop(CFE_SB_Buffer_t *msg)
 {
     CFE_EVS_SendEvent(CF_EID_INF_CMD_NOOP, CFE_EVS_EventType_INFORMATION, "CF: No-Op received, Version %d.%d.%d.%d",
                       CF_MAJOR_VERSION, CF_MINOR_VERSION, CF_REVISION, CF_MISSION_REV);
-    ++CF_AppData.hk.counters.cmd;
+    ++CF_AppData.HkPacket.CommandCounter;
 }
 
 /*----------------------------------------------------------------
@@ -70,7 +70,7 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_RESET_INVALID, CFE_EVS_EventType_ERROR,
                           "CF: Received RESET COUNTERS command with invalid parameter %d", param);
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
     else
     {
@@ -81,8 +81,9 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
         if ((param == CF_Reset_all) || (param == CF_Reset_command))
         {
             /* command counters */
-            memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
-            acc = 0; /* don't increment accept counter on command counter reset */
+            CF_AppData.HkPacket.CommandCounter      = 0;
+            CF_AppData.HkPacket.CommandErrorCounter = 0;
+            acc                                     = 0; /* don't increment accept counter on command counter reset */
         }
 
         /* if the param is CF_Reset_fault, or all counters */
@@ -90,8 +91,8 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
         {
             /* fault counters */
             for (i = 0; i < CF_NUM_CHANNELS; ++i)
-                memset(&CF_AppData.hk.channel_hk[i].counters.fault, 0,
-                       sizeof(CF_AppData.hk.channel_hk[i].counters.fault));
+                memset(&CF_AppData.HkPacket.channel_hk[i].counters.fault, 0,
+                       sizeof(CF_AppData.HkPacket.channel_hk[i].counters.fault));
         }
 
         /* if the param is CF_Reset_up, or all counters */
@@ -99,8 +100,8 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
         {
             /* up counters */
             for (i = 0; i < CF_NUM_CHANNELS; ++i)
-                memset(&CF_AppData.hk.channel_hk[i].counters.recv, 0,
-                       sizeof(CF_AppData.hk.channel_hk[i].counters.recv));
+                memset(&CF_AppData.HkPacket.channel_hk[i].counters.recv, 0,
+                       sizeof(CF_AppData.HkPacket.channel_hk[i].counters.recv));
         }
 
         /* if the param is CF_Reset_down, or all counters */
@@ -108,13 +109,13 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg)
         {
             /* down counters */
             for (i = 0; i < CF_NUM_CHANNELS; ++i)
-                memset(&CF_AppData.hk.channel_hk[i].counters.sent, 0,
-                       sizeof(CF_AppData.hk.channel_hk[i].counters.sent));
+                memset(&CF_AppData.HkPacket.channel_hk[i].counters.sent, 0,
+                       sizeof(CF_AppData.HkPacket.channel_hk[i].counters.sent));
         }
 
         if (acc)
         {
-            ++CF_AppData.hk.counters.cmd;
+            ++CF_AppData.HkPacket.CommandCounter;
         }
     }
 }
@@ -140,7 +141,7 @@ void CF_CmdTxFile(CFE_SB_Buffer_t *msg)
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_BAD_PARAM, CFE_EVS_EventType_ERROR,
                           "CF: bad parameter in CF_CmdTxFile(): chan=%u, class=%u keep=%u", (unsigned int)tx->chan_num,
                           (unsigned int)tx->cfdp_class, (unsigned int)tx->keep);
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
         return;
     }
 
@@ -153,12 +154,12 @@ void CF_CmdTxFile(CFE_SB_Buffer_t *msg)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_TX_FILE, CFE_EVS_EventType_INFORMATION,
                           "CF: file transfer successfully initiated");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_TX_FILE, CFE_EVS_EventType_ERROR, "CF: file transfer initiation failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -183,7 +184,7 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg)
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_BAD_PARAM, CFE_EVS_EventType_ERROR,
                           "CF: bad parameter in CF_CmdPlaybackDir(): chan=%u, class=%u keep=%u",
                           (unsigned int)tx->chan_num, (unsigned int)tx->cfdp_class, (unsigned int)tx->keep);
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
         return;
     }
 
@@ -196,13 +197,13 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_PLAYBACK_DIR, CFE_EVS_EventType_INFORMATION,
                           "CF: directory playback initiation successful");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_PLAYBACK_DIR, CFE_EVS_EventType_ERROR,
                           "CF: directory playback initiation failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -250,7 +251,7 @@ CFE_Status_t CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_Chan
 CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
 {
     /* no need to bounds check chan_num, done in caller */
-    CF_AppData.hk.channel_hk[chan_num].frozen = context->barg;
+    CF_AppData.HkPacket.channel_hk[chan_num].frozen = context->barg;
     return CFE_SUCCESS;
 }
 
@@ -267,12 +268,12 @@ void CF_CmdFreeze(CFE_SB_Buffer_t *msg)
     if (CF_DoChanAction((CF_UnionArgsCmd_t *)msg, "freeze", (CF_ChanActionFn_t)CF_DoFreezeThaw, &barg) == CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_FREEZE, CFE_EVS_EventType_INFORMATION, "CF: freeze successful");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_FREEZE, CFE_EVS_EventType_ERROR, "CF: freeze cmd failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -289,12 +290,12 @@ void CF_CmdThaw(CFE_SB_Buffer_t *msg)
     if (CF_DoChanAction((CF_UnionArgsCmd_t *)msg, "thaw", (CF_ChanActionFn_t)CF_DoFreezeThaw, &barg) == CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_THAW, CFE_EVS_EventType_INFORMATION, "CF: thaw successful");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_THAW, CFE_EVS_EventType_ERROR, "CF: thaw cmd failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -416,20 +417,20 @@ void CF_DoSuspRes(CF_TransactionCmd_t *cmd, uint8 action)
         /* A single transaction was mached, and it was already set the same way */
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_SUSPRES_SAME, CFE_EVS_EventType_ERROR,
                           "CF: %s cmd: setting suspend flag to current value of %d", msgstr[action], action);
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
     else if (ret <= 0)
     {
         /* No transaction was matched for the given combination of chan + eid + ts  */
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_SUSPRES_CHAN, CFE_EVS_EventType_ERROR, "CF: %s cmd: no transaction found",
                           msgstr[action]);
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_SUSPRES, CFE_EVS_EventType_INFORMATION,
                           "CF: %s cmd: setting suspend flag to %d", msgstr[action], action);
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
 }
 
@@ -478,13 +479,13 @@ void CF_CmdCancel(CFE_SB_Buffer_t *msg)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_CANCEL, CFE_EVS_EventType_INFORMATION,
                           "CF: cancel transaction successfully initiated");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         /* No transaction was matched for the given combination of chan + eid + ts  */
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_CANCEL_CHAN, CFE_EVS_EventType_ERROR, "CF: cancel cmd: no transaction found");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -510,14 +511,14 @@ void CF_CmdAbandon(CFE_SB_Buffer_t *msg)
     if (CF_TsnChanAction((CF_TransactionCmd_t *)msg, "abandon", CF_CmdAbandon_Txn, NULL) > 0)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_ABANDON, CFE_EVS_EventType_INFORMATION, "CF: abandon successful");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         /* No transaction was matched for the given combination of chan + eid + ts  */
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_ABANDON_CHAN, CFE_EVS_EventType_ERROR,
                           "CF: abandon cmd: no transaction found");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -548,12 +549,12 @@ void CF_CmdEnableDequeue(CFE_SB_Buffer_t *msg)
                         &barg) == CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_ENABLE_DEQUEUE, CFE_EVS_EventType_INFORMATION, "CF: dequeue enabled");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_DEQUEUE, CFE_EVS_EventType_ERROR, "CF: enable dequeue cmd failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -571,12 +572,12 @@ void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg)
                         &barg) == CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_DISABLE_DEQUEUE, CFE_EVS_EventType_INFORMATION, "CF: dequeue disabled");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_DISABLE_DEQUEUE, CFE_EVS_EventType_ERROR, "CF: disable dequeue cmd failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -627,13 +628,13 @@ void CF_CmdEnablePolldir(CFE_SB_Buffer_t *msg)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_ENABLE_POLLDIR, CFE_EVS_EventType_INFORMATION,
                           "CF: enabled polling directory");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_POLLDIR, CFE_EVS_EventType_ERROR,
                           "CF: enable polling directory cmd failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -652,13 +653,13 @@ void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_DISABLE_POLLDIR, CFE_EVS_EventType_INFORMATION,
                           "CF: disabled polling directory");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_DISABLE_POLLDIR, CFE_EVS_EventType_ERROR,
                           "CF: disable polling directory cmd failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -750,12 +751,12 @@ void CF_CmdPurgeQueue(CFE_SB_Buffer_t *msg)
         CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_PURGE_QUEUE, CFE_EVS_EventType_INFORMATION, "CF: queue purged");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_PURGE_QUEUE, CFE_EVS_EventType_ERROR, "CF: purge queue cmd failed");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -777,7 +778,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
     if (wq->chan >= CF_NUM_CHANNELS)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_CHAN, CFE_EVS_EventType_ERROR, "CF: write queue invalid channel arg");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
         success = false;
     }
     /* only invalid combination is up direction, pending queue */
@@ -785,7 +786,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_ARGS, CFE_EVS_EventType_ERROR,
                           "CF: write queue invalid command parameters");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
         success = false;
     }
     else
@@ -797,7 +798,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_OPEN, CFE_EVS_EventType_ERROR, "CF: write queue failed to open file %s",
                               wq->filename);
-            ++CF_AppData.hk.counters.err;
+            ++CF_AppData.HkPacket.CommandErrorCounter;
             success = false;
         }
     }
@@ -814,7 +815,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
                 CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_RX, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write CF_QueueIdx_RX data");
                 CF_WrappedClose(fd);
-                ++CF_AppData.hk.counters.err;
+                ++CF_AppData.HkPacket.CommandErrorCounter;
                 success = false;
             }
         }
@@ -827,7 +828,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
                 CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEHIST_RX, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write history RX data");
                 CF_WrappedClose(fd);
-                ++CF_AppData.hk.counters.err;
+                ++CF_AppData.HkPacket.CommandErrorCounter;
                 success = false;
             }
         }
@@ -849,7 +850,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
                     CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_TX, CFE_EVS_EventType_ERROR,
                                       "CF: write queue failed to write q index %d", qs[i]);
                     CF_WrappedClose(fd);
-                    ++CF_AppData.hk.counters.err;
+                    ++CF_AppData.HkPacket.CommandErrorCounter;
                     success = false;
                     break;
                 }
@@ -865,7 +866,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
                 CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_PEND, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write pending queue");
                 CF_WrappedClose(fd);
-                ++CF_AppData.hk.counters.err;
+                ++CF_AppData.HkPacket.CommandErrorCounter;
                 success = false;
             }
         }
@@ -879,7 +880,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
                 CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEHIST_TX, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write CF_QueueIdx_TX data");
                 CF_WrappedClose(fd);
-                ++CF_AppData.hk.counters.err;
+                ++CF_AppData.HkPacket.CommandErrorCounter;
                 success = false;
             }
         }
@@ -888,7 +889,7 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
     if (success)
     {
         CFE_EVS_SendEvent(CF_EID_INF_CMD_WQ, CFE_EVS_EventType_INFORMATION, "CF: write queue successful");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
 }
 
@@ -1074,11 +1075,11 @@ void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
 
     if (status == CFE_SUCCESS)
     {
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -1119,20 +1120,20 @@ void CF_CmdEnableEngine(CFE_SB_Buffer_t *msg)
         if (CF_CFDP_InitEngine() == CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_EID_INF_CMD_ENABLE_ENGINE, CFE_EVS_EventType_INFORMATION, "CF: enabled CFDP engine");
-            ++CF_AppData.hk.counters.cmd;
+            ++CF_AppData.HkPacket.CommandCounter;
         }
         else
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_ENGINE, CFE_EVS_EventType_ERROR,
                               "CF: failed to re-initialize and enable CFDP engine");
-            ++CF_AppData.hk.counters.err;
+            ++CF_AppData.HkPacket.CommandErrorCounter;
         }
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENG_ALREADY_ENA, CFE_EVS_EventType_ERROR,
                           "CF: received enable engine command while engine already enabled");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -1148,13 +1149,13 @@ void CF_CmdDisableEngine(CFE_SB_Buffer_t *msg)
     {
         CF_CFDP_DisableEngine();
         CFE_EVS_SendEvent(CF_EID_INF_CMD_DISABLE_ENGINE, CFE_EVS_EventType_INFORMATION, "CF: disabled CFDP engine");
-        ++CF_AppData.hk.counters.cmd;
+        ++CF_AppData.HkPacket.CommandCounter;
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENG_ALREADY_DIS, CFE_EVS_EventType_ERROR,
                           "CF: received disable engine command while engine already disabled");
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }
 
@@ -1243,13 +1244,13 @@ void CF_ProcessGroundCommand(CFE_SB_Buffer_t *msg)
             CFE_EVS_SendEvent(CF_EID_ERR_CMD_GCMD_LEN, CFE_EVS_EventType_ERROR,
                               "CF: invalid ground command length for command 0x%02x, expected %d got %zd", cmd,
                               expected_lengths[cmd], len);
-            ++CF_AppData.hk.counters.err;
+            ++CF_AppData.HkPacket.CommandErrorCounter;
         }
     }
     else
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CMD_GCMD_CC, CFE_EVS_EventType_ERROR,
                           "CF: invalid ground command packet cmd_code=0x%02x", cmd);
-        ++CF_AppData.hk.counters.err;
+        ++CF_AppData.HkPacket.CommandErrorCounter;
     }
 }

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -123,39 +123,39 @@ static inline void CF_DequeueTransaction(CF_Transaction_t *t)
 {
     CF_Assert(t && (t->chan_num < CF_NUM_CHANNELS));
     CF_CList_Remove(&CF_AppData.engine.channels[t->chan_num].qs[t->flags.com.q_index], &t->cl_node);
-    CF_Assert(CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index]); /* sanity check */
-    --CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
+    CF_Assert(CF_AppData.HkPacket.channel_hk[t->chan_num].q_size[t->flags.com.q_index]); /* sanity check */
+    --CF_AppData.HkPacket.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
 }
 
 static inline void CF_MoveTransaction(CF_Transaction_t *t, CF_QueueIdx_t q)
 {
     CF_Assert(t && (t->chan_num < CF_NUM_CHANNELS));
     CF_CList_Remove(&CF_AppData.engine.channels[t->chan_num].qs[t->flags.com.q_index], &t->cl_node);
-    CF_Assert(CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index]); /* sanity check */
-    --CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
+    CF_Assert(CF_AppData.HkPacket.channel_hk[t->chan_num].q_size[t->flags.com.q_index]); /* sanity check */
+    --CF_AppData.HkPacket.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
     CF_CList_InsertBack(&CF_AppData.engine.channels[t->chan_num].qs[q], &t->cl_node);
     t->flags.com.q_index = q;
-    ++CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
+    ++CF_AppData.HkPacket.channel_hk[t->chan_num].q_size[t->flags.com.q_index];
 }
 
 static inline void CF_CList_Remove_Ex(CF_Channel_t *c, CF_QueueIdx_t queueidx, CF_CListNode_t *node)
 {
     CF_CList_Remove(&c->qs[queueidx], node);
-    CF_Assert(CF_AppData.hk.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx]); /* sanity check */
-    --CF_AppData.hk.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx];
+    CF_Assert(CF_AppData.HkPacket.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx]); /* sanity check */
+    --CF_AppData.HkPacket.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx];
 }
 
 static inline void CF_CList_InsertAfter_Ex(CF_Channel_t *c, CF_QueueIdx_t queueidx, CF_CListNode_t *start,
                                            CF_CListNode_t *after)
 {
     CF_CList_InsertAfter(&c->qs[queueidx], start, after);
-    ++CF_AppData.hk.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx];
+    ++CF_AppData.HkPacket.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx];
 }
 
 static inline void CF_CList_InsertBack_Ex(CF_Channel_t *c, CF_QueueIdx_t queueidx, CF_CListNode_t *node)
 {
     CF_CList_InsertBack(&c->qs[queueidx], node);
-    ++CF_AppData.hk.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx];
+    ++CF_AppData.HkPacket.channel_hk[c - CF_AppData.engine.channels].q_size[queueidx];
 }
 
 /************************************************************************/

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -575,7 +575,7 @@ void Test_CF_ProcessMsg_UnrecognizedCommandEnterDefaultPath(void)
     CF_ProcessMsg(arg_msg);
 
     /* Assert */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_CMD_LENGTH);
 }
@@ -689,7 +689,7 @@ void Test_CF_AppMain_RunLoopCallTo_CFE_SB_ReceiveBuffer_Returns_CFE_SUCCESS_AndV
     /* Assert for CF_Init call and CF_ProcessMsg */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     /* Assert for CF_ProcessMsg */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 /*******************************************************************************

--- a/unit-test/cf_cfdp_dispatch_tests.c
+++ b/unit-test/cf_cfdp_dispatch_tests.c
@@ -154,7 +154,7 @@ void Test_CF_CFDP_R_DispatchRecv(void)
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     ph->fdirective.directive_code = CF_CFDP_FileDirective_INVALID_MAX;
     UtAssert_VOIDCALL(CF_CFDP_R_DispatchRecv(t, ph, &dispatch, NULL));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.spurious, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_DC_INV);
 
     /* file data with error */
@@ -162,7 +162,7 @@ void Test_CF_CFDP_R_DispatchRecv(void)
     ph->pdu_header.pdu_type = 1;
     UT_SetDeferredRetcode(UT_KEY(CF_TxnStatus_IsError), 1, true);
     UtAssert_VOIDCALL(CF_CFDP_R_DispatchRecv(t, ph, &dispatch, NULL));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.dropped, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.dropped, 1);
 
     /* test actual dispatch */
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
@@ -206,7 +206,7 @@ void Test_CF_CFDP_S_DispatchRecv(void)
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     ph->fdirective.directive_code = CF_CFDP_FileDirective_INVALID_MAX;
     UtAssert_VOIDCALL(CF_CFDP_S_DispatchRecv(t, ph, &dispatch));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.spurious, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_DC_INV);
 
     /* file data PDU, not expected in this type of txn */

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -300,7 +300,7 @@ void Test_CF_CFDP_R_Tick(void)
     UT_SetDeferredRetcode(UT_KEY(CF_Timer_Expired), 1, 1);
     UtAssert_VOIDCALL(CF_CFDP_R_Tick(t, &cont));
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 2);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.ack_limit, 1);
 
     /* in R2 state, ack_timer_armed set, timer expires, not in finack substate */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
@@ -376,7 +376,7 @@ void Test_CF_CFDP_R_Init(void)
     t->state = CF_TxnState_R1;
     UtAssert_VOIDCALL(CF_CFDP_R_Init(t));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CREAT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 1);
 
     /* failure of file open, class 2 */
@@ -385,7 +385,7 @@ void Test_CF_CFDP_R_Init(void)
     t->state = CF_TxnState_R2;
     UtAssert_VOIDCALL(CF_CFDP_R_Init(t));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CREAT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open, 2);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 }
 
@@ -464,7 +464,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     t->crc.result = 0xdeadbeef;
     UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(t, 0x1badc0de), 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.crc_mismatch, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.crc_mismatch, 1);
 
     /* CRC mismatch, class 2 */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, NULL);
@@ -472,7 +472,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     t->crc.result = 0xdeadbeef;
     UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(t, 0x2badc0de), 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.crc_mismatch, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.crc_mismatch, 2);
 
     /* CRC match */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, NULL);
@@ -512,7 +512,7 @@ void Test_CF_CFDP_R2_Complete(void)
     UtAssert_BOOL_TRUE(t->flags.rx.send_fin);
     UtAssert_BOOL_TRUE(t->flags.rx.complete);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_NAK_LIMIT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.nak_limit, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.nak_limit, 1);
 
     /* test with md_recv - with no more setup this only sets filedata state */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, &config);
@@ -552,7 +552,7 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_WrappedWrite), fd->data_len);
     UtAssert_INT32_EQ(CF_CFDP_R_ProcessFd(t, ph), 0);
     UtAssert_UINT32_EQ(t->state_data.r.cached_pos, 100);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.file_data_bytes, 100);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.file_data_bytes, 100);
     UtAssert_STUB_COUNT(CF_WrappedLseek, 0);
     UtAssert_STUB_COUNT(CF_WrappedWrite, 1);
 
@@ -564,7 +564,7 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_WrappedLseek), fd->offset);
     UtAssert_INT32_EQ(CF_CFDP_R_ProcessFd(t, ph), 0);
     UtAssert_UINT32_EQ(t->state_data.r.cached_pos, 300);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.file_data_bytes, 200);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.file_data_bytes, 200);
     UtAssert_STUB_COUNT(CF_WrappedLseek, 1);
     UtAssert_STUB_COUNT(CF_WrappedWrite, 2);
     UtAssert_UINT32_EQ(t->state_data.r.cached_pos, 300);
@@ -594,8 +594,8 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
 
     /* these stats should have been updated during the course of this test */
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_write, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_write, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_seek, 1);
 }
 
 void Test_CF_CFDP_R_SubstateRecvEof(void)
@@ -635,8 +635,8 @@ void Test_CF_CFDP_R_SubstateRecvEof(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_EOF);
 
     /* these counters should have been updated during the test */
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_size_mismatch, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_size_mismatch, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].counters.recv.error, 1);
 }
 
 void Test_CF_CFDP_R1_SubstateRecvEof(void)
@@ -965,7 +965,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_READ);
     UtAssert_BOOL_FALSE(t->flags.com.crc_calc);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_read, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_read, 1);
 
     /* failure of lseek */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, &config);
@@ -978,7 +978,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_SEEK_CRC);
     UtAssert_BOOL_FALSE(t->flags.com.crc_calc);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek, 1);
 }
 
 void Test_CF_CFDP_R2_SubstateSendFin(void)
@@ -1031,7 +1031,7 @@ void Test_CF_CFDP_R2_Recv_fin_ack(void)
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvAck), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_R2_Recv_fin_ack(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_FINACK);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error, 1);
 }
 
 void Test_CF_CFDP_R2_RecvMd(void)
@@ -1091,7 +1091,7 @@ void Test_CF_CFDP_R2_RecvMd(void)
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvMd), 1, CF_PDU_METADATA_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_MD);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error, 1);
 }
 
 void Test_CF_CFDP_R_SendInactivityEvent(void)
@@ -1104,7 +1104,7 @@ void Test_CF_CFDP_R_SendInactivityEvent(void)
     /* nominal */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &t, NULL);
     UtAssert_VOIDCALL(CF_CFDP_R_SendInactivityEvent(t));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.inactivity_timer, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.inactivity_timer, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_INACT_TIMER);
 }
 

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -246,7 +246,7 @@ void Test_CF_CFDP_S_Tick(void)
     UtAssert_VOIDCALL(CF_CFDP_S_Tick(t, &cont));
     UtAssert_STUB_COUNT(CF_Timer_Tick, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_INACT_TIMER);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.inactivity_timer, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.inactivity_timer, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 1);
 
     /* in CF_TxnState_S2, ack_timer_armed */
@@ -284,7 +284,7 @@ void Test_CF_CFDP_S_Tick(void)
     t->state_data.s.s2.acknak_count     = 9;
     UtAssert_VOIDCALL(CF_CFDP_S_Tick(t, &cont));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_ACK_LIMIT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.ack_limit, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.ack_limit, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 2);
 
     /* same, with CF_CFDP_S_SendEof no message */
@@ -406,7 +406,7 @@ void Test_CF_CFDP_S2_SubstateSendEof(void)
 
     /* nominal, this dequeues a transaction so q_size must be nonzero */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
-    CF_AppData.hk.channel_hk[t->chan_num].q_size[t->flags.com.q_index] = 10;
+    CF_AppData.HkPacket.channel_hk[t->chan_num].q_size[t->flags.com.q_index] = 10;
     UtAssert_VOIDCALL(CF_CFDP_S2_SubstateSendEof(t));
     UtAssert_UINT32_EQ(t->state_data.s.sub_state, CF_TxSubState_WAIT_FOR_EOF_ACK);
     UtAssert_BOOL_TRUE(t->flags.com.ack_timer_armed);
@@ -430,7 +430,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     /* failure of CF_CFDP_ConstructPduHeader */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), 0);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* nominal, smaller than chunk, no CRC */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
@@ -439,7 +439,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedRead), 1, read_size);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, false), read_size);
     cumulative_read += read_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* nominal, larger than PDU, no CRC */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
@@ -449,7 +449,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedRead), 1, read_size);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size * 2, false), read_size);
     cumulative_read += read_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
     UtAssert_STUB_COUNT(CF_CRC_Digest, 0);
 
     /* nominal, larger than chunk, with CRC */
@@ -460,7 +460,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedRead), 1, config->outgoing_file_chunk_size);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), config->outgoing_file_chunk_size);
     cumulative_read += config->outgoing_file_chunk_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
     UtAssert_STUB_COUNT(CF_CRC_Digest, 1);
 
     /* no message available */
@@ -470,7 +470,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     config->outgoing_file_chunk_size = read_size;
     t->fsize                         = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), 0);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* other send error */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
@@ -480,7 +480,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     t->fsize                         = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), -1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEND_FD);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* read w/failure */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
@@ -488,8 +488,8 @@ void Test_CF_CFDP_S_SendFileData(void)
     config->outgoing_file_chunk_size = read_size;
     t->fsize                         = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), -1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_read, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_read, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_READ);
 
     /* require lseek */
@@ -501,7 +501,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     t->fsize                         = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), read_size);
     cumulative_read += read_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* lseek w/failure */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, &config);
@@ -509,8 +509,8 @@ void Test_CF_CFDP_S_SendFileData(void)
     config->outgoing_file_chunk_size = read_size;
     t->fsize                         = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(t, offset, read_size, true), -1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_FD);
 }
 
@@ -659,7 +659,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(t));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_ALREADY_OPEN);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open, 1);
 
     /* file already open */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &t, NULL);
@@ -676,7 +676,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(t));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_OPEN);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_open, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_open, 2);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* first CF_WrappedLseek fails */
@@ -684,7 +684,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedLseek), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(t));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_END);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek, 1);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* second CF_WrappedLseek fails */
@@ -692,7 +692,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedLseek), 2, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(t));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_BEG);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.fault.file_seek, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.fault.file_seek, 2);
     UtAssert_INT32_EQ(t->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* CF_CFDP_SendMd fails w/ ERROR */
@@ -773,7 +773,7 @@ void Test_CF_CFDP_S2_Nak(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_NAK);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error, 1);
 
     /* nominal, re-send md request (0,0) */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
@@ -782,7 +782,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak->segment_list.segments[0]  = (CF_Logical_SegmentRequest_t) {0, 0};
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(t, ph));
     UtAssert_BOOL_TRUE(t->flags.tx.md_need_send);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.nak_segment_requests, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.nak_segment_requests, 1);
 
     /* nominal, nonzero offsets */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
@@ -792,7 +792,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak->segment_list.segments[1]  = (CF_Logical_SegmentRequest_t) {200, 300};
     t->fsize                       = 300;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(t, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.nak_segment_requests, 3);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.nak_segment_requests, 3);
 
     /* bad segments */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);
@@ -803,7 +803,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak->segment_list.segments[2]  = (CF_Logical_SegmentRequest_t) {400, 0};
     t->fsize                       = 300;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(t, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.nak_segment_requests, 6);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.nak_segment_requests, 6);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_INVALID_SR);
 
     /* bad decode */
@@ -812,7 +812,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak                            = &ph->int_header.nak;
     nak->segment_list.num_segments = 1;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(t, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error, 2);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_NAK);
 }
 
@@ -848,7 +848,7 @@ void Test_CF_CFDP_S2_WaitForEofAck(void)
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvAck), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S2_WaitForEofAck(t, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_EOF);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.error, 1);
 
     /* with error status */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &t, NULL);

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -284,7 +284,7 @@ void Test_CF_CFDP_ReceiveMessage(void)
     ph->fdirective.directive_code = CF_CFDP_FileDirective_FIN;
     c->cur                        = t;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(c));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.spurious, 1);
     UtAssert_STUB_COUNT(CF_CFDP_SendAck, 1);
     UtAssert_NULL(c->cur); /* cleared */
 
@@ -295,9 +295,9 @@ void Test_CF_CFDP_ReceiveMessage(void)
     ph->pdu_header.source_eid     = config->local_eid;
     ph->fdirective.directive_code = CF_CFDP_FileDirective_FIN;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(c));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious, 1); /* no increment */
-    UtAssert_STUB_COUNT(CF_CFDP_SendAck, 1);                                             /* no increment */
-    UtAssert_NULL(c->cur);                                                               /* cleared */
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.spurious, 1); /* no increment */
+    UtAssert_STUB_COUNT(CF_CFDP_SendAck, 1);                                                   /* no increment */
+    UtAssert_NULL(c->cur);                                                                     /* cleared */
 
     /* FIN handling special case, but failure of CF_CFDP_SendAck */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &c, NULL, &t, &config);
@@ -307,8 +307,9 @@ void Test_CF_CFDP_ReceiveMessage(void)
     ph->fdirective.directive_code = CF_CFDP_FileDirective_FIN;
     c->cur                        = t;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(c));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[t->chan_num].counters.recv.spurious, 2); /* this does get increment */
-    UtAssert_ADDRESS_EQ(c->cur, t);                                                      /* not changed */
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[t->chan_num].counters.recv.spurious,
+                       2);          /* this does get increment */
+    UtAssert_ADDRESS_EQ(c->cur, t); /* not changed */
 
     /* recv but not the correct destination_eid */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &c, NULL, &t, &config);
@@ -319,9 +320,9 @@ void Test_CF_CFDP_ReceiveMessage(void)
 
     /* recv correct destination_eid but CF_MAX_SIMULTANEOUS_RX hit */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &c, NULL, &t, &config);
-    CF_AppData.hk.channel_hk[t->chan_num].q_size[CF_QueueIdx_RX] = CF_MAX_SIMULTANEOUS_RX;
-    config->local_eid                                            = 123;
-    ph->pdu_header.destination_eid                               = config->local_eid;
+    CF_AppData.HkPacket.channel_hk[t->chan_num].q_size[CF_QueueIdx_RX] = CF_MAX_SIMULTANEOUS_RX;
+    config->local_eid                                                  = 123;
+    ph->pdu_header.destination_eid                                     = config->local_eid;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(c));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_RX_DROPPED);
 }
@@ -336,7 +337,7 @@ void Test_CF_CFDP_Send(void)
     /* nominal */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, NULL, NULL);
     UtAssert_VOIDCALL(CF_CFDP_Send(UT_CFDP_CHANNEL, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.sent.pdu, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].counters.sent.pdu, 1);
     UtAssert_STUB_COUNT(CFE_MSG_SetSize, 1);
     UtAssert_STUB_COUNT(CFE_SB_TransmitBuffer, 1);
 }
@@ -384,10 +385,10 @@ void Test_CF_CFDP_MsgOutGet(void)
 
     /* channel is frozen */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
     UtAssert_NULL(CF_CFDP_MsgOutGet(t, false));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
 
     /* no msg available from SB */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -479,7 +479,7 @@ void Test_CF_CFDP_RecvIdle(void)
     /* setup for FindUnusedChunks */
     memset(&ut_unused_chunks, 0, sizeof(ut_unused_chunks));
     CF_AppData.engine.channels[UT_CFDP_CHANNEL].cs[CF_Direction_RX] = &ut_unused_chunks.cl_node;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[0]             = 4;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].q_size[0]       = 4;
     UT_SetHandlerFunction(UT_KEY(CF_CList_Pop), UT_AltHandler_GenericPointerReturn, &ut_unused_chunks.cl_node);
 
     /* nominal call, file data, class 1 */
@@ -1015,9 +1015,9 @@ void Test_CF_CFDP_CycleTx(void)
 
     /* need to set dequeue_enabled so it enters the actual logic */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, &c, NULL, &t, &config);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[0] = 10;
-    CF_AppData.engine.enabled                           = 1;
-    config->chan[UT_CFDP_CHANNEL].dequeue_enabled       = 1;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].q_size[0] = 10;
+    CF_AppData.engine.enabled                                 = 1;
+    config->chan[UT_CFDP_CHANNEL].dequeue_enabled             = 1;
 
     /* nominal call, w/c->cur non-null */
     c->cur = t;
@@ -1139,14 +1139,14 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
 
     /* nominal call, polldir disabled (noop) */
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(c));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
 
     /* nominal call, polldir enabled but interval_sec == 0 */
     /* Will tick because CF_Timer_Expired stub returns 0 by default (not expired) */
     pdcfg->enabled = 1;
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(c));
     UtAssert_BOOL_FALSE(poll->timer_set);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
     UtAssert_STUB_COUNT(CF_Timer_Tick, 1);
 
     /* with interval_sec nonzero the timer should get set, but not tick */
@@ -1154,7 +1154,7 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(c));
     UtAssert_BOOL_TRUE(poll->timer_set);
     UtAssert_STUB_COUNT(CF_Timer_Tick, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
 
     /* call again should tick */
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(c));
@@ -1166,7 +1166,7 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(c));
     UtAssert_BOOL_FALSE(poll->timer_set);
     UtAssert_BOOL_TRUE(poll->pb.busy);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
 
     /* make an error occur in CF_CFDP_PlaybackDir_Initiate() */
     poll->pb.busy   = false; /* above would have set it true */
@@ -1196,7 +1196,7 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
     /* test that call to CF_CFDP_UpdatePollPbCounted will decrement back to 0 again */
     pdcfg->enabled = 0;
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(c));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
 }
 
 void Test_CF_CFDP_ProcessPlaybackDirectory(void)
@@ -1339,11 +1339,11 @@ void Test_CF_CFDP_CycleEngine(void)
     UtAssert_VOIDCALL(CF_CFDP_CycleEngine());
 
     /* enabled but frozen */
-    CF_AppData.engine.enabled                        = 1;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
+    CF_AppData.engine.enabled                              = 1;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
     UtAssert_VOIDCALL(CF_CFDP_CycleEngine());
 
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
     UtAssert_VOIDCALL(CF_CFDP_CycleEngine());
 }
 
@@ -1362,7 +1362,7 @@ void Test_CF_CFDP_ResetTransaction(void)
 
     /* nominal call */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &t, NULL);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[t->flags.com.q_index] = 10;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].q_size[t->flags.com.q_index] = 10;
     UtAssert_VOIDCALL(CF_CFDP_ResetTransaction(t, 1));
     UtAssert_STUB_COUNT(CF_FreeTransaction, 1);
 

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -175,9 +175,9 @@ void Test_CF_CmdNoop_SendNoopEventAndAcceptCommand(void)
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg = NULL;
 
-    uint16 initial_hk_cmd_counter = Any_uint16();
+    uint8 initial_hk_cmd_counter = Any_uint8();
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdNoop(arg_msg);
@@ -186,7 +186,7 @@ void Test_CF_CmdNoop_SendNoopEventAndAcceptCommand(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 /*******************************************************************************
@@ -201,13 +201,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     msg->data.byte[0] = 5; /* 5 is size of 'names' */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -216,7 +216,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCommand(void)
@@ -225,13 +225,13 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     msg->data.byte[0] = Any_uint8_GreaterThan(5); /* 5 is size of 'names' */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -240,7 +240,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSendEvent(void)
@@ -253,8 +253,8 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
     memset(&utbuf, 0, sizeof(utbuf));
 
     msg->data.byte[0] = CF_Reset_command;
-    CF_AppData.hk.counters.cmd = Any_uint16_Except(0);
-    CF_AppData.hk.counters.err = Any_uint16_Except(0);
+    CF_AppData.HkPacket.CommandCounter      = Any_uint16_Except(0);
+    CF_AppData.HkPacket.CommandErrorCounter = Any_uint16_Except(0);
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -262,8 +262,8 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_command_AndResetHkCmdAndErrCountSe
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
-    UtAssert_ZERO(CF_AppData.hk.counters.cmd);
-    UtAssert_ZERO(CF_AppData.hk.counters.err);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandCounter);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandErrorCounter);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEventAndAcceptCommand(void)
@@ -273,7 +273,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     int                       i                      = 0;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -281,21 +281,21 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
     }
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -306,24 +306,24 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_fault_ResetAllHkFaultCountSendEven
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_open);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_read);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_seek);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_write);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_rename);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.directory_read);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.nak_limit);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.ack_limit);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.fault.spare);
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.fault, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.fault),
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_open);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_read);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_seek);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_write);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_rename);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.directory_read);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.crc_mismatch);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.file_size_mismatch);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.nak_limit);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.ack_limit);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.inactivity_timer);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.fault.spare);
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.fault, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.fault),
                              "fault channel %d was completely cleared to 0", i);
     }
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEventAndAcceptCommand(void)
@@ -333,7 +333,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     int                       i                      = 0;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -341,15 +341,15 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
     }
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -360,18 +360,18 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_up_AndResetAllHkRecvCountSendEvent
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.pdu);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.error);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.spurious);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.pdu);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests);
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.recv, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.recv),
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.file_data_bytes);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.error);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.spurious);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.recv.nak_segment_requests);
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.recv, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.recv),
                              "recv channel %d was completely cleared to 0", i);
     }
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEventAcceptCommand(void)
@@ -381,7 +381,7 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
     uint8                     i                      = 0;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -389,12 +389,12 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
     }
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdReset(arg_msg);
@@ -405,15 +405,15 @@ void Test_CF_CmdReset_tests_SWhenCommandByteIs_down_AndResetAllHkSentCountendEve
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests);
-        UtAssert_ZERO(CF_AppData.hk.channel_hk[i].counters.sent.pdu);
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.sent, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.sent),
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.sent.file_data_bytes);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.sent.nak_segment_requests);
+        UtAssert_ZERO(CF_AppData.HkPacket.channel_hk[i].counters.sent.pdu);
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.sent, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.sent),
                              "sent channel %d was completely cleared to 0", i);
     }
     /* Assert to show counter incremented */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(void)
@@ -428,40 +428,40 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
 
     msg->data.byte[0] = CF_Reset_all;
 
-    CF_AppData.hk.counters.cmd = Any_uint16_Except(0);
-    CF_AppData.hk.counters.err = Any_uint16_Except(0);
+    CF_AppData.HkPacket.CommandCounter      = Any_uint16_Except(0);
+    CF_AppData.HkPacket.CommandErrorCounter = Any_uint16_Except(0);
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_open          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_read          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_seek          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_write         = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_rename        = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.directory_read     = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.crc_mismatch       = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.file_size_mismatch = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.nak_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.ack_limit          = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.inactivity_timer   = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.fault.spare              = Any_uint16_Except(0);
     }
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.error                = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.spurious             = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.dropped              = Any_uint16_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.recv.nak_segment_requests = Any_uint32_Except(0);
     }
 
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        CF_AppData.hk.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
-        CF_AppData.hk.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.file_data_bytes      = Any_uint64_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.nak_segment_requests = Any_uint32_Except(0);
+        CF_AppData.HkPacket.channel_hk[i].counters.sent.pdu                  = Any_uint32_Except(0);
     }
 
     /* Act */
@@ -471,24 +471,24 @@ void Test_CF_CmdReset_tests_WhenCommandByteIs_all_AndResetAllMemValuesSendEvent(
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_RESET);
 
-    UtAssert_ZERO(CF_AppData.hk.counters.cmd);
-    UtAssert_ZERO(CF_AppData.hk.counters.err);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandCounter);
+    UtAssert_ZERO(CF_AppData.HkPacket.CommandErrorCounter);
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.fault, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.fault),
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.fault, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.fault),
                              "fault channel %d was completely cleared to 0", i);
     }
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.recv, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.recv),
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.recv, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.recv),
                              "recv channel %d was completely cleared to 0", i);
     }
     for (i = 0; i < CF_NUM_CHANNELS; ++i)
     {
-        UtAssert_MemCmpValue(&CF_AppData.hk.channel_hk[i].counters.sent, 0,
-                             sizeof(&CF_AppData.hk.channel_hk[i].counters.sent),
+        UtAssert_MemCmpValue(&CF_AppData.HkPacket.channel_hk[i].counters.sent, 0,
+                             sizeof(&CF_AppData.HkPacket.channel_hk[i].counters.sent),
                              "sent channel %d was completely cleared to 0", i);
     }
 }
@@ -507,13 +507,14 @@ void Test_CF_CmdTxFile(void)
     CF_UT_cmd_tx_file_buf_t utbuf;
     CF_TxFileCmd_t *        msg = &utbuf.tf;
 
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* nominal, all zero should pass checks, just calls CF_CFDP_TxFile */
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_1;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_TX_FILE);
 
@@ -521,7 +522,7 @@ void Test_CF_CmdTxFile(void)
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_2;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_TX_FILE);
 
@@ -531,14 +532,14 @@ void Test_CF_CmdTxFile(void)
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* out of range arguments: bad channel */
     UT_CF_ResetEventCapture();
@@ -546,7 +547,7 @@ void Test_CF_CmdTxFile(void)
     msg->chan_num = CF_NUM_CHANNELS;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 3);
 
     /* out of range arguments: bad keep */
     UT_CF_ResetEventCapture();
@@ -554,7 +555,7 @@ void Test_CF_CmdTxFile(void)
     msg->keep = 15;
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 4);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 4);
 
     /* CF_CFDP_TxFile fails*/
     UT_CF_ResetEventCapture();
@@ -562,7 +563,7 @@ void Test_CF_CmdTxFile(void)
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_CmdTxFile(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_TX_FILE);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 5);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 5);
 }
 
 /*******************************************************************************
@@ -579,32 +580,33 @@ void Test_CF_CmdPlaybackDir(void)
     CF_UT_cmd_playback_dir_buf_t utbuf;
     CF_PlaybackDirCmd_t *        msg = &utbuf.pd;
 
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* nominal, all zero should pass checks, just calls CF_CFDP_PlaybackDir */
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_1;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = CF_CFDP_CLASS_2;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 2);
 
     /* out of range arguments: bad class */
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* out of range arguments: bad channel */
     UT_CF_ResetEventCapture();
@@ -612,7 +614,7 @@ void Test_CF_CmdPlaybackDir(void)
     msg->chan_num = CF_NUM_CHANNELS;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 3);
 
     /* out of range arguments: bad keep */
     UT_CF_ResetEventCapture();
@@ -620,7 +622,7 @@ void Test_CF_CmdPlaybackDir(void)
     msg->keep = 15;
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 4);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 4);
 
     /* CF_CFDP_PlaybackDir fails*/
     UT_CF_ResetEventCapture();
@@ -628,7 +630,7 @@ void Test_CF_CmdPlaybackDir(void)
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_CmdPlaybackDir(&utbuf.buf));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PLAYBACK_DIR);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 5);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 5);
 }
 
 /*******************************************************************************
@@ -876,15 +878,15 @@ void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
 
     /* set frozen to opposite to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
-    CF_AppData.hk.channel_hk[arg_chan_num].frozen = !context.barg;
+    CF_AppData.HkPacket.channel_hk[arg_chan_num].frozen = !context.barg;
 
     /* Act */
     local_result = CF_DoFreezeThaw(arg_chan_num, arg_context);
 
     /* Assert */
-    UtAssert_True(CF_AppData.hk.channel_hk[arg_chan_num].frozen == context.barg,
+    UtAssert_True(CF_AppData.HkPacket.channel_hk[arg_chan_num].frozen == context.barg,
                   "CF_DoFreezeThaw set frozen to %d and should be %d (context->barg))",
-                  CF_AppData.hk.channel_hk[arg_chan_num].frozen, context.barg);
+                  CF_AppData.HkPacket.channel_hk[arg_chan_num].frozen, context.barg);
     UtAssert_True(local_result == CFE_SUCCESS,
                   "CF_DoFreezeThaw returned %d and should be 0 (CFE_SUCCESS) (only returns 0)", local_result);
 }
@@ -901,7 +903,7 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     uint8 chan_num = Any_cf_channel();
@@ -911,19 +913,19 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdFreeze(arg_msg);
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.hk.channel_hk[chan_num].frozen == 1,
+    UtAssert_True(CF_AppData.HkPacket.channel_hk[chan_num].frozen == 1,
                   "CF_DoFreezeThaw set frozen to %d and should be 1 (freeze = 1))",
-                  CF_AppData.hk.channel_hk[chan_num].frozen);
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+                  CF_AppData.HkPacket.channel_hk[chan_num].frozen);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_FREEZE);
 }
@@ -941,14 +943,14 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.cmd = 0;
+    CF_AppData.HkPacket.CommandCounter = 0;
 
     /* Act */
     CF_CmdFreeze(arg_msg);
 
     /* Assert */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_FREEZE);
 }
 
@@ -964,7 +966,7 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoFreezeThaw via CF_DoChanAction */
     uint8 chan_num = Any_cf_channel();
@@ -974,19 +976,19 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdThaw(arg_msg);
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_True(CF_AppData.hk.channel_hk[chan_num].frozen == 0,
+    UtAssert_True(CF_AppData.HkPacket.channel_hk[chan_num].frozen == 0,
                   "CF_DoFreezeThaw set frozen to %d and should be 0 (thaw = 0))",
-                  CF_AppData.hk.channel_hk[chan_num].frozen);
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+                  CF_AppData.HkPacket.channel_hk[chan_num].frozen);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_THAW);
 }
@@ -1004,14 +1006,14 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.cmd = 0;
+    CF_AppData.HkPacket.CommandCounter = 0;
 
     /* Act */
     CF_CmdThaw(arg_msg);
 
     /* Assert */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_THAW);
 }
 
@@ -1336,7 +1338,8 @@ void Test_CF_DoSuspRes(void)
     CF_TransactionCmd_t *       cmd = &utbuf.xact;
     CF_ChanAction_SuspResArg_t  utargs;
 
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
     memset(&utargs, 0, sizeof(utargs));
     memset(cmd, 0, sizeof(*cmd));
 
@@ -1344,7 +1347,7 @@ void Test_CF_DoSuspRes(void)
     /* With no setup, CF_TsnChanAction() invokes CF_TraverseAllTransactions stub, which returns 0 */
     /* this should increment the reject counter because it did not match any transactions */
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 0));
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     /* set up to match 1 transaction, should be accepted, but should not generate an event */
     UT_CF_ResetEventCapture();
@@ -1352,7 +1355,7 @@ void Test_CF_DoSuspRes(void)
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_SUSPRES);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 
     /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
     /* this gets the case where it attempts to set to the same value, and is rejected due to that */
@@ -1363,7 +1366,7 @@ void Test_CF_DoSuspRes(void)
                           &utargs);
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 0));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_SUSPRES_SAME);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
     /* however this time CF_TraverseAllTransactions reports it matched multiple transactions, so it should NOT reject it
@@ -1373,7 +1376,7 @@ void Test_CF_DoSuspRes(void)
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_SUSPRES);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 2);
 }
 
 /*******************************************************************************
@@ -1402,7 +1405,7 @@ void Test_CF_CmdSuspend_Call_CF_DoSuspRes_WithGiven_msg_And_action_1(void)
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_CMD_SUSPRES_CHAN);
 
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 /*******************************************************************************
@@ -1431,7 +1434,7 @@ void Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0(void)
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_CMD_SUSPRES_CHAN);
 
     /* Assert incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 /*******************************************************************************
@@ -1479,7 +1482,7 @@ void Test_CF_CmdCancel_Success(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_CANCEL);
 }
@@ -1499,7 +1502,7 @@ void Test_CF_CmdCancel_Failure(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CANCEL_CHAN);
 }
 
@@ -1551,7 +1554,7 @@ void Test_CF_CmdAbandon_Success(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ABANDON);
 }
@@ -1571,7 +1574,7 @@ void Test_CF_CmdAbandon_Failure(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ABANDON_CHAN);
 }
 
@@ -1615,7 +1618,7 @@ void Test_CF_CmdEnableDequeue_Success(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
     CF_ConfigTable_t config_table;
@@ -1629,7 +1632,7 @@ void Test_CF_CmdEnableDequeue_Success(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdEnableDequeue(arg_msg);
@@ -1640,10 +1643,11 @@ void Test_CF_CmdEnableDequeue_Success(void)
                   "CF_CmdEnableDequeue set dequeue_enabled to %d and should be 1 (barg = 1))",
                   CF_AppData.config_table->chan[chan_num].dequeue_enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d\nACCEPTANCE OF COMMAND (+1) SHOULD BE "
-                  "THE BEHAVIOR BUT IT IS NOT",
-                  CF_AppData.hk.counters.cmd, initial_hk_cmd_counter);
+    UtAssert_True(
+        CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+        "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d\nACCEPTANCE OF COMMAND (+1) SHOULD BE "
+        "THE BEHAVIOR BUT IT IS NOT",
+        CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_DEQUEUE);
 }
@@ -1666,14 +1670,14 @@ void Test_CF_CmdEnableDequeue_Failure(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.err = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* Act */
     CF_CmdEnableDequeue(arg_msg);
 
     /* Assert */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_DEQUEUE);
 }
 
@@ -1689,7 +1693,7 @@ void Test_CF_CmdDisableDequeue_Success(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     /* Arrange unstubbable: CF_DoEnableDisableDequeue via CF_DoChanAction */
     CF_ConfigTable_t config_table;
@@ -1703,7 +1707,7 @@ void Test_CF_CmdDisableDequeue_Success(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = chan_num;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdDisableDequeue(arg_msg);
@@ -1714,9 +1718,9 @@ void Test_CF_CmdDisableDequeue_Success(void)
                   "CF_CmdEnableDequeue set dequeue_enabled to %d and should be 0 (barg = 0))",
                   CF_AppData.config_table->chan[chan_num].dequeue_enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_DEQUEUE);
 }
@@ -1739,14 +1743,14 @@ void Test_CF_CmdDisableDequeue_Failure(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = CF_NUM_CHANNELS + 1;
 
-    CF_AppData.hk.counters.err = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
 
     /* Act */
     CF_CmdDisableDequeue(arg_msg);
 
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_DEQUEUE);
 }
 
@@ -1905,7 +1909,7 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&config_table, 0, sizeof(config_table));
@@ -1918,7 +1922,7 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     msg->data.byte[1] = polldir;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdEnablePolldir(arg_msg);
@@ -1929,9 +1933,9 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
                   "Channel %u Polldir %u set to %u and should be 1 (context->barg)", channel, polldir,
                   CF_AppData.config_table->chan[channel].polldir[polldir].enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_POLLDIR);
 }
 
@@ -1943,7 +1947,7 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -1952,7 +1956,7 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
 
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     msg->data.byte[1] = error_polldir;
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdEnablePolldir(arg_msg);
@@ -1960,9 +1964,9 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_POLLDIR);
 }
 
@@ -1981,7 +1985,7 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_cmd_counter = Any_uint16();
+    uint8                     initial_hk_cmd_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&config_table, 0, sizeof(config_table));
@@ -1994,7 +1998,7 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     msg->data.byte[1] = polldir;
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdDisablePolldir(arg_msg);
@@ -2005,9 +2009,9 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
                   "Channel %u Polldir %u set to %u and should be 0 (context->barg)", channel, polldir,
                   CF_AppData.config_table->chan[channel].polldir[polldir].enabled);
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
-                  "CF_AppData.hk.counters.cmd is %d and should be 1 more than %d", CF_AppData.hk.counters.cmd,
-                  initial_hk_cmd_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandCounter == (uint16)(initial_hk_cmd_counter + 1),
+                  "CF_AppData.HkPacket.CommandCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandCounter, initial_hk_cmd_counter);
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_POLLDIR);
 }
 
@@ -2019,7 +2023,7 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2029,7 +2033,7 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     /* Arrange unstubbable: CF_DoEnableDisablePolldir */
     msg->data.byte[1] = error_polldir;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdDisablePolldir(arg_msg);
@@ -2037,9 +2041,9 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter*/
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_POLLDIR);
 }
 
@@ -2291,7 +2295,7 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     CF_UT_cmd_unionargs_buf_t utbuf;
     CF_UnionArgsCmd_t *       msg                    = &utbuf.ua;
     CFE_SB_Buffer_t *         arg_msg                = &utbuf.buf;
-    uint16                    initial_hk_err_counter = Any_uint16();
+    uint8                     initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2301,7 +2305,7 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     /* Arrange unstubbable: CF_DoPurgeQueue */
     msg->data.byte[1] = error_purge;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdPurgeQueue(arg_msg);
@@ -2309,9 +2313,9 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter */
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_QUEUE);
 }
 
@@ -2328,7 +2332,7 @@ void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)
     /* Arrange unstubbable: CF_DoChanAction */
     msg->data.byte[0] = channel;
 
-    CF_AppData.hk.counters.cmd = 0;
+    CF_AppData.HkPacket.CommandCounter = 0;
 
     /* Act */
     CF_CmdPurgeQueue(arg_msg);
@@ -2336,7 +2340,7 @@ void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_PURGE_QUEUE);
 }
@@ -2353,14 +2357,14 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
     CF_UT_cmd_write_q_buf_t utbuf;
     CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
-    uint16                  initial_hk_err_counter = Any_uint16();
+    uint8                   initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
     wq->chan = CF_NUM_CHANNELS;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2369,7 +2373,7 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand(void)
@@ -2378,14 +2382,14 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
     CF_UT_cmd_write_q_buf_t utbuf;
     CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
-    uint16                  initial_hk_err_counter = Any_uint16();
+    uint8                   initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
     wq->chan = Any_uint8_GreaterThan(CF_NUM_CHANNELS);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2395,7 +2399,7 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
@@ -2404,7 +2408,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     CF_UT_cmd_write_q_buf_t utbuf;
     CF_WriteQueueCmd_t *    wq                     = &utbuf.wq;
     CFE_SB_Buffer_t *       arg_msg                = &utbuf.buf;
-    uint16                  initial_hk_err_counter = Any_uint16();
+    uint8                   initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2415,7 +2419,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     wq->type  = CF_Type_up;
     wq->queue = CF_Queue_pend;
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2425,7 +2429,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_ARGS);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_IsNot_q_pend_SendEventAndRejectCommand(
@@ -2436,7 +2440,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     CF_WriteQueueCmd_t *           wq = &utbuf.wq;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
-    uint16                         initial_hk_err_counter = Any_uint16();
+    uint8                          initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2455,7 +2459,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2467,7 +2471,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_queue_Is_q_pend_SendEventAndRejectCommand(
@@ -2478,7 +2482,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     CF_WriteQueueCmd_t *           wq = &utbuf.wq;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     CFE_SB_Buffer_t *              arg_msg                = &utbuf.buf;
-    uint16                         initial_hk_err_counter = Any_uint16();
+    uint8                          initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2497,7 +2501,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate), &context_CF_WrappedOpenCreate, sizeof(context_CF_WrappedOpenCreate),
                      false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2509,7 +2513,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedClose_SendEventCloseAndRejectCommandWhen_CF_WriteTxnQueueDataToFile_Fails(
@@ -2522,7 +2526,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
-    uint16                               initial_hk_err_counter                   = Any_uint16();
+    uint8                                initial_hk_err_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2546,7 +2550,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
                      sizeof(context_CF_WriteTxnQueueDataToFile), false);
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2557,7 +2561,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventClosesAndRejectCommand(
@@ -2571,7 +2575,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2597,7 +2601,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2608,7 +2612,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2622,7 +2626,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
     int32                                    context_CF_WrappedClose_fd;
-    uint16                                   initial_hk_err_counter = Any_uint16();
+    uint8                                    initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2648,7 +2652,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2659,7 +2663,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2673,7 +2677,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2699,7 +2703,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2710,7 +2714,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_wq_IsDownAnd_queue_IsActive_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2725,7 +2729,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     int32                                forced_return_CF_WriteTxnQueueDataToFile_1st_call = 0;
     int32                                forced_return_CF_WriteTxnQueueDataToFile_2nd_call = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2752,7 +2756,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2763,7 +2767,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsPend_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2777,7 +2781,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
-    uint16                               initial_hk_err_counter = Any_uint16();
+    uint8                                initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2803,7 +2807,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2814,7 +2818,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_PEND);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDownAnd_queue_IsHistory_fd_IsPositive_Call_CF_WrappedClose_SendEventCloseAndRejectCommand(
@@ -2828,7 +2832,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
     int32                                    context_CF_WrappedClose_fd;
-    uint16                                   initial_hk_err_counter = Any_uint16();
+    uint8                                    initial_hk_err_counter = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2854,7 +2858,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
 
     UT_SetDataBuffer(UT_KEY(CF_WrappedClose), &context_CF_WrappedClose_fd, sizeof(context_CF_WrappedClose_fd), false);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2865,7 +2869,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
@@ -2877,7 +2881,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2902,7 +2906,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2914,7 +2918,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
@@ -2925,7 +2929,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2947,7 +2951,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -2959,7 +2963,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
@@ -2970,7 +2974,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2992,7 +2996,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3004,7 +3008,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
@@ -3015,7 +3019,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3037,7 +3041,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3049,7 +3053,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
@@ -3061,7 +3065,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3086,7 +3090,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3098,7 +3102,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
@@ -3109,7 +3113,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    uint8                          initial_hk_cmd_counter                       = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3131,7 +3135,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3143,7 +3147,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
@@ -3154,7 +3158,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3176,7 +3180,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3188,7 +3192,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 /* Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Pend IS an error and is handled by a previous test */
@@ -3201,7 +3205,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3223,7 +3227,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3235,7 +3239,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
@@ -3246,7 +3250,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3268,7 +3272,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3280,7 +3284,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
@@ -3291,7 +3295,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3313,7 +3317,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3325,7 +3329,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
@@ -3336,7 +3340,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     CFE_SB_Buffer_t *              arg_msg = &utbuf.buf;
     CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
     int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    uint8                          initial_hk_cmd_counter                   = Any_uint8();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -3358,7 +3362,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdWriteQueue(arg_msg);
@@ -3370,7 +3374,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 /*******************************************************************************
@@ -3516,9 +3520,10 @@ void Test_CF_CmdGetSetParam(void)
     uint16              expected_count;
 
     memset(&ut_config_table, 0, sizeof(ut_config_table));
-    memset(&CF_AppData.hk.counters, 0, sizeof(CF_AppData.hk.counters));
-    CF_AppData.config_table = &ut_config_table;
-    expected_count          = 0;
+    CF_AppData.HkPacket.CommandCounter      = 0;
+    CF_AppData.HkPacket.CommandErrorCounter = 0;
+    CF_AppData.config_table                 = &ut_config_table;
+    expected_count                          = 0;
 
     /* Nominal: "set" for each parameter */
     for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
@@ -3526,7 +3531,7 @@ void Test_CF_CmdGetSetParam(void)
         UT_CF_ResetEventCapture();
         UtAssert_VOIDCALL(CF_CmdGetSetParam(1, param_id, 1 + param_id, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET1);
-        UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, ++expected_count);
+        UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, ++expected_count);
     }
 
     /* each of the config parameters should have actually been set to a different value */
@@ -3547,27 +3552,27 @@ void Test_CF_CmdGetSetParam(void)
         UT_CF_ResetEventCapture();
         UtAssert_VOIDCALL(CF_CmdGetSetParam(0, param_id, 1, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET2);
-        UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, ++expected_count);
+        UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, ++expected_count);
     }
 
     /* Bad param ID */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_CmdGetSetParam(0, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_PARAM);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 
     /* Bad channel ID */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_CmdGetSetParam(0, 0, 0, CF_NUM_CHANNELS + 1));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_CHAN);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 2);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 2);
 
     /* Validation fail */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_CmdGetSetParam(1, CF_GetSet_ValueID_outgoing_file_chunk_size,
                                         100 + sizeof(CF_CFDP_PduFileDataContent_t), UT_CFDP_CHANNEL));
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_VALIDATE);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 3);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 3);
 }
 
 /*******************************************************************************
@@ -3599,7 +3604,7 @@ void Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET1);
     /* Assert for incremented counter() */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 }
 
 /*******************************************************************************
@@ -3630,7 +3635,7 @@ void Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstant
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET2);
     /* Assert for incremented counter() */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 }
 
 /*******************************************************************************
@@ -3644,13 +3649,13 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                          = NULL;
     uint32           forced_return_CF_CFDP_InitEngine = CFE_SUCCESS;
-    uint16           initial_hk_cmd_counter           = Any_uint16();
+    uint8            initial_hk_cmd_counter           = Any_uint8();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdEnableEngine(arg_msg);
@@ -3662,7 +3667,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementErrCounter(void)
@@ -3670,13 +3675,13 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                          = NULL;
     uint32           forced_return_CF_CFDP_InitEngine = Any_uint32_Except(CFE_SUCCESS);
-    uint16           initial_hk_err_counter           = Any_uint16();
+    uint8            initial_hk_err_counter           = Any_uint8();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdEnableEngine(arg_msg);
@@ -3688,18 +3693,18 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounter(void)
 {
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                = NULL;
-    uint16           initial_hk_err_counter = Any_uint16();
+    uint8            initial_hk_err_counter = Any_uint8();
 
     CF_AppData.engine.enabled = 1; /* 1 is enabled */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdEnableEngine(arg_msg);
@@ -3711,7 +3716,7 @@ void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounte
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_ENA);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
 }
 
 /*******************************************************************************
@@ -3724,11 +3729,11 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
 {
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                = NULL;
-    uint16           initial_hk_cmd_counter = Any_uint16();
+    uint8            initial_hk_cmd_counter = Any_uint8();
 
     CF_AppData.engine.enabled = 1; /* 1 is enabled */
 
-    CF_AppData.hk.counters.cmd = initial_hk_cmd_counter;
+    CF_AppData.HkPacket.CommandCounter = initial_hk_cmd_counter;
 
     /* Act */
     CF_CmdDisableEngine(arg_msg);
@@ -3739,18 +3744,18 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
     UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_ENGINE);
 
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, (initial_hk_cmd_counter + 1) & 0xFF);
 }
 
 void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(void)
 {
     /* Arrange */
     CFE_SB_Buffer_t *arg_msg                = NULL;
-    uint16           initial_hk_err_counter = Any_uint16();
+    uint8            initial_hk_err_counter = Any_uint8();
 
     CF_AppData.engine.enabled = 0; /* 0 is not enabled */
 
-    CF_AppData.hk.counters.err = initial_hk_err_counter;
+    CF_AppData.HkPacket.CommandErrorCounter = initial_hk_err_counter;
 
     /* Act */
     CF_CmdDisableEngine(arg_msg);
@@ -3760,10 +3765,10 @@ void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(v
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_DIS);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-    UtAssert_True(CF_AppData.hk.counters.err == (uint16)(initial_hk_err_counter + 1),
-                  "CF_AppData.hk.counters.err is %d and should be 1 more than %d", CF_AppData.hk.counters.err,
-                  initial_hk_err_counter);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, (initial_hk_err_counter + 1) & 0xFF);
+    UtAssert_True(CF_AppData.HkPacket.CommandErrorCounter == (uint16)(initial_hk_err_counter + 1),
+                  "CF_AppData.HkPacket.CommandErrorCounter is %d and should be 1 more than %d",
+                  CF_AppData.HkPacket.CommandErrorCounter, initial_hk_err_counter);
 }
 
 /*******************************************************************************
@@ -3794,7 +3799,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_EqTo_CF_NUM_COMMANDS_FailAndSendEvent
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSendEvent(void)
@@ -3819,7 +3824,7 @@ void Test_CF_ProcessGroundCommand_When_cmd_GreaterThan_CF_NUM_COMMANDS_FailAndSe
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_CC);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForThatCommandSendEventAndFailure(void)
@@ -3846,7 +3851,7 @@ void Test_CF_ProcessGroundCommand_Receives_cmd_AndLengthDoesNotMatchExpectedForT
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_GCMD_LEN);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 1);
 }
 
 void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_msg(void)
@@ -3874,7 +3879,7 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x00_AndCall_CF_CmdNoop_With_m
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_INF_CMD_NOOP);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 1);
 }
 
 /* Hit a NULL entry to exercise that conditional and no action */
@@ -3900,8 +3905,8 @@ void Test_CF_ProcessGroundCommand_ReceivesCmdCode_0x0C_AndDoNothingBecause_fns_1
     UtAssert_STUB_COUNT(CFE_MSG_GetSize, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.cmd, 0);
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 0);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandCounter, 0);
+    UtAssert_UINT32_EQ(CF_AppData.HkPacket.CommandErrorCounter, 0);
 }
 
 /*******************************************************************************

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -127,7 +127,7 @@ void Test_CF_ResetHistory(void)
 
     memset(&h, 0, sizeof(h));
 
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST] = 4;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST] = 4;
 
     /* nominal call */
     UtAssert_VOIDCALL(CF_ResetHistory(&CF_AppData.engine.channels[UT_CFDP_CHANNEL], &h));
@@ -145,10 +145,10 @@ void Test_CF_FindUnusedTransaction(void)
     memset(&hist, 0, sizeof(hist));
     memset(&txn, 0, sizeof(txn));
     memset(&CF_AppData, 0, sizeof(CF_AppData));
-    c                                                                  = &CF_AppData.engine.channels[UT_CFDP_CHANNEL];
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_FREE] = 2;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST_FREE] = 1;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST]      = 1;
+    c = &CF_AppData.engine.channels[UT_CFDP_CHANNEL];
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_FREE]      = 2;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST_FREE] = 1;
+    CF_AppData.HkPacket.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST]      = 1;
 
     UtAssert_NULL(CF_FindUnusedTransaction(c));
 
@@ -272,12 +272,12 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
     expected_head    = &CF_AppData.engine.channels[arg_t.chan_num].qs[arg_t.flags.com.q_index];
     expected_cl_node = &arg_t.cl_node;
 
-    CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index] = initial_q_size;
+    CF_AppData.HkPacket.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index] = initial_q_size;
 
     /* Act */
     CF_DequeueTransaction(&arg_t);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index];
+    updated_q_size = CF_AppData.HkPacket.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index];
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_clist_remove.head, expected_head);
@@ -317,7 +317,7 @@ void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(
     expected_insert_back_node = &arg_t->cl_node;
 
     /* Queue size needes to be >= 1 */
-    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] = 1;
+    CF_AppData.HkPacket.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] = 1;
 
     /* Act */
     CF_MoveTransaction(arg_t, arg_q);
@@ -355,12 +355,12 @@ void Test_CF_CList_Remove_Ex_Call_CF_CList_Remove_AndDecrement_q_size(void)
     expected_remove_head = &arg_c->qs[arg_index];
     expected_remove_node = arg_node;
 
-    CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
+    CF_AppData.HkPacket.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
 
     /* Act */
     CF_CList_Remove_Ex(arg_c, arg_index, arg_node);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.HkPacket.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_Remove, 1);
@@ -390,12 +390,12 @@ void Test_CF_CList_InsertAfter_Ex_Call_CF_CList_InsertAfter_AndIncrement_q_size(
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertAfter), &context_CF_CList_InsertAfter, sizeof(context_CF_CList_InsertAfter),
                      false);
 
-    CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
+    CF_AppData.HkPacket.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
 
     /* Act */
     CF_CList_InsertAfter_Ex(arg_c, arg_index, arg_start, arg_after);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.HkPacket.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_InsertAfter, 1);
@@ -426,12 +426,12 @@ void Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size(vo
     expected_insert_back_head = &arg_c->qs[arg_index];
     expected_insert_back_node = arg_node;
 
-    CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
+    CF_AppData.HkPacket.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
 
     /* Act */
     CF_CList_InsertBack_Ex(arg_c, arg_index, arg_node);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.HkPacket.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #382
  - Command counters renamed
    - `cmd` renamed to `CommandCounter`
    - `err` renamed to `CommandErrorCounter`
  - Command counters changed from size 16 to size 8, and moved out of their own struct into the HK packet directly (this is how all other cFS components/apps implemented the counters)
  - `hk` renamed to `HkPacket` (most cFS components/apps use this common name for the housekeeping packet)

Note: if the `CamelCase` is an issue, can still implement these changes as `snake_case`, although I guess now is as good a time as any to start converting CF variables to `CamelCase`. If so I can open a new issue to flag that all variables should be changed over - all at once (if someone wants to implement that) or gradually as changes are made.
CF is the only cFS app/component to use `snake_case` for naming variables.

Re-introduced from #383.#394, #397 reverted this PR.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit Tests etc.).

**Expected behavior changes**
`Command`/`CommandError` counters now held directly in the HK packet, instead of through an additional struct member.

This PR improves consistency across cFS, and makes future maintenance easier as variables are named and located as expected.

**Contributor Info**
Avi Weiss @thnkslprpt