### PR TITLE
Fix #351, Removes semi-colon in TEST_CF_ADD macro

### DIFF
--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -219,7 +219,7 @@ void cf_tests_Setup(void);
 void cf_tests_Teardown(void);
 
 /* Helper macro to avoid coping test name */
-#define TEST_CF_ADD(test) UtTest_Add(test, cf_tests_Setup, cf_tests_Teardown, #test);
+#define TEST_CF_ADD(test) UtTest_Add(test, cf_tests_Setup, cf_tests_Teardown, #test)
 
 void TestUtil_InitializeRandomSeed(void);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #351. This change removes the semi-colon in a macro for cleanliness and remove any concern for expanding to double semi-colon.

**Testing performed**
lcov locally

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
 - OS: Ubuntu 22.04

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
