### PR TITLE
Fix #403, patches for older system compatibility

### DIFF
--- a/unit-test/cf_codec_tests.c
+++ b/unit-test/cf_codec_tests.c
@@ -54,12 +54,17 @@ void Test_CF_CFDP_GetValueEncodedSize(void)
     UtAssert_UINT32_EQ(CF_CFDP_GetValueEncodedSize(16777216), 4);
     UtAssert_UINT32_EQ(CF_CFDP_GetValueEncodedSize(UINT32_MAX), 4);
 
+#ifdef UINT64_C
     /*
      * This next case uses UINT64_C macro to force promotion so the +1 is done as 64-bit,
-     * otherwise the UINT32_MAX is a 32-bit value and +1 results in 0.
+     * otherwise the UINT32_MAX is a 32-bit value and +1 results in 0.  Not all systems have
+	 * UINT64_C so these will be skipped in that case.
      */
     UtAssert_UINT32_EQ(CF_CFDP_GetValueEncodedSize(UINT32_MAX + UINT64_C(1)), 5);
+#endif
+#ifdef UINT64_MAX
     UtAssert_UINT32_EQ(CF_CFDP_GetValueEncodedSize(UINT64_MAX), 8);
+#endif
 }
 
 void Test_CF_EncodeIntegerInSize(void)

--- a/unit-test/utilities/cf_test_utils.c
+++ b/unit-test/utilities/cf_test_utils.c
@@ -448,38 +448,6 @@ int Any_int_Except(int exception)
     return random_val;
 }
 
-int Any_int_GreaterThan(int floor) /* NOTE: INTMAX_MAX will fail, and is invalid value */
-{
-    int  random_val;
-    bool coin_toss;
-
-    if (floor > 0)
-    {
-        random_val = (int)(rand() % (INTMAX_MAX - floor - 1)); /* -1 for greater than */
-
-        random_val += floor + 1;
-    }
-    else
-    {
-        coin_toss = rand() % 2;
-
-        if (coin_toss == HEADS)
-        {
-            random_val = (int)(rand() % (-floor)); /* floor is negative, -floor inverts to positive */
-            /* 0 to INTMAX_MAX becomes -1 to INTMAX_MIN */
-            random_val *= -1; /* flip sign */
-            random_val += -1; /* subtract 1, 0 becomes -1 */
-        }
-        else
-        {
-            random_val = (int)(rand() % (INTMAX_MAX)); /* floor is negative, random will be positive so any positive (or
-                                                          zero) will work */
-        }
-    }
-
-    return random_val;
-}
-
 int Any_int_Negative(void)
 {
     return ((rand() % MAX_INT) * -1) - 1; /* *-1 flips sign, -1 for 0 and MIN_INT */

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -261,7 +261,6 @@ uint64       Any_uint64_Except(uint64 exception);
 unsigned int Any_unsigned_int(void);
 int          Any_int(void);
 int          Any_int_Except(int exception);
-int          Any_int_GreaterThan(int floor);
 int          Any_int_Negative(void);
 int          Any_int_Positive(void);
 int          Any_int_PositiveExcept(int exception);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Do not assume INTMAX_MAX or UINT64_C macros are available. Notably, these are absent on VxWorks 6.9,

Fixes #403

**Testing performed**
Build on VxWorks 6.9

**Expected behavior changes**
Compile succeeds.  Test cases that depend on host system 64-bit macros will not be run

**System(s) tested on**
VxWorks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
