### PR TITLE
Fix #363, decoding segs using incorrect macro

### DIFF
--- a/fsw/src/cf_codec.c
+++ b/fsw/src/cf_codec.c
@@ -1125,7 +1125,7 @@ void CF_CFDP_DecodeAllSegments(CF_DecoderState_t *state, CF_Logical_SegmentList_
     {
         --limit;
 
-        if (plseg->num_segments >= CF_PDU_MAX_TLV)
+        if (plseg->num_segments >= CF_PDU_MAX_SEGMENTS)
         {
             /* too many */
             CF_CODEC_SET_DONE(state);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #363 

Will now use the correct macro - CF_PDU_MAX_SEGMENTS as opposed to CF_PDU_MAX_TLV

**Testing performed**
Steps taken to test the contribution:
1. Unit/coverage testing
2. Build verification testing

**System(s) tested on**
 - Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard