### PR TITLE
Fix #418, reorganize header files and restructure messages

### DIFF
--- a/arch_build.cmake
+++ b/arch_build.cmake
@@ -1,0 +1,39 @@
+###########################################################
+#
+# CF App platform build setup
+#
+# This file is evaluated as part of the "prepare" stage
+# and can be used to set up prerequisites for the build,
+# such as generating header files
+#
+###########################################################
+
+# The list of header files that control the CF configuration
+set(CF_PLATFORM_CONFIG_FILE_LIST
+  cf_internal_cfg.h
+  cf_msgids.h
+  cf_platform_cfg.h
+)
+
+if (CFE_EDS_ENABLED_BUILD)
+
+  # In an EDS-based build, msgids come generated from the EDS tool
+  set(CF_CFGFILE_SRC_cf_msgids "${CMAKE_CURRENT_LIST_DIR}/config/cf_eds_msg_topicids.h")
+
+endif(CFE_EDS_ENABLED_BUILD)
+
+# Create wrappers around the all the config header files
+# This makes them individually overridable by the missions, without modifying
+# the distribution default copies
+foreach(CF_CFGFILE ${CF_PLATFORM_CONFIG_FILE_LIST})
+  get_filename_component(CFGKEY "${CF_CFGFILE}" NAME_WE)
+  if (DEFINED CF_CFGFILE_SRC_${CFGKEY})
+    set(DEFAULT_SOURCE "${CF_CFGFILE_SRC_${CFGKEY}}")
+  else()
+    set(DEFAULT_SOURCE "${CMAKE_CURRENT_LIST_DIR}/config/default_${CF_CFGFILE}")
+  endif()
+  generate_config_includefile(
+    FILE_NAME           "${CF_CFGFILE}"
+    FALLBACK_FILE       ${DEFAULT_SOURCE}
+  )
+endforeach()

--- a/config/default_cf_extern_typedefs.h
+++ b/config/default_cf_extern_typedefs.h
@@ -26,7 +26,7 @@
 #ifndef CF_EXTERN_TYPEDEFS_H
 #define CF_EXTERN_TYPEDEFS_H
 
-#include <cf_platform_cfg.h>
+#include "cf_platform_cfg.h"
 
 /**
  * @brief Values for CFDP file transfer class

--- a/config/default_cf_fcncodes.h
+++ b/config/default_cf_fcncodes.h
@@ -19,152 +19,25 @@
 
 /**
  * @file
+ *   Specification for the CFS CFDP (CF) command function codes
  *
- *  The CF Application message definitions header file
+ * @note
+ *   This file should be strictly limited to the command/function code (CC)
+ *   macro definitions.  Other definitions such as enums, typedefs, or other
+ *   macros should be placed in the msgdefs.h or msg.h files.
  */
+#ifndef CF_FCNCODES_H
+#define CF_FCNCODES_H
 
-#ifndef CF_MSG_H
-#define CF_MSG_H
-
-#include <cfe.h>
-#include <cf_platform_cfg.h>
-#include <cf_extern_typedefs.h>
-#include <cf_tbldefs.h>
-
-#define CF_ALL_CHANNELS (255)
-#define CF_ALL_POLLDIRS (CF_ALL_CHANNELS)
-#define CF_COMPOUND_KEY (254)
-
-/**
- * \defgroup cfscftlm CFS CFDP Telemetry
- * \{
- */
-
-/**
- * \brief Housekeeping command counters
- */
-typedef struct CF_HkCmdCounters
-{
-    uint16 cmd; /**< \brief Command success counter */
-    uint16 err; /**< \brief Command error counter */
-} CF_HkCmdCounters_t;
-
-/**
- * \brief Housekeeping sent counters
- */
-typedef struct CF_HkSent
-{
-    uint64 file_data_bytes;      /**< \brief Sent File data bytes */
-    uint32 pdu;                  /**< \brief Sent PDUs counter */
-    uint32 nak_segment_requests; /**< \brief Sent NAK segment requests counter */
-} CF_HkSent_t;
-
-/**
- * \brief Housekeeping received counters
- */
-typedef struct CF_HkRecv
-{
-    uint64 file_data_bytes;      /**< \brief Received File data bytes */
-    uint32 pdu;                  /**< \brief Received PDUs with valid header counter */
-    uint32 error;                /**< \brief Received PDUs with error counter, see related event for cause */
-    uint16 spurious;             /**< \brief Received PDUs with invalid directive code for current context or
-                                  *          file directive FIN without matching active transaction counter,
-                                  *          see related event for cause
-                                  */
-    uint16 dropped;              /**< \brief Received PDUs dropped due to a transaction error */
-    uint32 nak_segment_requests; /**< \brief Received NAK segment requests counter */
-} CF_HkRecv_t;
-
-/**
- * \brief Housekeeping fault counters
- */
-typedef struct CF_HkFault
-{
-    uint16 file_open;          /**< \brief File open fault counter */
-    uint16 file_read;          /**< \brief File read fault counter */
-    uint16 file_seek;          /**< \brief File seek fault counter */
-    uint16 file_write;         /**< \brief File write fault counter */
-    uint16 file_rename;        /**< \brief File rename fault counter */
-    uint16 directory_read;     /**< \brief Directory read fault counter */
-    uint16 crc_mismatch;       /**< \brief CRC mismatch fault counter */
-    uint16 file_size_mismatch; /**< \brief File size mismatch fault counter */
-    uint16 nak_limit;          /**< \brief NAK limit exceeded fault counter */
-    uint16 ack_limit;          /**< \brief ACK limit exceeded fault counter */
-    uint16 inactivity_timer;   /**< \brief Inactivity timer exceeded counter */
-    uint16 spare;              /**< \brief Alignment spare to avoid implicit padding */
-} CF_HkFault_t;
-
-/**
- * \brief Housekeeping counters
- */
-typedef struct CF_HkCounters
-{
-    CF_HkSent_t  sent;  /**< \brief Sent counters */
-    CF_HkRecv_t  recv;  /**< \brief Received counters */
-    CF_HkFault_t fault; /**< \brief Fault counters */
-} CF_HkCounters_t;
-
-/**
- * \brief Housekeeping channel data
- */
-typedef struct CF_HkChannel_Data
-{
-    CF_HkCounters_t counters;                /**< \brief Counters */
-    uint16          q_size[CF_QueueIdx_NUM]; /**< \brief Queue sizes */
-    uint8           poll_counter;            /**< \brief Number of active polling directories */
-    uint8           playback_counter;        /**< \brief Number of active playback directories */
-    uint8           frozen;                  /**< \brief Frozen state: 0 == not frozen, else frozen */
-    uint8           spare[7];                /**< \brief Alignment spare (uint64 values in the counters) */
-} CF_HkChannel_Data_t;
-
-/**
- * \brief Housekeeping packet
- */
-typedef struct CF_HkPacket
-{
-    CFE_MSG_TelemetryHeader_t tlm_header; /**< \brief Telemetry header */
-    CF_HkCmdCounters_t        counters;   /**< \brief Command counters */
-    uint8                     spare[4];   /**< \brief Alignment spare (CF_HkCmdCounters_t is 4 bytes) */
-
-    CF_HkChannel_Data_t channel_hk[CF_NUM_CHANNELS]; /**< \brief Per channel housekeeping data */
-} CF_HkPacket_t;
-
-/**
- * \brief End of transaction packet
- */
-typedef struct CF_EotPacket
-{
-    CFE_MSG_TelemetryHeader_t tlm_header; /**< \brief Telemetry header */
-    CF_TransactionSeq_t       seq_num;    /**< \brief transaction identifier, stays constant for entire transfer */
-    uint32                    channel;    /**< \brief Channel number */
-    uint32                    direction;  /**< \brief direction of this transaction */
-    uint32                    state;      /**< \brief Transaction state */
-    uint32                    txn_stat;   /**< \brief final status code of transaction (extended CFDP CC) */
-    CF_EntityId_t             src_eid;    /**< \brief the source eid of the transaction */
-    CF_EntityId_t             peer_eid;   /**< \brief peer_eid is always the "other guy", same src_eid for RX */
-    uint32                    fsize;      /**< \brief File size */
-    uint32                    crc_result; /**< \brief CRC result */
-    CF_TxnFilenames_t         fnames;     /**< \brief file names associated with this transaction */
-} CF_EotPacket_t;
-
-/**
- * \brief Single application file info packet buffer
- *
- * This typedef supports CFE_SB_AllocateMessageBuffer use with a CF_EotPkt_t
- * that compiles with the alignment constraints of a CFE_SB_Buffer_t
- */
-typedef union
-{
-    CFE_SB_Buffer_t SBBuf; /**< \brief Message buffer for alignment */
-    CF_EotPacket_t  eot;   /**< \brief Single end of transaction info packet */
-} CF_EotPktBuf_t;
-
-/**\}*/
+/************************************************************************
+ * Macro Definitions
+ ************************************************************************/
 
 /**
  * \defgroup cfscfcmdcodes CFS CFDP Command Codes
  * \{
  */
+
 typedef enum
 {
     /**
@@ -174,12 +47,12 @@ typedef enum
      *       No-operation command for aliveness verification and version reporting
      *
      *  \par Command Structure
-     *       #CF_NoArgsCmd_t
+     *       No Payload / Arguments
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_NOOP_INF_EID
      *
      *  \par Error Conditions
@@ -187,7 +60,7 @@ typedef enum
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -201,7 +74,7 @@ typedef enum
      *       Resets the requested housekeeping counters
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t where byte[0] specifies the counters type, byte[1-3] don't care:
+     *       #CF_UnionArgs_Payload_t where byte[0] specifies the counters type, byte[1-3] don't care:
      *       - 0 = all counters
      *       - 1 = command counters
      *       - 2 = fault counters
@@ -211,7 +84,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_RESET_INF_EID
      *
      *  \par Error Conditions
@@ -220,7 +93,7 @@ typedef enum
      *       - Invalid counter type, #CF_EID_ERR_CMD_RESET_INVALID
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -239,7 +112,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_TX_FILE
      *
      *  \par Error Conditions
@@ -249,7 +122,7 @@ typedef enum
      *       - Transaction initialization failure, #CF_EID_ERR_CMD_TX_FILE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -271,7 +144,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_PLAYBACK_DIR
      *
      *  \par Error Conditions
@@ -281,7 +154,7 @@ typedef enum
      *       - Playback initialization failure, #CF_EID_ERR_CMD_PLAYBACK_DIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -299,14 +172,14 @@ typedef enum
      *       this could cause failures for class 2 transactions in progress.
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t where byte[0] specifies the channel number or all channels
+     *       #CF_UnionArgs_Payload_t where byte[0] specifies the channel number or all channels
      *       - 255 = all channels
      *       - else = single channel
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_FREEZE
      *
      *  \par Error Conditions
@@ -316,7 +189,7 @@ typedef enum
      *       - Command processing failure, #CF_EID_ERR_CMD_FREEZE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -333,14 +206,14 @@ typedef enum
      *       for the specified channel, note received messages are consumed either way.
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t where byte[0] specifies the channel number or all channels
+     *       #CF_UnionArgs_Payload_t where byte[0] specifies the channel number or all channels
      *       - 255 = all channels
      *       - else = single channel
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_THAW
      *
      *  \par Error Conditions
@@ -350,7 +223,7 @@ typedef enum
      *       - Command processing failure, #CF_EID_ERR_CMD_THAW
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -369,12 +242,12 @@ typedef enum
      *       whereas freeze/thaw are tracked per channel.
      *
      *  \par Command Structure
-     *       #CF_TransactionCmd_t
+     *       #CF_Transaction_Payload_t
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_SUSPRES
      *
      *  \par Error Conditions
@@ -386,7 +259,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -405,12 +278,12 @@ typedef enum
      *       transaction, whereas freeze/thaw are tracked per channel.
      *
      *  \par Command Structure
-     *       #CF_TransactionCmd_t
+     *       #CF_Transaction_Payload_t
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_SUSPRES
      *
      *  \par Error Conditions
@@ -422,7 +295,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -440,12 +313,12 @@ typedef enum
      *       or all transactions on a specific channel.
      *
      *  \par Command Structure
-     *       #CF_TransactionCmd_t
+     *       #CF_Transaction_Payload_t
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_CANCEL
      *
      *  \par Error Conditions
@@ -456,7 +329,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_CANCEL_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -474,12 +347,12 @@ typedef enum
      *       or all transactions on a specific channel.
      *
      *  \par Command Structure
-     *       #CF_TransactionCmd_t
+     *       #CF_Transaction_Payload_t
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_ABANDON
      *
      *  \par Error Conditions
@@ -490,7 +363,7 @@ typedef enum
      *       - No matching transaction, #CF_EID_ERR_CMD_ABANDON_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -511,7 +384,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_GETSET1
      *
      *  \par Error Conditions
@@ -522,7 +395,7 @@ typedef enum
      *       - Parameter value failed validation, #CF_EID_ERR_CMD_GETSET_VALIDATE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -543,7 +416,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_GETSET2
      *
      *  \par Error Conditions
@@ -553,7 +426,7 @@ typedef enum
      *       - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -574,7 +447,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_WQ
      *
      *  \par Error Conditions
@@ -589,7 +462,7 @@ typedef enum
      *       - Write TX history data failed, #CF_EID_ERR_CMD_WQ_WRITEHIST_TX
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -605,14 +478,14 @@ typedef enum
      *       Enables the sending of file data PDUs.
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t where byte[0] specifies the channel number or all channels
+     *       #CF_UnionArgs_Payload_t where byte[0] specifies the channel number or all channels
      *       - 255 = all channels
      *       - else = single channel
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_ENABLE_DEQUEUE
      *
      *  \par Error Conditions
@@ -622,7 +495,7 @@ typedef enum
      *       - Enable dequeue failed, #CF_EID_ERR_CMD_ENABLE_DEQUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -638,14 +511,14 @@ typedef enum
      *       Disables the sending of file data PDUs.
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t where byte[0] specifies the channel number or all channels
+     *       #CF_UnionArgs_Payload_t where byte[0] specifies the channel number or all channels
      *       - 255 = all channels
      *       - else = single channel
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_DISABLE_DEQUEUE
      *
      *  \par Error Conditions
@@ -655,7 +528,7 @@ typedef enum
      *       - Disable dequeue failed, #CF_EID_INF_CMD_DISABLE_DEQUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -671,7 +544,7 @@ typedef enum
      *       Enables the processing of polling directories
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t
+     *       #CF_UnionArgs_Payload_t
      *
      *       byte[0] specifies the channel number or all channels
      *       - 255 = all channels
@@ -684,7 +557,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_ENABLE_POLLDIR
      *
      *  \par Error Conditions
@@ -695,7 +568,7 @@ typedef enum
      *       - Enable directory polling failed, #CF_EID_ERR_CMD_ENABLE_POLLDIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -711,7 +584,7 @@ typedef enum
      *       Disable the processing of polling directories
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t
+     *       #CF_UnionArgs_Payload_t
      *
      *       byte[0] specifies the channel number or all channels
      *       - 255 = all channels
@@ -724,7 +597,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_DISABLE_POLLDIR
      *
      *  \par Error Conditions
@@ -735,7 +608,7 @@ typedef enum
      *       - Disable directory polling failed, #CF_EID_ERR_CMD_DISABLE_POLLDIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -751,7 +624,7 @@ typedef enum
      *       Purge the requested queue
      *
      *  \par Command Structure
-     *       #CF_UnionArgsCmd_t
+     *       #CF_UnionArgs_Payload_t
      *
      *       byte[0] specifies the channel number or all channels
      *       - 255 = all channels
@@ -765,7 +638,7 @@ typedef enum
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_PURGE_QUEUE
      *
      *  \par Error Conditions
@@ -776,7 +649,7 @@ typedef enum
      *       - Purge queue failed, #CF_EID_ERR_CMD_PURGE_QUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -793,12 +666,12 @@ typedef enum
      *       are not processed while the engine is enabled.
      *
      *  \par Command Structure
-     *       #CF_NoArgsCmd_t
+     *       No Payload / Arguments
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_ENABLE_ENGINE
      *
      *  \par Error Conditions
@@ -808,7 +681,7 @@ typedef enum
      *       - Engine already enabled, #CF_EID_ERR_CMD_ENG_ALREADY_ENA
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -826,12 +699,12 @@ typedef enum
      *       re-enabled the new configuration will take effect.
      *
      *  \par Command Structure
-     *       #CF_NoArgsCmd_t
+     *       No Payload / Arguments
      *
      *  \par Command Verification
      *       Successful execution of this command may be verified with
      *       the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
      *       - #CF_EID_INF_CMD_DISABLE_ENGINE
      *
      *  \par Error Conditions
@@ -840,7 +713,7 @@ typedef enum
      *       - Engine already disabled, #CF_EID_ERR_CMD_ENG_ALREADY_DIS
      *
      *  \par Evidence of failure may be found in the following telemetry:
-     *       - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
+     *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
      *
      *  \par Criticality
      *       None
@@ -855,177 +728,4 @@ typedef enum
 
 /**\}*/
 
-/**
- * \defgroup cfscfcmdstructs CFS CFDP Command Structures
- * \{
- */
-
-/**
- * \brief No arguments command structure
- *
- * For command details see #CF_NOOP_CC, #CF_ENABLE_ENGINE_CC, #CF_DISABLE_ENGINE_CC
- */
-typedef struct CF_NoArgsCmd
-{
-    CFE_MSG_CommandHeader_t cmd_header; /**< \brief Command header */
-} CF_NoArgsCmd_t;
-
-/**
- * \brief Command payload argument union to support 4 uint8's, 2 uint16's or 1 uint32
- */
-typedef union CF_UnionArgs_Payload
-{
-    uint32 dword;    /**< \brief Generic uint32 argument */
-    uint16 hword[2]; /**< \brief Generic uint16 array of arguments */
-    uint8  byte[4];  /**< \brief Generic uint8 array of arguments */
-} CF_UnionArgs_Payload_t;
-
-/**
- * \brief Generic command structure with arguments supports common handling on multiple command types
- *
- * For command details see #CF_RESET_CC, #CF_FREEZE_CC, #CF_THAW_CC, #CF_ENABLE_DEQUEUE_CC,
- * #CF_DISABLE_DEQUEUE_CC, #CF_ENABLE_DIR_POLLING_CC, #CF_ENABLE_DIR_POLLING_CC, #CF_PURGE_QUEUE_CC
- */
-typedef struct
-{
-    CFE_MSG_CommandHeader_t cmd_header; /**< \brief Command header */
-    CF_UnionArgs_Payload_t  data;       /**< \brief Generic command arguments */
-} CF_UnionArgsCmd_t;
-
-/**
- * \brief IDs for use for Reset cmd
- */
-typedef enum
-{
-    CF_Reset_all     = 0, /**< \brief Reset all */
-    CF_Reset_command = 1, /**< \brief Reset command */
-    CF_Reset_fault   = 2, /**< \brief Reset fault */
-    CF_Reset_up      = 3, /**< \brief Reset up */
-    CF_Reset_down    = 4  /**< \brief Reset down */
-} CF_Reset_t;
-
-/**
- * \brief Type IDs for use for Write Queue cmd
- */
-typedef enum
-{
-    CF_Type_all  = 0, /**< \brief Type all */
-    CF_Type_up   = 1, /**< \brief Type up */
-    CF_Type_down = 2  /**< \brief Type down */
-} CF_Type_t;
-
-/**
- * \brief Queue IDs for use for Write Queue cmd
- */
-typedef enum
-{
-    CF_Queue_pend    = 0, /**< \brief Queue pending */
-    CF_Queue_active  = 1, /**< \brief Queue active */
-    CF_Queue_history = 2, /**< \brief Queue history */
-    CF_Queue_all     = 3  /**< \brief Queue all */
-} CF_Queue_t;
-
-/**
- * \brief Parameter IDs for use with Get/Set parameter messages
- *
- * Specifically these are used for the "key" field within CF_GetParamCmd_t and
- * CF_SetParamCmd_t message structures.
- */
-typedef enum
-{
-    CF_GetSet_ValueID_ticks_per_second,                      /**< \brief Ticks per second key */
-    CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup,          /**< \brief Receive CRC calculated bytes per wake-up key */
-    CF_GetSet_ValueID_ack_timer_s,                           /**< \brief ACK timer in seconds key */
-    CF_GetSet_ValueID_nak_timer_s,                           /**< \brief NAK timer in seconds key */
-    CF_GetSet_ValueID_inactivity_timer_s,                    /**< \brief Inactivity timer in seconds key */
-    CF_GetSet_ValueID_outgoing_file_chunk_size,              /**< \brief Outgoing file chunk size key */
-    CF_GetSet_ValueID_ack_limit,                             /**< \brief ACK retry limit key */
-    CF_GetSet_ValueID_nak_limit,                             /**< \brief NAK retry limit key */
-    CF_GetSet_ValueID_local_eid,                             /**< \brief Local entity id key */
-    CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup, /**< \brief Max outgoing messages per wake-up key */
-    CF_GetSet_ValueID_MAX                                    /**< \brief Key limit used for validity check */
-} CF_GetSet_ValueID_t;
-
-/**
- * \brief Get parameter command structure
- *
- * For command details see #CF_GET_MIB_PARAM_CC
- */
-typedef struct CF_GetParamCmd
-{
-    CFE_MSG_CommandHeader_t cmd_header; /**< \brief Command header */
-    uint8                   key;        /**< \brief Parameter key, see #CF_GetSet_ValueID_t */
-    uint8                   chan_num;   /**< \brief Channel number */
-} CF_GetParamCmd_t;
-
-/**
- * \brief Set parameter command structure
- *
- * For command details see #CF_SET_MIB_PARAM_CC
- */
-typedef struct CF_SetParamCmd
-{
-    CFE_MSG_CommandHeader_t cmd_header; /**< \brief Command header */
-    uint32                  value;      /**< \brief Parameter value to set */
-    uint8                   key;        /**< \brief Parameter key, see #CF_GetSet_ValueID_t */
-    uint8                   chan_num;   /**< \brief Channel number */
-    uint8                   spare[2];   /**< \brief Alignment spare, uint32 multiple */
-} CF_SetParamCmd_t;
-
-/**
- * \brief Transmit file command structure
- *
- * For command details see #CF_TX_FILE_CC
- */
-typedef struct CF_TxFileCmd
-{
-    CFE_MSG_CommandHeader_t cmd_header;                        /**< \brief Command header */
-    uint8                   cfdp_class;                        /**< \brief CFDP class: 0=class 1, 1=class 2 */
-    uint8                   keep;                              /**< \brief Keep file flag: 1=keep, else delete */
-    uint8                   chan_num;                          /**< \brief Channel number */
-    uint8                   priority;                          /**< \brief Priority: 0=highest priority */
-    CF_EntityId_t           dest_id;                           /**< \brief Destination entity id */
-    char                    src_filename[CF_FILENAME_MAX_LEN]; /**< \brief Source file/directory name */
-    char                    dst_filename[CF_FILENAME_MAX_LEN]; /**< \brief Destination file/directory name */
-} CF_TxFileCmd_t;
-
-/**
- * \brief Write Queue command structure
- *
- * For command details see #CF_WRITE_QUEUE_CC
- */
-typedef struct CF_WriteQueueCmd
-{
-    CFE_MSG_CommandHeader_t cmd_header; /**< \brief Command header */
-    uint8                   type;       /**< \brief Transaction direction: all=0, up=1, down=2 */
-    uint8                   chan;       /**< \brief Channel number */
-    uint8                   queue;      /**< \brief Queue type: 0=pending, 1=active, 2=history, 3=all */
-    uint8                   spare;      /**< \brief Alignment spare, puts filename on 32-bit boundary */
-
-    char filename[CF_FILENAME_MAX_LEN]; /**< \brief Filename written to */
-} CF_WriteQueueCmd_t;
-
-/**
- * \brief Playback directory command structure
- *
- * For command details see #CF_PLAYBACK_DIR_CC
- */
-typedef CF_TxFileCmd_t CF_PlaybackDirCmd_t;
-
-/**
- * \brief Transaction command structure
- *
- * For command details see #CF_SUSPEND_CC, #CF_RESUME_CC, #CF_CANCEL_CC, #CF_ABANDON_CC
- */
-typedef struct CF_TransactionCmd
-{
-    CFE_MSG_CommandHeader_t cmd_header; /**< \brief Command header */
-    CF_TransactionSeq_t     ts;         /**< \brief Transaction sequence number */
-    CF_EntityId_t           eid;        /**< \brief Entity id */
-    uint8                   chan;       /**< \brief Channel number: 254=use ts, 255=all channels, else channel */
-    uint8                   spare[3];   /**< \brief Alignment spare for 32-bit multiple */
-} CF_TransactionCmd_t;
-
-/**\}*/
-
-#endif /* !CF_MSG_H */
+#endif

--- a/config/default_cf_interface_cfg.h
+++ b/config/default_cf_interface_cfg.h
@@ -19,17 +19,22 @@
 
 /**
  * @file
+ *   CFS CFDP (CF) Application Public Definitions
  *
- *  CF application platform configuration.
- *  These options are used to configure application behavior.
+ * This provides default values for configurable items that affect
+ * the interface(s) of this module.  This includes the CMD/TLM message
+ * interface, tables definitions, and any other data products that
+ * serve to exchange information with other entities.
+ *
+ * @note This file may be overridden/superceded by mission-provided defintions
+ * either by overriding this header or by generating definitions from a command/data
+ * dictionary tool.
  */
+#ifndef CF_INTERFACE_CFG_H
+#define CF_INTERFACE_CFG_H
 
-#ifndef CF_PLATFORM_CFG_H
-#define CF_PLATFORM_CFG_H
-
-/*************************************************************************
- * Macro definitions
- *************************************************************************/
+#include "common_types.h"
+#include "cfe_mission_cfg.h"
 
 /**
  * \defgroup cfscfplatformcfg CFS CFDP Platform Configuration
@@ -52,7 +57,7 @@
  *        CF_ConfigPacket_t, set config params command
  *        CF_TxFileCmd_t, transmit file command
  *        CF_PlaybackDirCmd_t, equivalent to above
- *        CF_TransactionCmd_t, any command that selects a transaction based on EID
+ *        CF_Transaction_Payload_t, any command that selects a transaction based on EID
  *
  * @par Limits
  *         Must be one of uint8, uint16, uint32, uint64.
@@ -71,25 +76,12 @@ typedef uint32 CF_EntityId_t;
  *
  * @note This type is used in several CF commands, and so changing the size
  *       of this type will affect the following structure:
- *        CF_TransactionCmd_t, any command that selects a transaction based on TSN
+ *        CF_Transaction_Payload_t, any command that selects a transaction based on TSN
  *
  * @par Limits
  *         Must be one of uint8, uint16, uint32, uint64.
  */
 typedef uint32 CF_TransactionSeq_t;
-
-/**
- *  @brief Application Pipe Depth
- *
- *  @par Description:
- *       Dictates the pipe depth of the cf command pipe.
- *
- *  @par Limits:
- *		 The minimum size of this parameter is 1
- *       The maximum size dictated by cFE platform configuration
- *		 parameter is CFE_SB_MAX_PIPE_DEPTH
- */
-#define CF_PIPE_DEPTH (32)
 
 /**
  *  @brief Number of channels
@@ -117,44 +109,6 @@ typedef uint32 CF_TransactionSeq_t;
 #define CF_NAK_MAX_SEGMENTS (58)
 
 /**
- *  @brief RX chunks per transaction (per channel)
- *
- *  @par Description:
- *       Number of chunks per transaction per channel (RX).
- *
- * CHUNKS -
- * A chunk is a representation of a range (offset, size) of data received by a receiver.
- *
- * Class 2 CFDP deals with NAK, so received data must be tracked for receivers in order to generate
- * the NAK. The sender must also keep track of NAK requests and send new file data PDUs as a result.
- * (array size must be CF_NUM_CHANNELS)
- * CF_CHANNEL_NUM_RX_CHUNKS_PER_TRANSACTION is an array for each channel indicating the number of chunks per transaction
- * CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION is an array for each channel indicating the number of chunks to keep track
- * of NAK requests from the receiver per transaction
- *
- *  @par Limits:
- *
- */
-#define CF_CHANNEL_NUM_RX_CHUNKS_PER_TRANSACTION \
-    {                                            \
-        CF_NAK_MAX_SEGMENTS, CF_NAK_MAX_SEGMENTS \
-    }
-
-/**
- *  @brief TX chunks per transaction (per channel)
- *
- *  @par Description:
- *       Number of chunks per transaction per channel (TX).
- *
- *  @par Limits:
- *
- */
-#define CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION \
-    {                                            \
-        CF_NAK_MAX_SEGMENTS, CF_NAK_MAX_SEGMENTS \
-    }
-
-/**
  *  @brief Total number of chunks (tx, rx, all channels)
  *
  *  @par Description:
@@ -168,42 +122,6 @@ typedef uint32 CF_TransactionSeq_t;
 /* (in other words, the summation of all elements in CF_CHANNEL_NUM_R/TX_CHUNKS_PER_TRANSACTION */
 #define CF_TOTAL_CHUNKS (CF_NAK_MAX_SEGMENTS * 4)
 
-/* definitions that affect file queuing */
-/**
- *  @brief Number of max commanded playback files per chan.
- *
- *  @par Description:
- *       This is the max number of outstanding ground commanded file transmits per channel.
- *
- *  @par Limits:
- *
- */
-#define CF_MAX_COMMANDED_PLAYBACK_FILES_PER_CHAN (10)
-
-/**
- *  @brief Max number of simultaneous file receives.
- *
- *  @par Description:
- *       Each channel can support this number of file receive transactions at a time.
- *
- *  @par Limits:
- *
- */
-#define CF_MAX_SIMULTANEOUS_RX (5)
-
-/* definitions that affect execution */
-
-/**
- *  @brief Max number of commanded playback directories per channel.
- *
- *  @par Description:
- *       Each channel can support this number of ground commanded directory playbacks.
- *
- *  @par Limits:
- *
- */
-#define CF_MAX_COMMANDED_PLAYBACK_DIRECTORIES_PER_CHAN (2)
-
 /**
  *  @brief Max number of polling directories per channel.
  *
@@ -215,29 +133,6 @@ typedef uint32 CF_TransactionSeq_t;
  *
  */
 #define CF_MAX_POLLING_DIR_PER_CHAN (5)
-
-/**
- *  @brief Number of transactions per playback directory.
- *
- *  @par Description:
- *       Each playback/polling directory operation will be able to have this
- *       many active transfers at a time pending or active.
- *
- *  @par Limits:
- *
- */
-#define CF_NUM_TRANSACTIONS_PER_PLAYBACK (5)
-
-/**
- *  @brief Number of histories per channel
- *
- *  @par Description:
- *       Each channel can support this number of file receive transactions at a time.
- *
- *  @par Limits:
- *       65536 is the current max.
- */
-#define CF_NUM_HISTORIES_PER_CHANNEL (256)
 
 /**
  *  @brief Max PDU size.
@@ -256,36 +151,12 @@ typedef uint32 CF_TransactionSeq_t;
 #define CF_MAX_PDU_SIZE (512)
 
 /**
- *  @brief Name of the CF Configuration Table
- *
- *  @par Description:
- *       This parameter defines the name of the CF Configuration Table.
- *
- *  @par Limits
- *       The length of this string, including the NULL terminator cannot exceed
- *       the #OS_MAX_PATH_LEN value.
- */
-#define CF_CONFIG_TABLE_NAME ("config_table")
-
-/**
- *  @brief CF Configuration Table Filename
- *
- *  @par Description:
- *       The value of this constant defines the filename of the CF Config Table
- *
- *  @par Limits
- *       The length of this string, including the NULL terminator cannot exceed
- *       the #OS_MAX_PATH_LEN value.
- */
-#define CF_CONFIG_TABLE_FILENAME ("/cf/cf_def_config.tbl")
-
-/**
  *  @brief Maximum file name length.
  *
  *  @par Limits:
  *
  */
-#define CF_FILENAME_MAX_NAME (OS_MAX_FILE_NAME)
+#define CF_FILENAME_MAX_NAME CFE_MISSION_MAX_FILE_LEN
 
 /**
  *  @brief Maximum file path (not including file name)
@@ -293,7 +164,7 @@ typedef uint32 CF_TransactionSeq_t;
  *  @par Limits:
  *
  */
-#define CF_FILENAME_MAX_PATH (OS_MAX_PATH_LEN - OS_MAX_FILE_NAME)
+#define CF_FILENAME_MAX_PATH (CFE_MISSION_MAX_PATH_LEN - CFE_MISSION_MAX_FILE_LEN)
 
 /**
  *  @brief Max filename and path length.
@@ -301,52 +172,7 @@ typedef uint32 CF_TransactionSeq_t;
  *  @par Limits:
  *
  */
-#define CF_FILENAME_MAX_LEN (CF_FILENAME_MAX_NAME + CF_FILENAME_MAX_PATH)
-
-/**
- *  @brief R2 CRC calc chunk size
- *
- *  @par Description
- *       R2 performs CRC calculation upon file completion in chunks. This is the size
- *       of the buffer. The larger the size the more stack will be used, but
- *       the faster it can go. The overall number of bytes calculated per wakeup
- *       is set in the configuration table.
- *
- *  @par Limits:
- *
- */
-#define CF_R2_CRC_CHUNK_SIZE (1024)
-
-#if CF_FILENAME_MAX_LEN > OS_MAX_PATH_LEN
-#error CF_FILENAME_MAX_LEN must be <= OS_MAX_PATH_LEN
-#endif
-
-/**
- *  @brief Number of milliseconds to wait for a SB message
- */
-#define CF_RCVMSG_TIMEOUT (100)
-
-/**
- * @brief Limits the number of retries to obtain the CF throttle sem
- *
- * @par Description
- *      If the CF throttle sem is not available during CF startup, the initialization
- *      will retry after a short delay.
- *
- * @sa CF_STARTUP_SEM_TASK_DELAY
- */
-#define CF_STARTUP_SEM_MAX_RETRIES 25
-
-/**
- * @brief Number of milliseconds to wait if CF throttle sem is not available
- *
- * @par Description
- *      If the CF throttle sem is not available during CF startup, the initialization
- *      will delay for this period of time before trying again
- *
- * @sa CF_STARTUP_SEM_MAX_RETRIES
- */
-#define CF_STARTUP_SEM_TASK_DELAY 100
+#define CF_FILENAME_MAX_LEN CFE_MISSION_MAX_PATH_LEN
 
 /**
  * @brief Number of trailing bytes to add to CFDP PDU
@@ -388,4 +214,4 @@ typedef uint32 CF_TransactionSeq_t;
 
 /**\}*/
 
-#endif /* !CF_PLATFORM_CFG_H */
+#endif

--- a/config/default_cf_internal_cfg.h
+++ b/config/default_cf_internal_cfg.h
@@ -1,0 +1,235 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (CF) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   CFS CFDP (CF) Application Private Config Definitions
+ *
+ * This provides default values for configurable items that are internal
+ * to this module and do NOT affect the interface(s) of this module.  Changes
+ * to items in this file only affect the local module and will be transparent
+ * to external entities that are using the public interface(s).
+ *
+ * @note This file may be overridden/superceded by mission-provided defintions
+ * either by overriding this header or by generating definitions from a command/data
+ * dictionary tool.
+ */
+#ifndef CF_INTERNAL_CFG_H
+#define CF_INTERNAL_CFG_H
+
+/**
+ * \defgroup cfscfplatformcfg CFS CFDP Platform Configuration
+ * \{
+ */
+
+/**
+ *  @brief RX chunks per transaction (per channel)
+ *
+ *  @par Description:
+ *       Number of chunks per transaction per channel (RX).
+ *
+ * CHUNKS -
+ * A chunk is a representation of a range (offset, size) of data received by a receiver.
+ *
+ * Class 2 CFDP deals with NAK, so received data must be tracked for receivers in order to generate
+ * the NAK. The sender must also keep track of NAK requests and send new file data PDUs as a result.
+ * (array size must be CF_NUM_CHANNELS)
+ * CF_CHANNEL_NUM_RX_CHUNKS_PER_TRANSACTION is an array for each channel indicating the number of chunks per transaction
+ * CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION is an array for each channel indicating the number of chunks to keep track
+ * of NAK requests from the receiver per transaction
+ *
+ *  @par Limits:
+ *
+ */
+#define CF_CHANNEL_NUM_RX_CHUNKS_PER_TRANSACTION \
+    {                                            \
+        CF_NAK_MAX_SEGMENTS, CF_NAK_MAX_SEGMENTS \
+    }
+
+/**
+ *  @brief TX chunks per transaction (per channel)
+ *
+ *  @par Description:
+ *       Number of chunks per transaction per channel (TX).
+ *
+ *  @par Limits:
+ *
+ */
+#define CF_CHANNEL_NUM_TX_CHUNKS_PER_TRANSACTION \
+    {                                            \
+        CF_NAK_MAX_SEGMENTS, CF_NAK_MAX_SEGMENTS \
+    }
+
+/**
+ *  @brief Application Pipe Depth
+ *
+ *  @par Description:
+ *       Dictates the pipe depth of the cf command pipe.
+ *
+ *  @par Limits:
+ *		 The minimum size of this parameter is 1
+ *       The maximum size dictated by cFE platform configuration
+ *		 parameter is CFE_SB_MAX_PIPE_DEPTH
+ */
+#define CF_PIPE_DEPTH (32)
+
+/**
+ *  @brief Number of max commanded playback files per chan.
+ *
+ *  @par Description:
+ *       This is the max number of outstanding ground commanded file transmits per channel.
+ *
+ *  @par Limits:
+ *
+ */
+#define CF_MAX_COMMANDED_PLAYBACK_FILES_PER_CHAN (10)
+
+/**
+ *  @brief Max number of simultaneous file receives.
+ *
+ *  @par Description:
+ *       Each channel can support this number of file receive transactions at a time.
+ *
+ *  @par Limits:
+ *
+ */
+#define CF_MAX_SIMULTANEOUS_RX (5)
+
+/* definitions that affect execution */
+
+/**
+ *  @brief Max number of commanded playback directories per channel.
+ *
+ *  @par Description:
+ *       Each channel can support this number of ground commanded directory playbacks.
+ *
+ *  @par Limits:
+ *
+ */
+#define CF_MAX_COMMANDED_PLAYBACK_DIRECTORIES_PER_CHAN (2)
+
+/**
+ *  @brief Number of histories per channel
+ *
+ *  @par Description:
+ *       Each channel can support this number of file receive transactions at a time.
+ *
+ *  @par Limits:
+ *       65536 is the current max.
+ */
+#define CF_NUM_HISTORIES_PER_CHANNEL (256)
+
+/**
+ *  @brief Number of transactions per playback directory.
+ *
+ *  @par Description:
+ *       Each playback/polling directory operation will be able to have this
+ *       many active transfers at a time pending or active.
+ *
+ *  @par Limits:
+ *
+ */
+#define CF_NUM_TRANSACTIONS_PER_PLAYBACK (5)
+
+/**
+ *  @brief Name of the CF Configuration Table
+ *
+ *  @par Description:
+ *       This parameter defines the name of the CF Configuration Table.
+ *
+ *  @par Limits
+ *       The length of this string, including the NULL terminator cannot exceed
+ *       the #OS_MAX_PATH_LEN value.
+ */
+#define CF_CONFIG_TABLE_NAME ("config_table")
+
+/**
+ *  @brief CF Configuration Table Filename
+ *
+ *  @par Description:
+ *       The value of this constant defines the filename of the CF Config Table
+ *
+ *  @par Limits
+ *       The length of this string, including the NULL terminator cannot exceed
+ *       the #OS_MAX_PATH_LEN value.
+ */
+#define CF_CONFIG_TABLE_FILENAME ("/cf/cf_def_config.tbl")
+
+/**
+ *  @brief R2 CRC calc chunk size
+ *
+ *  @par Description
+ *       R2 performs CRC calculation upon file completion in chunks. This is the size
+ *       of the buffer. The larger the size the more stack will be used, but
+ *       the faster it can go. The overall number of bytes calculated per wakeup
+ *       is set in the configuration table.
+ *
+ *  @par Limits:
+ *
+ */
+#define CF_R2_CRC_CHUNK_SIZE (1024)
+
+/**
+ *  @brief Number of milliseconds to wait for a SB message
+ */
+#define CF_RCVMSG_TIMEOUT (100)
+
+/**
+ * @brief Limits the number of retries to obtain the CF throttle sem
+ *
+ * @par Description
+ *      If the CF throttle sem is not available during CF startup, the initialization
+ *      will retry after a short delay.
+ *
+ * @sa CF_STARTUP_SEM_TASK_DELAY
+ */
+#define CF_STARTUP_SEM_MAX_RETRIES 25
+
+/**
+ * @brief Number of milliseconds to wait if CF throttle sem is not available
+ *
+ * @par Description
+ *      If the CF throttle sem is not available during CF startup, the initialization
+ *      will delay for this period of time before trying again
+ *
+ * @sa CF_STARTUP_SEM_MAX_RETRIES
+ */
+#define CF_STARTUP_SEM_TASK_DELAY 100
+
+/**\}*/
+
+#endif

--- a/config/default_cf_mission_cfg.h
+++ b/config/default_cf_mission_cfg.h
@@ -19,31 +19,19 @@
 
 /**
  * @file
- *  The CF Application Message IDs header file
+ *
+ * CFS CFDP (CF) Application Mission Configuration Header File
+ *
+ * This is a compatibility header for the "mission_cfg.h" file that has
+ * traditionally provided public config definitions for each CFS app.
+ *
+ * @note This file may be overridden/superceded by mission-provided defintions
+ * either by overriding this header or by generating definitions from a command/data
+ * dictionary tool.
  */
+#ifndef CF_MISSION_CFG_H
+#define CF_MISSION_CFG_H
 
-#ifndef CF_MSGIDS_H
-#define CF_MSGIDS_H
+#include "cf_interface_cfg.h"
 
-/**
- * \defgroup cfscfcmdmid CFS CFDP Command Message IDs
- * \{
- */
-
-#define CF_CMD_MID     (0x18B3) /**< \brief Message ID for commands */
-#define CF_SEND_HK_MID (0x18B4) /**< \brief Message ID to request housekeeping telemetry */
-#define CF_WAKE_UP_MID (0x18B5) /**< \brief Message ID for waking up the processing cycle */
-
-/**\}*/
-
-/**
- * \defgroup cfscftlmmid CFS CFDP Telemetry Message IDs
- * \{
- */
-
-#define CF_HK_TLM_MID  (0x08B0) /**< \brief Message ID for housekeeping telemetry */
-#define CF_EOT_TLM_MID (0x08B3) /**< \brief Message ID for end of transaction telemetry */
-
-/**\}*/
-
-#endif /* !CF_MSGIDS_H */
+#endif

--- a/config/default_cf_msg.h
+++ b/config/default_cf_msg.h
@@ -1,0 +1,44 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Specification for the CFS CFDP (CF) command and telemetry
+ *   message data types.
+ *
+ * This is a compatibility header for the "cf_msg.h" file that has
+ * traditionally provided the message definitions for cFS apps.
+ *
+ * @note This file may be overridden/superceded by mission-provided defintions
+ * either by overriding this header or by generating definitions from a command/data
+ * dictionary tool.
+ */
+#ifndef CF_MSG_H
+#define CF_MSG_H
+
+#include "cf_interface_cfg.h"
+#include "cf_fcncodes.h"
+#include "cf_msgdefs.h"
+#include "cf_msgstruct.h"
+
+#define CF_COMPOUND_KEY (254)
+#define CF_ALL_CHANNELS (255)
+#define CF_ALL_POLLDIRS (CF_ALL_CHANNELS)
+
+#endif

--- a/config/default_cf_msgdefs.h
+++ b/config/default_cf_msgdefs.h
@@ -1,0 +1,282 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Specification for the CFS CFDP (CF) command and telemetry
+ *   message payload content definitions.
+ */
+#ifndef CF_MSGDEFS_H
+#define CF_MSGDEFS_H
+
+#include "common_types.h"
+#include "cf_extern_typedefs.h"
+
+/**
+ * \defgroup cfscftlm CFS CFDP Telemetry
+ * \{
+ */
+
+/**
+ * \brief Housekeeping command counters
+ */
+typedef struct CF_HkCmdCounters
+{
+    uint16 cmd; /**< \brief Command success counter */
+    uint16 err; /**< \brief Command error counter */
+} CF_HkCmdCounters_t;
+
+/**
+ * \brief Housekeeping sent counters
+ */
+typedef struct CF_HkSent
+{
+    uint64 file_data_bytes;      /**< \brief Sent File data bytes */
+    uint32 pdu;                  /**< \brief Sent PDUs counter */
+    uint32 nak_segment_requests; /**< \brief Sent NAK segment requests counter */
+} CF_HkSent_t;
+
+/**
+ * \brief Housekeeping received counters
+ */
+typedef struct CF_HkRecv
+{
+    uint64 file_data_bytes;      /**< \brief Received File data bytes */
+    uint32 pdu;                  /**< \brief Received PDUs with valid header counter */
+    uint32 error;                /**< \brief Received PDUs with error counter, see related event for cause */
+    uint16 spurious;             /**< \brief Received PDUs with invalid directive code for current context or
+                                  *          file directive FIN without matching active transaction counter,
+                                  *          see related event for cause
+                                  */
+    uint16 dropped;              /**< \brief Received PDUs dropped due to a transaction error */
+    uint32 nak_segment_requests; /**< \brief Received NAK segment requests counter */
+} CF_HkRecv_t;
+
+/**
+ * \brief Housekeeping fault counters
+ */
+typedef struct CF_HkFault
+{
+    uint16 file_open;          /**< \brief File open fault counter */
+    uint16 file_read;          /**< \brief File read fault counter */
+    uint16 file_seek;          /**< \brief File seek fault counter */
+    uint16 file_write;         /**< \brief File write fault counter */
+    uint16 file_rename;        /**< \brief File rename fault counter */
+    uint16 directory_read;     /**< \brief Directory read fault counter */
+    uint16 crc_mismatch;       /**< \brief CRC mismatch fault counter */
+    uint16 file_size_mismatch; /**< \brief File size mismatch fault counter */
+    uint16 nak_limit;          /**< \brief NAK limit exceeded fault counter */
+    uint16 ack_limit;          /**< \brief ACK limit exceeded fault counter */
+    uint16 inactivity_timer;   /**< \brief Inactivity timer exceeded counter */
+    uint16 spare;              /**< \brief Alignment spare to avoid implicit padding */
+} CF_HkFault_t;
+
+/**
+ * \brief Housekeeping counters
+ */
+typedef struct CF_HkCounters
+{
+    CF_HkSent_t  sent;  /**< \brief Sent counters */
+    CF_HkRecv_t  recv;  /**< \brief Received counters */
+    CF_HkFault_t fault; /**< \brief Fault counters */
+} CF_HkCounters_t;
+
+/**
+ * \brief Housekeeping channel data
+ */
+typedef struct CF_HkChannel_Data
+{
+    CF_HkCounters_t counters;                /**< \brief Counters */
+    uint16          q_size[CF_QueueIdx_NUM]; /**< \brief Queue sizes */
+    uint8           poll_counter;            /**< \brief Number of active polling directories */
+    uint8           playback_counter;        /**< \brief Number of active playback directories */
+    uint8           frozen;                  /**< \brief Frozen state: 0 == not frozen, else frozen */
+    uint8           spare[7];                /**< \brief Alignment spare (uint64 values in the counters) */
+} CF_HkChannel_Data_t;
+
+/**
+ * \brief Housekeeping packet
+ */
+typedef struct CF_HkPacket_Payload
+{
+    CF_HkCmdCounters_t counters; /**< \brief Command counters */
+    uint8              spare[4]; /**< \brief Alignment spare (CF_HkCmdCounters_t is 4 bytes) */
+
+    CF_HkChannel_Data_t channel_hk[CF_NUM_CHANNELS]; /**< \brief Per channel housekeeping data */
+} CF_HkPacket_Payload_t;
+
+/**
+ * \brief End of transaction packet
+ */
+typedef struct CF_EotPacket_Payload
+{
+    CF_TransactionSeq_t seq_num;    /**< \brief transaction identifier, stays constant for entire transfer */
+    uint32              channel;    /**< \brief Channel number */
+    uint32              direction;  /**< \brief direction of this transaction */
+    uint32              state;      /**< \brief Transaction state */
+    uint32              txn_stat;   /**< \brief final status code of transaction (extended CFDP CC) */
+    CF_EntityId_t       src_eid;    /**< \brief the source eid of the transaction */
+    CF_EntityId_t       peer_eid;   /**< \brief peer_eid is always the "other guy", same src_eid for RX */
+    uint32              fsize;      /**< \brief File size */
+    uint32              crc_result; /**< \brief CRC result */
+    CF_TxnFilenames_t   fnames;     /**< \brief file names associated with this transaction */
+} CF_EotPacket_Payload_t;
+
+/**\}*/
+
+/**
+ * \defgroup cfscfcmdstructs CFS CFDP Command Structures
+ * \{
+ */
+
+/**
+ * \brief Command payload argument union to support 4 uint8's, 2 uint16's or 1 uint32
+ */
+typedef union CF_UnionArgs_Payload
+{
+    uint32 dword;    /**< \brief Generic uint32 argument */
+    uint16 hword[2]; /**< \brief Generic uint16 array of arguments */
+    uint8  byte[4];  /**< \brief Generic uint8 array of arguments */
+} CF_UnionArgs_Payload_t;
+
+/**
+ * \brief IDs for use for Reset cmd
+ */
+typedef enum
+{
+    CF_Reset_all     = 0, /**< \brief Reset all */
+    CF_Reset_command = 1, /**< \brief Reset command */
+    CF_Reset_fault   = 2, /**< \brief Reset fault */
+    CF_Reset_up      = 3, /**< \brief Reset up */
+    CF_Reset_down    = 4  /**< \brief Reset down */
+} CF_Reset_t;
+
+/**
+ * \brief Type IDs for use for Write Queue cmd
+ */
+typedef enum
+{
+    CF_Type_all  = 0, /**< \brief Type all */
+    CF_Type_up   = 1, /**< \brief Type up */
+    CF_Type_down = 2  /**< \brief Type down */
+} CF_Type_t;
+
+/**
+ * \brief Queue IDs for use for Write Queue cmd
+ */
+typedef enum
+{
+    CF_Queue_pend    = 0, /**< \brief Queue pending */
+    CF_Queue_active  = 1, /**< \brief Queue active */
+    CF_Queue_history = 2, /**< \brief Queue history */
+    CF_Queue_all     = 3  /**< \brief Queue all */
+} CF_Queue_t;
+
+/**
+ * \brief Parameter IDs for use with Get/Set parameter messages
+ *
+ * Specifically these are used for the "key" field within CF_GetParamCmd_t and
+ * CF_SetParamCmd_t message structures.
+ */
+typedef enum
+{
+    CF_GetSet_ValueID_ticks_per_second,                      /**< \brief Ticks per second key */
+    CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup,          /**< \brief Receive CRC calculated bytes per wake-up key */
+    CF_GetSet_ValueID_ack_timer_s,                           /**< \brief ACK timer in seconds key */
+    CF_GetSet_ValueID_nak_timer_s,                           /**< \brief NAK timer in seconds key */
+    CF_GetSet_ValueID_inactivity_timer_s,                    /**< \brief Inactivity timer in seconds key */
+    CF_GetSet_ValueID_outgoing_file_chunk_size,              /**< \brief Outgoing file chunk size key */
+    CF_GetSet_ValueID_ack_limit,                             /**< \brief ACK retry limit key */
+    CF_GetSet_ValueID_nak_limit,                             /**< \brief NAK retry limit key */
+    CF_GetSet_ValueID_local_eid,                             /**< \brief Local entity id key */
+    CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup, /**< \brief Max outgoing messages per wake-up key */
+    CF_GetSet_ValueID_MAX                                    /**< \brief Key limit used for validity check */
+} CF_GetSet_ValueID_t;
+
+/**
+ * \brief Get parameter command structure
+ *
+ * For command details see #CF_GET_MIB_PARAM_CC
+ */
+typedef struct CF_GetParam_Payload
+{
+    uint8 key;      /**< \brief Parameter key, see #CF_GetSet_ValueID_t */
+    uint8 chan_num; /**< \brief Channel number */
+} CF_GetParam_Payload_t;
+
+/**
+ * \brief Set parameter command structure
+ *
+ * For command details see #CF_SET_MIB_PARAM_CC
+ */
+typedef struct CF_SetParam_Payload
+{
+    uint32 value;    /**< \brief Parameter value to set */
+    uint8  key;      /**< \brief Parameter key, see #CF_GetSet_ValueID_t */
+    uint8  chan_num; /**< \brief Channel number */
+    uint8  spare[2]; /**< \brief Alignment spare, uint32 multiple */
+} CF_SetParam_Payload_t;
+
+/**
+ * \brief Transmit file command structure
+ *
+ * For command details see #CF_TX_FILE_CC
+ */
+typedef struct CF_TxFile_Payload
+{
+    uint8         cfdp_class;                        /**< \brief CFDP class: 0=class 1, 1=class 2 */
+    uint8         keep;                              /**< \brief Keep file flag: 1=keep, else delete */
+    uint8         chan_num;                          /**< \brief Channel number */
+    uint8         priority;                          /**< \brief Priority: 0=highest priority */
+    CF_EntityId_t dest_id;                           /**< \brief Destination entity id */
+    char          src_filename[CF_FILENAME_MAX_LEN]; /**< \brief Source file/directory name */
+    char          dst_filename[CF_FILENAME_MAX_LEN]; /**< \brief Destination file/directory name */
+} CF_TxFile_Payload_t;
+
+/**
+ * \brief Write Queue command structure
+ *
+ * For command details see #CF_WRITE_QUEUE_CC
+ */
+typedef struct CF_WriteQueue_Payload
+{
+    uint8 type;  /**< \brief Transaction direction: all=0, up=1, down=2 */
+    uint8 chan;  /**< \brief Channel number */
+    uint8 queue; /**< \brief Queue type: 0=pending, 1=active, 2=history, 3=all */
+    uint8 spare; /**< \brief Alignment spare, puts filename on 32-bit boundary */
+
+    char filename[CF_FILENAME_MAX_LEN]; /**< \brief Filename written to */
+} CF_WriteQueue_Payload_t;
+
+/**
+ * \brief Transaction command structure
+ *
+ * For command details see #CF_SUSPEND_CC, #CF_RESUME_CC, #CF_CANCEL_CC, #CF_ABANDON_CC
+ */
+typedef struct CF_Transaction_Payload
+{
+    CF_TransactionSeq_t ts;       /**< \brief Transaction sequence number */
+    CF_EntityId_t       eid;      /**< \brief Entity id */
+    uint8               chan;     /**< \brief Channel number: 254=use ts, 255=all channels, else channel */
+    uint8               spare[3]; /**< \brief Alignment spare for 32-bit multiple */
+} CF_Transaction_Payload_t;
+
+/**\}*/
+
+#endif

--- a/config/default_cf_msgids.h
+++ b/config/default_cf_msgids.h
@@ -1,0 +1,48 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   CFS CFDP (CF) Application Message IDs
+ */
+#ifndef CF_MSGIDS_H
+#define CF_MSGIDS_H
+
+/**
+ * \defgroup cfscfcmdmid CFS CFDP Command Message IDs
+ * \{
+ */
+
+#define CF_CMD_MID     (0x18B3) /**< \brief Message ID for commands */
+#define CF_SEND_HK_MID (0x18B4) /**< \brief Message ID to request housekeeping telemetry */
+#define CF_WAKE_UP_MID (0x18B5) /**< \brief Message ID for waking up the processing cycle */
+
+/**\}*/
+
+/**
+ * \defgroup cfscftlmmid CFS CFDP Telemetry Message IDs
+ * \{
+ */
+
+#define CF_HK_TLM_MID  (0x08B0) /**< \brief Message ID for housekeeping telemetry */
+#define CF_EOT_TLM_MID (0x08B3) /**< \brief Message ID for end of transaction telemetry */
+
+/**\}*/
+
+#endif

--- a/config/default_cf_msgstruct.h
+++ b/config/default_cf_msgstruct.h
@@ -1,0 +1,288 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Specification for the CFS CFDP (CF) command and telemetry
+ *   message data types.
+ *
+ * @note
+ *   Constants and enumerated types related to these message structures
+ *   are defined in cf_msgdefs.h.
+ */
+#ifndef CF_MSGSTRUCT_H
+#define CF_MSGSTRUCT_H
+
+/************************************************************************
+ * Includes
+ ************************************************************************/
+#include "cf_msgdefs.h"
+#include "cf_mission_cfg.h"
+#include "cfe_msg_hdr.h"
+
+/**
+ * \defgroup cfscftlm CFS CFDP Telemetry
+ * \{
+ */
+
+/**
+ * \brief Housekeeping packet
+ */
+typedef struct CF_HkPacket
+{
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry header */
+    CF_HkPacket_Payload_t     Payload;
+} CF_HkPacket_t;
+
+/**
+ * \brief End of transaction packet
+ */
+typedef struct CF_EotPacket
+{
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry header */
+    CF_EotPacket_Payload_t    Payload;
+} CF_EotPacket_t;
+
+/**\}*/
+
+/**
+ * \defgroup cfscfcmdstructs CFS CFDP Command Structures
+ * \{
+ */
+
+/**
+ * \brief Noop command structure
+ *
+ * For command details see #CF_NOOP_CC
+ */
+typedef struct CF_NoopCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CF_NoopCmd_t;
+
+/**
+ * \brief EnableEngine command structure
+ *
+ * For command details see #CF_ENABLE_ENGINE_CC
+ */
+typedef struct CF_EnableEngineCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CF_EnableEngineCmd_t;
+
+/**
+ * \brief DisableEngine command structure
+ *
+ * For command details see #CF_DISABLE_ENGINE_CC
+ */
+typedef struct CF_DisableEngineCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CF_DisableEngineCmd_t;
+
+/**
+ * \brief Reset command structure
+ *
+ * For command details see #CF_RESET_CC
+ */
+typedef struct CF_ResetCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_ResetCmd_t;
+
+/**
+ * \brief Freeze command structure
+ *
+ * For command details see #CF_FREEZE_CC
+ */
+typedef struct CF_FreezeCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_FreezeCmd_t;
+
+/**
+ * \brief Thaw command structure
+ *
+ * For command details see #CF_THAW_CC
+ */
+typedef struct CF_ThawCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_ThawCmd_t;
+
+/**
+ * \brief EnableDequeue command structure
+ *
+ * For command details see #CF_ENABLE_DEQUEUE_CC
+ */
+typedef struct CF_EnableDequeueCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_EnableDequeueCmd_t;
+
+/**
+ * \brief DisableDequeue command structure
+ *
+ * For command details see #CF_DISABLE_DEQUEUE_CC
+ */
+typedef struct CF_DisableDequeueCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_DisableDequeueCmd_t;
+
+/**
+ * \brief EnableDirPolling command structure
+ *
+ * For command details see #CF_ENABLE_DIR_POLLING_CC
+ */
+typedef struct CF_EnableDirPollingCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_EnableDirPollingCmd_t;
+
+/**
+ * \brief DisableDirPolling command structure
+ *
+ * For command details see #CF_DISABLE_DIR_POLLING_CC
+ */
+typedef struct CF_DisableDirPollingCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_DisableDirPollingCmd_t;
+
+/**
+ * \brief PurgeQueue command structure
+ *
+ * For command details see #CF_PURGE_QUEUE_CC
+ */
+typedef struct CF_PurgeQueueCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_UnionArgs_Payload_t  Payload;       /**< \brief Generic command arguments */
+} CF_PurgeQueueCmd_t;
+
+/**
+ * \brief Get parameter command structure
+ *
+ * For command details see #CF_GET_MIB_PARAM_CC
+ */
+typedef struct CF_GetParamCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_GetParam_Payload_t   Payload;
+} CF_GetParamCmd_t;
+
+/**
+ * \brief Set parameter command structure
+ *
+ * For command details see #CF_SET_MIB_PARAM_CC
+ */
+typedef struct CF_SetParamCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_SetParam_Payload_t   Payload;
+} CF_SetParamCmd_t;
+
+/**
+ * \brief Transmit file command structure
+ *
+ * For command details see #CF_TX_FILE_CC
+ */
+typedef struct CF_TxFileCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_TxFile_Payload_t     Payload;
+} CF_TxFileCmd_t;
+
+/**
+ * \brief Write Queue command structure
+ *
+ * For command details see #CF_WRITE_QUEUE_CC
+ */
+typedef struct CF_WriteQueueCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_WriteQueue_Payload_t Payload;
+} CF_WriteQueueCmd_t;
+
+/**
+ * \brief Playback directory command structure
+ *
+ * For command details see #CF_PLAYBACK_DIR_CC
+ */
+typedef struct CF_PlaybackDirCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+    CF_TxFile_Payload_t     Payload;
+} CF_PlaybackDirCmd_t;
+
+/**
+ * \brief Suspend command structure
+ *
+ * For command details see #CF_SUSPEND_CC
+ */
+typedef struct CF_SuspendCmd
+{
+    CFE_MSG_CommandHeader_t  CommandHeader; /**< \brief Command header */
+    CF_Transaction_Payload_t Payload;
+} CF_SuspendCmd_t;
+
+/**
+ * \brief Resume command structure
+ *
+ * For command details see #CF_RESUME_CC
+ */
+typedef struct CF_ResumeCmd
+{
+    CFE_MSG_CommandHeader_t  CommandHeader; /**< \brief Command header */
+    CF_Transaction_Payload_t Payload;
+} CF_ResumeCmd_t;
+
+/**
+ * \brief Cancel command structure
+ *
+ * For command details see #CF_CANCEL_CC
+ */
+typedef struct CF_CancelCmd
+{
+    CFE_MSG_CommandHeader_t  CommandHeader; /**< \brief Command header */
+    CF_Transaction_Payload_t Payload;
+} CF_CancelCmd_t;
+
+/**
+ * \brief Abandon command structure
+ *
+ * For command details see #CF_ABANDON_CC
+ */
+typedef struct CF_AbandonCmd
+{
+    CFE_MSG_CommandHeader_t  CommandHeader; /**< \brief Command header */
+    CF_Transaction_Payload_t Payload;
+} CF_AbandonCmd_t;
+
+/**\}*/
+
+#endif

--- a/config/default_cf_platform_cfg.h
+++ b/config/default_cf_platform_cfg.h
@@ -1,0 +1,42 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ * CFS CFDP (CF) Application Platform Configuration Header File
+ *
+ * This is a compatibility header for the "platform_cfg.h" file that has
+ * traditionally provided both public and private config definitions
+ * for each CFS app.
+ *
+ * These definitions are now provided in two separate files, one for
+ * the public/mission scope and one for internal scope.
+ *
+ * @note This file may be overridden/superceded by mission-provided defintions
+ * either by overriding this header or by generating definitions from a command/data
+ * dictionary tool.
+ */
+#ifndef CF_PLATFORM_CFG_H
+#define CF_PLATFORM_CFG_H
+
+#include "cf_mission_cfg.h"
+#include "cf_internal_cfg.h"
+
+#endif

--- a/config/default_cf_tbl.h
+++ b/config/default_cf_tbl.h
@@ -1,0 +1,35 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Specification for the CFS CFDP (CF) table structures
+ *
+ * @note
+ *   Constants and enumerated types related to these table structures
+ *   are defined in cf_tbldefs.h.
+ */
+#ifndef CF_TBL_H
+#define CF_TBL_H
+
+#include "cf_mission_cfg.h"
+#include "cf_tbldefs.h"
+#include "cf_tblstruct.h"
+
+#endif

--- a/config/default_cf_tbldefs.h
+++ b/config/default_cf_tbldefs.h
@@ -18,15 +18,21 @@
  ************************************************************************/
 
 /**
- * \file
- *  The CF Application Table Definitions header file
+ * @file
+ *   Specification for the CFS CFDP (CF) table related
+ *   constant definitions.
+ *
+ * @note
+ *   These Macro definitions have been put in this file (instead of
+ *   cf_tbl.h). DO NOT PUT ANY TYPEDEFS OR
+ *   STRUCTURE DEFINITIONS IN THIS FILE!
+ *   ADD THEM TO cf_tbl.h IF NEEDED!
  */
-
 #ifndef CF_TBLDEFS_H
 #define CF_TBLDEFS_H
 
-#include <cf_platform_cfg.h>
-#include <cf_extern_typedefs.h>
+#include "cf_mission_cfg.h"
+#include "cf_extern_typedefs.h"
 
 /**
  * \brief Configuration entry for directory polling
@@ -72,23 +78,13 @@ typedef struct CF_ChannelConfig
     char  move_dir[OS_MAX_PATH_LEN]; /**< \brief Move directory if not empty */
 } CF_ChannelConfig_t;
 
-/**
- * \brief Top-level CFDP configuration structure
+
+/*
+ * Previously, the entire definition of the CF table was in this file, now it is split.
+ * For backward compatibility with existing CF table definitions, include the other part here.
  */
-typedef struct CF_ConfigTable
-{
-    uint32 ticks_per_second;             /**< \brief expected ticks per second to CFDP app */
-    uint32 rx_crc_calc_bytes_per_wakeup; /**< \brief max number of bytes per wakeup to calculate
-                                          * r2 CRC for recvd file (must be 1024-byte aligned)
-                                          */
+#ifndef CF_OMIT_DEPRECATED
+#include "cf_tblstruct.h"
+#endif
 
-    CF_EntityId_t local_eid; /**< \brief the local entity ID of the CF app */
-
-    CF_ChannelConfig_t chan[CF_NUM_CHANNELS]; /**< \brief Channel configuration */
-
-    uint16 outgoing_file_chunk_size;    /**< maximum size of outgoing file data PDUs - must be
-                                         *   smaller than file data character array */
-    char tmp_dir[CF_FILENAME_MAX_PATH]; /**< directory to put temp files */
-} CF_ConfigTable_t;
-
-#endif /* !CF_TBLDEFS_H */
+#endif

--- a/config/default_cf_tblstruct.h
+++ b/config/default_cf_tblstruct.h
@@ -1,0 +1,56 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
+ * Application version 3.0.0”
+ *
+ * Copyright (c) 2019 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Specification for the CFS CFDP (CF) table structures
+ *
+ * Provides default definitions for HK table structures
+ *
+ * @note This file may be overridden/superceded by mission-provided defintions
+ * either by overriding this header or by generating definitions from a command/data
+ * dictionary tool.
+ */
+#ifndef CF_TBLSTRUCT_H
+#define CF_TBLSTRUCT_H
+
+#include "common_types.h"
+#include "cf_mission_cfg.h"
+#include "cf_tbldefs.h"
+
+/**
+ * \brief Top-level CFDP configuration structure
+ */
+typedef struct CF_ConfigTable
+{
+    uint32 ticks_per_second;             /**< \brief expected ticks per second to CFDP app */
+    uint32 rx_crc_calc_bytes_per_wakeup; /**< \brief max number of bytes per wakeup to calculate
+                                          * r2 CRC for recvd file (must be 1024-byte aligned)
+                                          */
+
+    CF_EntityId_t local_eid; /**< \brief the local entity ID of the CF app */
+
+    CF_ChannelConfig_t chan[CF_NUM_CHANNELS]; /**< \brief Channel configuration */
+
+    uint16 outgoing_file_chunk_size;    /**< maximum size of outgoing file data PDUs - must be
+                                         *   smaller than file data character array */
+    char tmp_dir[CF_FILENAME_MAX_PATH]; /**< directory to put temp files */
+} CF_ConfigTable_t;
+
+#endif

--- a/docs/dox_src/cf-common.doxyfile.in
+++ b/docs/dox_src/cf-common.doxyfile.in
@@ -5,5 +5,6 @@
 # Include front material followed by everything in fsw
 INPUT      += @cf_MISSION_DIR@/docs/dox_src/cfs_cf.dox
 INPUT      += @cf_MISSION_DIR@/fsw
+INPUT      += @cf_MISSION_DIR@/config
 
 IMAGE_PATH += @cf_MISSION_DIR@/docs/dox_src

--- a/docs/dox_src/cfs_cf.dox
+++ b/docs/dox_src/cfs_cf.dox
@@ -484,7 +484,7 @@
 
   cf_platform_cfg.h uses macro definitions for configurable options, while cf_def_config.c
   uses a table. cf_def_config.c parameters can be accessed using the get/set functions
-  CF_CmdGetParam() and CF_CmdSetParam().
+  CF_GetParamCmd() and CF_SetParamCmd().
 
   CF expects to receive a CF_WAKEUP_MID message from the SCH (scheduler) app at a fixed
   rate. The number of wakeups per second is reflected in the configuration table. This
@@ -615,9 +615,9 @@
      *       - 4 = down counters
      typedef union CF_UnionArgs_Payload
      {
-         uint32 dword;    
-         uint16 hword[2]; 
-         uint8  byte[4];  
+         uint32 dword;
+         uint16 hword[2];
+         uint8  byte[4];
      }
 CF_UnionArgs_Payload_t;
 \endverbatim
@@ -626,44 +626,44 @@ CF_UnionArgs_Payload_t;
         reset.counters. The value should be set to one of five possible values defined in the reset enumeration.
 
   \verbatim typedef enum {
-            CF_Reset_all     = 0, 
-            CF_Reset_command = 1, 
-            CF_Reset_fault   = 2, 
-            CF_Reset_up      = 3, 
-            CF_Reset_down    = 4  
+            CF_Reset_all     = 0,
+            CF_Reset_command = 1,
+            CF_Reset_fault   = 2,
+            CF_Reset_up      = 3,
+            CF_Reset_down    = 4
         } CF_Reset_t;
   \endverbatim
 
 
 
   <H2> Transmit File Command </H2>
-    
+
   The CF Transmit File command is sent to CF using message ID #CF_CMD_MID with
   command code #CF_TX_FILE_CC.
-  
+
   This command is used to queue a file to be sent by the CF application. To
   'transmit' a file means to output, or send a file.
-  
+
   When the command is executed successfully, the command counter will increment
   and an event will be generated.
-  
+
   If the command is not successful, the command error counter will increment and
   an error event will be generated indicating the reason for failure.
 
   \verbatim
   typedef struct CF_TxFileCmd
   {
-      CFE_MSG_CommandHeader_t cmd_header;                        
-      uint8                   cfdp_class;                        
-      uint8                   keep;                              
-      uint8                   chan_num;                          
-      uint8                   priority;                          
-      CF_EntityId_t           dest_id;                           
-      char                    src_filename[CF_FILENAME_MAX_LEN]; 
-      char                    dst_filename[CF_FILENAME_MAX_LEN]; 
+      CFE_MSG_CommandHeader_t cmd_header;
+      uint8                   cfdp_class;
+      uint8                   keep;
+      uint8                   chan_num;
+      uint8                   priority;
+      CF_EntityId_t           dest_id;
+      char                    src_filename[CF_FILENAME_MAX_LEN];
+      char                    dst_filename[CF_FILENAME_MAX_LEN];
   } CF_TxFileCmd_t;
   \endverbatim
-  
+
   The first parameter, \c cfdp_class, identifies whether the file will be transferred
   using #CF_CFDP_CLASS_1 or #CF_CFDP_CLASS_2. For Class 1 transfers, CF will send the data
   once and expect no feedback from the peer. Class 2 transfers are more reliable
@@ -673,22 +673,22 @@ CF_UnionArgs_Payload_t;
   or preserved by CF after the transfer successfully completes. To have the file
   deleted by CF, set this parameter to zero. If this parameter is set to one,
   the file will not be deleted. Regardless of the setting, if the file-transfer
-  is not successful the file will not be deleted. 
-  
+  is not successful the file will not be deleted.
+
   The third parameter, \c chan_num, specifies the output channel in which the
   file will be sent. The value range for this parameter is 0 to
   (#CF_NUM_CHANNELS - 1). #CF_NUM_CHANNELS is specified in the
   CF platform configuration file.
-    
+
   The fourth parameter, \c priority, specifies where the file is placed on the
-  pending queue. High priority files are placed at the front of the queue. A 
+  pending queue. High priority files are placed at the front of the queue. A
   value of zero is the highest priority. A value of 255 is the lowest priority.
-    
+
   The fifth parameter, \c src_filename, specifies the path name and filename to
   send. This parameter is a string with max size equal to #CF_FILENAME_MAX_LEN
   bytes. The src_filename must be an existing file. The string must begin
   with a forward slash, have no spaces and be properly terminated.
-  
+
   The last parameter, \c dst_filename, specifies the destination path name and
   filename. This parameter is a string with max size equal to #CF_FILENAME_MAX_LEN
   bytes. This parameter is delivered to the peer so that the peer knows
@@ -698,19 +698,19 @@ CF_UnionArgs_Payload_t;
   string is not NULL, CF requires that it is properly terminated and contains no
   spaces. This parameter can be used to rename the file after it's received at
   the destination.
-  
-  
-  
+
+
+
   <H2> Playback Directory Command </H2>
-  
+
   The CF Playback Directory command is sent to CF using message ID #CF_CMD_MID
   with command code #CF_PLAYBACK_DIR_CC.  The command causes an event message
   to be generated. This command is used to queue the files that are located
   in the specified directory at the time the command is received.
-  
+
   If the command is not successful, the command error counter will increment and
   an error event will be generated indicating the reason for failure.
-  
+
   To 'playback' a directory means to send all files in that directory. To queue
   the files for sending, the class must be 1 or 2, the channel must be in-use,
   the files must be closed and not be active or pending, the preserve parameter
@@ -718,22 +718,22 @@ CF_UnionArgs_Payload_t;
   properly terminated. The src_filename must begin and end with a forward slash. All
   possible values for Priority are valid. A priority value of zero is the
   highest priority.
-      
+
   \verbatim
   typedef CF_TxFileCmd_t CF_PlaybackDirCmd_t;
   typedef struct CF_TxFileCmd
   {
-      CFE_MSG_CommandHeader_t cmd_header;                        
-      uint8                   cfdp_class;                        
-      uint8                   keep;                              
-      uint8                   chan_num;                          
-      uint8                   priority;                          
-      CF_EntityId_t           dest_id;                           
-      char                    src_filename[CF_FILENAME_MAX_LEN]; 
-      char                    dst_filename[CF_FILENAME_MAX_LEN]; 
+      CFE_MSG_CommandHeader_t cmd_header;
+      uint8                   cfdp_class;
+      uint8                   keep;
+      uint8                   chan_num;
+      uint8                   priority;
+      CF_EntityId_t           dest_id;
+      char                    src_filename[CF_FILENAME_MAX_LEN];
+      char                    dst_filename[CF_FILENAME_MAX_LEN];
   } CF_TxFileCmd_t;
   \endverbatim
-    
+
   The first parameter, \c cfdp_class, identifies whether the files will be
   transferred using #CF_CFDP_CLASS_1 or #CF_CFDP_CLASS_2. For Class 1 transfers, CF will
   send the data once and expect no feedback from the peer. Class 2 transfers are
@@ -744,138 +744,136 @@ CF_UnionArgs_Payload_t;
   or preserved by CF after the transfer successfully completes. To have the
   files deleted by CF, set this parameter to zero. If this parameter is set to
   one, the file will not be deleted. Regardless of the setting, if the
-  file-transfer is not successful the file will not be deleted. 
+  file-transfer is not successful the file will not be deleted.
 
   The third parameter, \c chan_num, specifies the output channel in which the files
   will be sent. All files in the directory will be sent on the specified
   channel. The value range for this parameter is 0 to (#CF_NUM_CHANNELS
   - 1). #CF_NUM_CHANNELS is specified in the CF platform configuration
   file.
-  
+
   The fourth parameter, \c priority, specifies where the files are placed on the
   pending queue. All files in the directory will be queued with the given
   priority. High priority files are placed at the front of the queue. A value of
   zero is the highest priority. A value of 255 is the lowest priority.
-    
+
   The fifth parameter, \c src_filename, specifies the path name where the files are
   located. The string must have no spaces, be properly terminated and have a
   forward slash as the last character. This parameter is a string with max size
   equal to #CF_FILENAME_MAX_LEN characters.
-  
+
   The last parameter, \c dst_filename, specifies where the files are to be stored
   after they are received by the peer. This parameter is a string with max size
   equal to #CF_FILENAME_MAX_LEN bytes. This parameter is delivered to the peer so
   that the peer knows where to store the file. The peer engine dictates the requirements
   of this string. The CF application allows this string to be NULL in which case the
-  peer engine will store the incoming files in the default directory. If the string 
+  peer engine will store the incoming files in the default directory. If the string
   is not NULL, CF requires that it is properly terminated, contains no spaces and ends
-  with a forward slash. There is no way to rename the files at the destination as in 
+  with a forward slash. There is no way to rename the files at the destination as in
   the Playback File command.
 
-  
+
   <H2> Freeze Command </H2>
-  
+
   The CF Freeze command is sent to CF using message ID #CF_CMD_MID with command
   code #CF_FREEZE_CC. The freeze command has no command parameters. This command
   is used to freeze all transactions. The freeze command should be applied to
-  both the source and destination peers at nearly the same time. 
-  
+  both the source and destination peers at nearly the same time.
+
   When the command is executed successfully, the command counter is incremented
   and an event message will be generated. This event message is an
   'Informational' type and is NOT filtered by default. If the command is not successful,
   the command error counter will increment and an error event will be generated
   indicating the reason for failure.
-   
- 
+
+
   <H2> Thaw Command </H2>
-  
+
   The CF Thaw command is sent to CF using message ID #CF_CMD_MID with command
   code #CF_THAW_CC. The thaw command has no command parameters. This command is
   used to thaw all transactions that were commanded to 'freeze' earlier. The
   thaw command should be applied to both the source and destination peers at
   nearly the same time.
-  
+
   When the command is executed successfully, the command counter is incremented
   and an event message will be generated. This event message is an
   'Informational' type and is NOT filtered by default. If the command is not successful,
   the command error counter will increment and an error event will be generated
   indicating the reason for failure.
 
-  
+
   <H2> Suspend Command </H2>
-  
+
   The CF Suspend command is sent to CF using message ID #CF_CMD_MID with command
   code #CF_SUSPEND_CC. This command is used to suspend one or all transactions.
   The suspend command has one command parameter that indicates what transaction
   to suspend. See details below.  The suspend command should be applied to both
-  the source and destination peers at nearly the same time.  
-  
+  the source and destination peers at nearly the same time.
+
   When the command is executed successfully, the command counter is incremented
   and an event message will be generated. This event message is an
   'Informational' type and is NOT filtered by default. If the command is not successful,
   the command error counter will increment and an error event will be generated
   indicating the reason for failure.
-  
+
   NOTE: Suspending an outgoing transaction before EOF is sent, will pause the
   flow of PDUs on that channel. This happens because the next file is started
   when the current file EOF is sent. If a user wishes to stop the current transaction
   (before the EOF is sent) and still allow the next pending file to begin, the
   current transaction should be cancelled (or abandoned) in lieu of being
-  suspended. Canceling is always a better option than abandoning. 
-  
-  NOTE: When a suspended transaction is cancelled, the cancel does not take 
+  suspended. Canceling is always a better option than abandoning.
+
+  NOTE: When a suspended transaction is cancelled, the cancel does not take
   effect until the transaction is resumed.
 
-  \verbatim 
-  typedef struct CF_TransactionCmd
+  \verbatim
+  typedef struct CF_Transaction_Payload
   {
-      CFE_MSG_CommandHeader_t cmd_header; 
-      CF_TransactionSeq_t     ts;         
-      CF_EntityId_t           eid;        
-      uint8                   chan;       
-      uint8                   spare[3];   
-  } CF_TransactionCmd_t;
+      CF_TransactionSeq_t     ts;
+      CF_EntityId_t           eid;
+      uint8                   chan;
+      uint8                   spare[3];
+  } CF_Transaction_Payload_t;
 
   \endverbatim
 
   The \c ts parameter specifies the transaction sequence number to suspend.
   The \c eid parameter specifies the entity id used in the transaction.
   The \c chan parameter can specify a single channel, all channels, or the channel
-  corresponding to the transaction sequence number.  
-    
-  
+  corresponding to the transaction sequence number.
+
+
   <H2> Resume Command </H2>
-  
+
   The CF Resume command is sent to CF using message ID #CF_CMD_MID with command
   code #CF_RESUME_CC. This command is used to resume a suspended transaction or
   all transactions. The resume command has one command parameter that indicates
   what transaction to resume. See details below.  The resume command should be
   applied to both the source and destination peers at nearly the same time.
-  
+
   When the command is executed successfully, the command counter is incremented
   and an event message will be generated. This event message is an
   'Informational' type and is NOT filtered by default. If the command is not successful,
   the command error counter will increment and an error event will be generated
   indicating the reason for failure.
 
-  \verbatim 
-  typedef struct CF_TransactionCmd
+  \verbatim
+  typedef struct CF_Transaction_Payload
   {
-      CFE_MSG_CommandHeader_t cmd_header; 
-      CF_TransactionSeq_t     ts;         
-      CF_EntityId_t           eid;        
-      uint8                   chan;       
-      uint8                   spare[3];   
-  } CF_TransactionCmd_t;
+      CF_TransactionSeq_t     ts;
+      CF_EntityId_t           eid;
+      uint8                   chan;
+      uint8                   spare[3];
+  } CF_Transaction_Payload_t;
 
   \endverbatim
 
   The \c ts parameter specifies the transaction sequence number to resume.
   The \c eid parameter specifies the entity id used in the transaction.
   The \c chan parameter can specify a single channel, all channels, or the channel
-  corresponding to the transaction sequence number.  
-    
-  
+  corresponding to the transaction sequence number.
+
+
   <H2> Cancel Command </H2>
 
   The CF Cancel command is sent to CF using message ID #CF_CMD_MID with command
@@ -885,7 +883,7 @@ CF_UnionArgs_Payload_t;
   to the source entity only. For example, uplink transactions should be
   cancelled at the ground engine. The CF application should not receive a cancel
   command in this case. The CF application will learn of the cancel request
-  through the protocol messages. Downlink transactions and outgoing transactions 
+  through the protocol messages. Downlink transactions and outgoing transactions
   (with respect to CF)  should be cancelled by sending this CF cancel command.
 
   When the command is executed successfully, the command counter is incremented
@@ -893,157 +891,155 @@ CF_UnionArgs_Payload_t;
   'Informational' type and is NOT filtered by default. If the command is not successful,
   the command error counter will increment and an error event will be generated
   indicating the reason for failure.
-  
-  NOTE: If a Cancel command is received by CF on an outgoing transaction that 
-  is suspended, the cancel does not take effect until the transaction is 
-  resumed.  
+
+  NOTE: If a Cancel command is received by CF on an outgoing transaction that
+  is suspended, the cancel does not take effect until the transaction is
+  resumed.
 
 
-  \verbatim 
-  typedef struct CF_TransactionCmd
+  \verbatim
+  typedef struct CF_Transaction_Payload
   {
-      CFE_MSG_CommandHeader_t cmd_header; 
-      CF_TransactionSeq_t     ts;         
-      CF_EntityId_t           eid;        
-      uint8                   chan;       
-      uint8                   spare[3];   
-  } CF_TransactionCmd_t;
+      CF_TransactionSeq_t     ts;
+      CF_EntityId_t           eid;
+      uint8                   chan;
+      uint8                   spare[3];
+  } CF_Transaction_Payload_t;
 
   \endverbatim
 
   The \c ts parameter specifies the transaction sequence number to cancel.
   The \c eid parameter specifies the entity id used in the transaction.
   The \c chan parameter can specify a single channel, all channels, or the channel
-  corresponding to the transaction sequence number.  
+  corresponding to the transaction sequence number.
 
-  
+
   <H2> Abandon Command </H2>
-  
+
   The CF Abandon command is sent to CF using message ID #CF_CMD_MID with command
   code #CF_ABANDON_CC. This command is used to abandon a transaction or all
   transactions. The abandon command has one command parameter that indicates
   what transaction to abandon. See details below.  The abandon command should be
-  applied to both the source and destination peers at nearly the same time. 
+  applied to both the source and destination peers at nearly the same time.
 
   When the command is executed successfully, the command counter is incremented
-  and an event message will be generated. This event message is an 'Informational' 
+  and an event message will be generated. This event message is an 'Informational'
   type and is NOT filtered by default.
-  
-  If the command is not successful, the command error counter will increment and 
+
+  If the command is not successful, the command error counter will increment and
   an error event will be generated indicating the reason for failure.
   When the command is executed successfully, the command counter is incremented
   and an event message will be generated. This event message is an
   'Informational' type and is NOT filtered by default. If the command is not successful,
   the command error counter will increment and an error event will be generated
   indicating the reason for failure.
-  
+
   NOTE: Unlike the cancel command, if a suspended transaction is abandoned, the
   transaction will be abandoned at the time the abandon command is received.
   Likewise, if a frozen transaction is abandoned, the transaction will be
   abandoned when the abandoned cmd is received.
-    
-  \verbatim 
-  typedef struct CF_TransactionCmd
+
+  \verbatim
+  typedef struct CF_Transaction_Payload
   {
-      CFE_MSG_CommandHeader_t cmd_header; 
-      CF_TransactionSeq_t     ts;         
-      CF_EntityId_t           eid;        
-      uint8                   chan;       
-      uint8                   spare[3];   
-  } CF_TransactionCmd_t;
+      CF_TransactionSeq_t     ts;
+      CF_EntityId_t           eid;
+      uint8                   chan;
+      uint8                   spare[3];
+  } CF_Transaction_Payload_t;
 
   \endverbatim
 
   The \c ts parameter specifies the transaction sequence number to abandon.
   The \c eid parameter specifies the entity id used in the transaction.
   The \c chan parameter can specify a single channel, all channels, or the channel
-  corresponding to the transaction sequence number.  
-  
-  
-  
+  corresponding to the transaction sequence number.
+
+
+
   <H2> Set MIB Parameter Command </H2>
-  
+
   The CF Set MIB Parameter command is sent to CF using message ID #CF_CMD_MID
   with command code #CF_SET_MIB_PARAM_CC. This command is used to change the
   flight engine Message Information Base (MIB). The MIB is a term used in the
   CCSDS blue book that can be interpreted as the engine configuration
   parameters. The command has two command parameters, Param indicates which
-  parameter to change, and Value indicates the new setting. 
-  
+  parameter to change, and Value indicates the new setting.
+
   When the command is executed successfully, the command counter is incremented
-  and an event message will be generated displaying the parameter values received. 
+  and an event message will be generated displaying the parameter values received.
   This event message is an 'Informational' type and is NOT filtered by default.
-  
+
   If the command is not successful, the command error counter will increment and
   an error event will be generated indicating the reason for failure.
-    
+
   This command may be used to change any flight MIB parameter.
-  
-  NOTE: Changing these parameters will change the actual table values, thereby 
+
+  NOTE: Changing these parameters will change the actual table values, thereby
   changing the checksum of the CF configuration table.
-      
-  \verbatim 
+
+  \verbatim
   typedef struct CF_SetParamCmd
   {
-      CFE_MSG_CommandHeader_t cmd_header; 
-      uint32                  value;      
-      uint8                   key;        
-      uint8                   chan_num;   
-      uint8                   spare[2];   
+      CFE_MSG_CommandHeader_t cmd_header;
+      uint32                  value;
+      uint8                   key;
+      uint8                   chan_num;
+      uint8                   spare[2];
   } CF_SetParamCmd_t;
 
   \endverbatim
 
   The \c value parameter specifies the new value of the engine
   parameter.
-    
+
   The \c key parameter specifies which engine parameter to set.
-  
+
   The \c chan_num parameter specifies the channel number to set.
-    
-  
+
+
   <H2> Get MIB Parameter Command </H2>
-  
+
   The CF Set MIB Parameter command is sent to CF using message ID #CF_CMD_MID
   with command code #CF_GET_MIB_PARAM_CC. This command is used to view a single
   Message Information Base (MIB) parameter. The MIB is a term used in the CCSDS
-  blue book that can be interpreted as the engine configuration parameters. 
-    
+  blue book that can be interpreted as the engine configuration parameters.
+
   The command has two command parameter, key indicates which parameter to
   view and the channel number specifies the channel configuration to use.
   The parameter given and its current setting will be displayed in the event.
-  
+
   When the command is executed successfully, the command counter is incremented
-  and an event message will be generated displaying the given parameter value 
-  and the current setting for that parameter. This event message is an 'Informational' 
-  type and is NOT filtered by default. 
-  
+  and an event message will be generated displaying the given parameter value
+  and the current setting for that parameter. This event message is an 'Informational'
+  type and is NOT filtered by default.
+
   If the command is not successful, the command error counter will increment and
   an error event will be generated indicating the reason for failure.
-      
-  This command may be used to view any flight MIB parameter.  
-     
-  \verbatim 
+
+  This command may be used to view any flight MIB parameter.
+
+  \verbatim
   typedef struct CF_GetParamCmd
   {
-      CFE_MSG_CommandHeader_t cmd_header; 
-      uint8                   key;        
-      uint8                   chan_num;   
+      CFE_MSG_CommandHeader_t cmd_header;
+      uint8                   key;
+      uint8                   chan_num;
   } CF_GetParamCmd_t;
 
   \endverbatim
-    
+
   The \c key parameter specifies which engine parameter to get.
-  
+
   The \c chan_num parameter specifies the channel number to get the data from.
-    
-    
+
+
   <H2> Write Queue Information Command </H2>
-  
+
 
   The CF Write Queue Information command is sent to CF using message ID
-#CF_CMD_MID with command code #CF_WRITE_QUEUE_CC.  
-  
+#CF_CMD_MID with command code #CF_WRITE_QUEUE_CC.
+
   This command is used to write the contents of a single queue to a file. CF has
   a pending, queue, an active queue and a history queue for each output channel.
   CF also has an active queue and a history queue for incoming transactions.
@@ -1052,47 +1048,47 @@ CF_UnionArgs_Payload_t;
   and an event message will be generated.
 
   If the command is not successful, the command error counter will increment and
-  an error event will be generated indicating the reason for failure.  
-    
+  an error event will be generated indicating the reason for failure.
+
   \verbatim
   typedef struct CF_WriteQueueCmd
   {
-      CFE_MSG_CommandHeader_t cmd_header; 
-      uint8                   type;       
-      uint8                   chan;       
-      uint8                   queue;      
-      uint8                   spare;      
+      CFE_MSG_CommandHeader_t cmd_header;
+      uint8                   type;
+      uint8                   chan;
+      uint8                   queue;
+      uint8                   spare;
 
-      char filename[CF_FILENAME_MAX_LEN]; 
+      char filename[CF_FILENAME_MAX_LEN];
   } CF_WriteQueueCmd_t;
 
   \endverbatim
-  
-  The first parameter, \c type, specifies the queue type. The queue type may be 
+
+  The first parameter, \c type, specifies the queue type. The queue type may be
   uplink (incoming), or downlink (outgoing), or both,
 
   The second parameter, \c chan, is necessary only if the type parameter is set
   to a value of two (downlink). If the Type parameter is set to a value of one
-  (uplink), the code does not read this parameter. Chan specifies the downlink 
-  channel that owns the queue. The value range for this parameter is 0 to 
-  (#CF_NUM_CHANNELS - 1). #CF_NUM_CHANNELS is specified in the 
+  (uplink), the code does not read this parameter. Chan specifies the downlink
+  channel that owns the queue. The value range for this parameter is 0 to
+  (#CF_NUM_CHANNELS - 1). #CF_NUM_CHANNELS is specified in the
   CF platform configuration file.
-  
-  The third parameter, \c queue, identifies which queue contents will be written 
-  to the file. A value of 0 for pending queue, 1 for active and 2 for history.  
-  Because there is no uplink pending queue, a value of zero is not valid when 
-  the Type parameter is set to one (uplink). 
+
+  The third parameter, \c queue, identifies which queue contents will be written
+  to the file. A value of 0 for pending queue, 1 for active and 2 for history.
+  Because there is no uplink pending queue, a value of zero is not valid when
+  the Type parameter is set to one (uplink).
 
   The fourth parameter, \c filename, specifies the name of the file that will
   receive the queue data. This parameter is a string with max size equal to
 #CF_FILENAME_MAX_LEN bytes specified in the CF platform configuration file.
 
-  
+
   <H2> Enable Dequeue Command </H2>
-  
+
   The CF Enable Dequeue command is sent to CF using message ID #CF_CMD_MID with
-  command code #CF_ENABLE_DEQUEUE_CC. 
-  
+  command code #CF_ENABLE_DEQUEUE_CC.
+
   This command is used to enable reading from the pending queue on a particular
   channel. It has one parameter (channel) and is sent when the pending queue
   reads are disabled for that channel. The pending queue holds the names of the
@@ -1103,70 +1099,70 @@ CF_UnionArgs_Payload_t;
   and an event message will be generated.
 
   If the command is not successful, the command error counter will increment and
-  an error event will be generated indicating the reason for failure.  
-  
+  an error event will be generated indicating the reason for failure.
+
   \verbatim
        *       Command Structure
        *       #CF_UnionArgs_Payload_t where byte[0] specifies the channel number or all channels
        *       - 255 = all channels
-       *       - else = single channel  
+       *       - else = single channel
        typedef union CF_UnionArgs_Payload
   {
-      uint32 dword;    
-      uint16 hword[2]; 
-      uint8  byte[4];  
+      uint32 dword;
+      uint16 hword[2];
+      uint8  byte[4];
   } CF_UnionArgs_Payload_t;
-  \endverbatim  
+  \endverbatim
 
   The first and only parameter, \c byte[0], specifies which pending queue to enable.
-  Each channel has one pending queue. The value range for this parameter is 0 to 
+  Each channel has one pending queue. The value range for this parameter is 0 to
   255. A value of 255 specifies all channels. All other values are for a single channel.
 
 
   <H2> Disable Dequeue Command </H2>
- 
+
   The CF Enable Dequeue command is sent to CF using message ID #CF_CMD_MID with
-  command code #CF_DISABLE_DEQUEUE_CC. 
-  
+  command code #CF_DISABLE_DEQUEUE_CC.
+
   This command is used to disable reading from the pending queue on a particular
-  channel. It has one parameter (channel) and sent when the user would like to 
-  stop sending files on a particular channel. 
-  
-  NOTE: This command does not stop a file transaction that is in progress on the 
-  specified channel. Use the cancel command to stop a file transaction that is 
+  channel. It has one parameter (channel) and sent when the user would like to
+  stop sending files on a particular channel.
+
+  NOTE: This command does not stop a file transaction that is in progress on the
+  specified channel. Use the cancel command to stop a file transaction that is
   in progress.
-  
+
 
   When the command is executed successfully, the command counter is incremented
   and then an event message will be generated.
 
   If the command is not successful, the command error counter will increment and
-  an error event will be generated indicating the reason for failure.  
-  
+  an error event will be generated indicating the reason for failure.
+
   \verbatim
        *       Command Structure
        *       #CF_UnionArgs_Payload_t where byte[0] specifies the channel number or all channels
        *       - 255 = all channels
-       *       - else = single channel  
+       *       - else = single channel
 
        typedef union CF_UnionArgs_Payload
   {
-      uint32 dword;    
-      uint16 hword[2]; 
-      uint8  byte[4];  
+      uint32 dword;
+      uint16 hword[2];
+      uint8  byte[4];
   } CF_UnionArgs_Payload_t;
-  \endverbatim  
+  \endverbatim
 
   The first and only parameter, \c byte[0], specifies which pending queue to enable.
-  Each channel has one pending queue. The value range for this parameter is 0 to 
+  Each channel has one pending queue. The value range for this parameter is 0 to
   255. A value of 255 specifies all channels. All other values are for a single channel.
 
 
   <H2> Enable Directory Polling Command </H2>
-  
+
   The CF Enable Directory Polling command is sent to CF using message ID
-#CF_CMD_MID with command code #CF_ENABLE_DIR_POLLING_CC. 
-  
+#CF_CMD_MID with command code #CF_ENABLE_DIR_POLLING_CC.
+
   This command is used to enable one or all polling directories on a particular
   channel. CF will check polling directories for filenames and queue them for
   output, only if the polling directory is enabled. Polling directory processing
@@ -1174,13 +1170,13 @@ CF_UnionArgs_Payload_t;
   and looping through hidden files, closed files and files that have already
   been queued can take a substantial amount of CPU time. It is recommended to
   keep polling directories disabled when they are not actively receiving files.
-  
+
   When the command is executed successfully, the command counter is incremented
-  and an event message will be generated.  
+  and an event message will be generated.
 
   If the command is not successful, the command error counter will increment and
-  an error event will be generated indicating the reason for failure.  
-  
+  an error event will be generated indicating the reason for failure.
+
   \verbatim
      *       Command Structure
      *       #CF_UnionArgs_Payload_t
@@ -1196,29 +1192,29 @@ CF_UnionArgs_Payload_t;
 
      typedef union CF_UnionArgs_Payload
   {
-      uint32 dword;    
-      uint16 hword[2]; 
-      uint8  byte[4];  
+      uint32 dword;
+      uint16 hword[2];
+      uint8  byte[4];
   } CF_UnionArgs_Payload_t;
-  \endverbatim  
+  \endverbatim
 
-  The first parameter, \c byte[0], specifies which channel contains the polling 
-  directory to enable. The value range for this parameter is 0 to 255. A value 
+  The first parameter, \c byte[0], specifies which channel contains the polling
+  directory to enable. The value range for this parameter is 0 to 255. A value
   of 255 specifies all channels. All other values are for a single channel.
-  
+
   The second parameter, \c byte[1], specifies which polling directory to enable. To
   enable all polling directories on a specific channel, set this parameter to
   0xFF. The polling directories are numbered from zero to
   (CF_MAX_POLLING_DIRS_PER_CHAN - 1). CF_MAX_POLLING_DIRS_PER_CHAN is specified
   in the CF platform configuration file. The polling directory number may be obtained
-  by viewing the contents of the CF configuration table.  
-  
+  by viewing the contents of the CF configuration table.
+
 
   <H2> Disable Directory Polling Command </H2>
-  
+
   The CF Enable Directory Polling command is sent to CF using message ID
-#CF_CMD_MID with command code #CF_DISABLE_DIR_POLLING_CC. 
-  
+#CF_CMD_MID with command code #CF_DISABLE_DIR_POLLING_CC.
+
   This command is used to disable one or all polling directories on a particular
   channel. CF will check polling directories for filenames and queue them for
   output, only if the polling directory is enabled. Polling directory processing
@@ -1226,13 +1222,13 @@ CF_UnionArgs_Payload_t;
   and looping through hidden files, closed files and files that have already
   been queued can take a substantial amount of CPU time. It is recommended to
   keep polling directories disabled when they are not actively receiving files.
-  
+
   When the command is executed successfully, the command counter is incremented
   and an event message will be generated.
 
   If the command is not successful, the command error counter will increment and
-  an error event will be generated indicating the reason for failure.  
-  
+  an error event will be generated indicating the reason for failure.
+
   \verbatim
      *       Command Structure
      *       #CF_UnionArgs_Payload_t
@@ -1248,29 +1244,29 @@ CF_UnionArgs_Payload_t;
 
      typedef union CF_UnionArgs_Payload
   {
-      uint32 dword;    
-      uint16 hword[2]; 
-      uint8  byte[4];  
+      uint32 dword;
+      uint16 hword[2];
+      uint8  byte[4];
   } CF_UnionArgs_Payload_t;
-  \endverbatim  
+  \endverbatim
 
-  The first parameter, \c byte[0], specifies which channel contains the polling 
-  directory to disable. The value range for this parameter is 0 to 255. A value 
+  The first parameter, \c byte[0], specifies which channel contains the polling
+  directory to disable. The value range for this parameter is 0 to 255. A value
   of 255 specifies all channels. All other values are for a single channel.
-  
+
   The second parameter, \c byte[1], specifies which polling directory to disable. To
   disable all polling directories on a specific channel, set this parameter to
   0xFF. The polling directories are numbered from zero to
   (CF_MAX_POLLING_DIRS_PER_CHAN - 1). CF_MAX_POLLING_DIRS_PER_CHAN is specified
   in the CF platform configuration file. The polling directory number may be obtained
-  by viewing the contents of the CF configuration table.  
+  by viewing the contents of the CF configuration table.
 
 
   <H2> Purge Queue Command </H2>
-  
+
   The CF Write Queue Information command is sent to CF using message ID
-#CF_CMD_MID with command code #CF_PURGE_QUEUE_CC.  
-  
+#CF_CMD_MID with command code #CF_PURGE_QUEUE_CC.
+
   This command is used to remove all entries on a single queue. CF has a
   pending queue, an active queue, and a history queue for each channel.
   Only the pending and history queues can be purged.
@@ -1279,7 +1275,7 @@ CF_UnionArgs_Payload_t;
   and an event message will be generated indicating that the node has been removed.
 
   If the command is not successful, the command error counter will increment and
-  an error event will be generated indicating the reason for failure.  
+  an error event will be generated indicating the reason for failure.
 
   \verbatim
      *       Command Structure
@@ -1297,34 +1293,34 @@ CF_UnionArgs_Payload_t;
 
      typedef union CF_UnionArgs_Payload
   {
-      uint32 dword;    
-      uint16 hword[2]; 
-      uint8  byte[4];  
+      uint32 dword;
+      uint16 hword[2];
+      uint8  byte[4];
   } CF_UnionArgs_Payload_t;
-  \endverbatim  
+  \endverbatim
 
   The first parameter, \c byte[0], specifies a single channel id or a value
   indicating all channels.
-      
-  The second parameter, \c byte[1], identifies which queue will be purged. 
-  A value of 0 for pending queue, 1 for history and 2 for both.  
- 
+
+  The second parameter, \c byte[1], identifies which queue will be purged.
+  A value of 0 for pending queue, 1 for history and 2 for both.
+
   <H2> Enable Engine Command </H2>
-  
+
   The CF Enable Engine command is sent to CF using message ID
 #CF_CMD_MID with command code #CF_ENABLE_ENGINE_CC. The command has no
-  command parameters and is used to reinitialize engine and enable processing.  
+  command parameters and is used to reinitialize engine and enable processing.
   Note configuration table updates are not processed while the engine is enabled.
 
 
   <H2> Enable Disable Command </H2>
-  
+
   The CF Enable Engine command is sent to CF using message ID
 #CF_CMD_MID with command code #CF_DISABLE_ENGINE_CC. The command has no
-  command parameters and is used to disable engine processing.  
-  Note configuration table updates can be performed while the engine is disabled, 
+  command parameters and is used to disable engine processing.
+  Note configuration table updates can be performed while the engine is disabled,
   and when the engine is re-enabled the new configuration will take effect.
-  
+
   Prev: \ref cfscfcfgpg <BR>
   Next: \ref cfscftlmpg
 **/
@@ -1338,29 +1334,29 @@ CF_UnionArgs_Payload_t;
  *
  * \ref cfscftlm
  *
- 
+
   Prev: \ref cfscfcmdspg <BR>
   Next: \ref cfscfeventspg
  */
 
 /**
   \page cfscftlmdesc CFS CFDP Telemetry Descriptions
-  
+
   <H2> CF Housekeeping Telemetry Packet </H2>
-  
+
   The Housekeeping Telemetry packet is sent by CF to the software bus on
   command. When CF receives the CF_SEND_HK_MID command, a packet is constructed
   and sent by CF. CF typically receives this command every four or five seconds.
-  
-  
+
+
   <H2> CF End of Transaction Packet </H2>
-  
-  The End of Transaction packet is sent to the software bus upon completion 
+
+  The End of Transaction packet is sent to the software bus upon completion
   of a file send or receive transaction. A packet with message ID #CF_EOT_TLM_MID is
   constructed and sent by CF. The packet contains information about the last
   completed transaction which includes sequence number, channel, direction, state,
   status, EID, file size, CRC result, and filenames.
-    
+
   Prev: \ref cfscftlmpg <BR>
   Next: \ref cfscftbl
 **/
@@ -1382,15 +1378,15 @@ CF_UnionArgs_Payload_t;
 
   The CF application has one table used for configuration. This table is
   accessed during initialization and updated by CF when changes to the table
-  parameters are made through CF commands or CFE table services. 
-  
+  parameters are made through CF commands or CFE table services.
+
   The table contains default configuration settings. Many table configuration
   settings can be adjusted by command. These adjustments will modify the table
   and are therefore reflected if the table is dumped. These adjustments will
   also change the table checksum. The configuration table is loaded at the time
   the application is started. CF supports table updates during runtime only when
   the engine is disabled.
-      
+
   CF utilizes a CFS table for run-time configuration defined by #CF_ConfigTable_t.  The channel
   configuration is in #CF_ConfigTable_t.chan which contains a polling element defined by
   #CF_PollDir_t.
@@ -1411,19 +1407,19 @@ CF_UnionArgs_Payload_t;
   Currently, this application does not support the following:
   1. an Entity ID length other than the size defined in cf_platform_cfg.h
   2. a transaction ID length other than the size defined in cf_platform_cfg.h
-  3. a PDU header size greater than CF_CFDP_MAX_HEADER_SIZE bytes 
+  3. a PDU header size greater than CF_CFDP_MAX_HEADER_SIZE bytes
 
   The stack size for the CF application must be monitored and must be no less
   than 16384 bytes. Depending on the CF configuration, the stack size may need
   to be set higher than 16384. The stack size is specified in the cfe_es_startup.scr
   file that is located in the /mission/build/xxx/exe area.
-  
+
   Poll directories must not have subdirectories, otherwise errors will occur
   at put request time.
 
-  All files in polling directories must be closed. 
+  All files in polling directories must be closed.
 
-  The same file cannot be sent on two channels at same time. 
+  The same file cannot be sent on two channels at same time.
 
   Spaces are not allowed in filenames.
 
@@ -1431,10 +1427,10 @@ CF_UnionArgs_Payload_t;
   version of CFS CF application. All outgoing transactions will have the
   segmentation control bit in the meta-data PDU set to - 'Recorded Boundaries
   Not Respected'.
-  
+
   This version of CF does not support keep alive procedures that are detailed in
   section 4.1.6.5 of CFDP CCSDS 727.0-B-5 Blue Book.
-  
+
   Invalid file structures are not supported by this version of the CF
   application. Invalid file structures are described in 4.1.6.1.1.8 of CFDP
   CCSDS 727.0-B-5 Blue Book and apply only when record boundaries are respected
@@ -1442,9 +1438,9 @@ CF_UnionArgs_Payload_t;
 
   Only transmission modes unacknowledged (class 1) and acknowledged (class 2) are
   supported by the CF application.
-  
+
   The CFDP Application will fail on startup if the following conditions are not met:
-  
+
   <UL>
     <LI> Unable to create a Software Bus Pipe  <BR>
     <LI> Unable to subscribe to the CF Command Message  <BR>
@@ -1454,10 +1450,10 @@ CF_UnionArgs_Payload_t;
     <LI> Unable to load the CF Configuration Table with a default table file  <BR>
     <LI> Unable to acquire a pointer to the CF Configuration Table  <BR>
   </UL>
-  
+
   Each one of these conditions will generate a unique event message and will cause the CF
   Application to terminate before processing any CF command pipe messages.
-  
+
   Prev: \ref cfscfeventspg <BR>
   Next: \ref cfscffaqs
 
@@ -1479,12 +1475,12 @@ CF_UnionArgs_Payload_t;
 
   <UL>
     <LI> If you get a "PDU too short":</LI>
-      <UL> 
+      <UL>
         <LI> The ground system might not be setting the "length" in the CCSDS header correctly. </LI>
       </UL>
     <LI> If you get an "EOF PUD too short"  or missing 2 bytes from an uploaded file: </LI>
       <UL>
-        <LI> The current version of CF does not support PDU CRC. The ground system needs to set the "CRC Flag" to false. </LI> 
+        <LI> The current version of CF does not support PDU CRC. The ground system needs to set the "CRC Flag" to false. </LI>
       </UL>
     <LI> If you get a "CRC mismatch for R trans": </LI>
       <UL>

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -46,8 +46,8 @@ CF_AppData_t CF_AppData;
  *-----------------------------------------------------------------*/
 void CF_HkCmd(void)
 {
-    CFE_MSG_SetMsgTime(&CF_AppData.hk.tlm_header.Msg, CFE_TIME_GetTime());
-    /* return value ignored */ CFE_SB_TransmitMsg(&CF_AppData.hk.tlm_header.Msg, true);
+    CFE_MSG_SetMsgTime(&CF_AppData.hk.TelemetryHeader.Msg, CFE_TIME_GetTime());
+    /* return value ignored */ CFE_SB_TransmitMsg(&CF_AppData.hk.TelemetryHeader.Msg, true);
 }
 
 /*----------------------------------------------------------------
@@ -205,7 +205,7 @@ CFE_Status_t CF_Init(void)
 
     CF_AppData.run_status = CFE_ES_RunStatus_APP_RUN;
 
-    CFE_MSG_Init(&CF_AppData.hk.tlm_header.Msg, CFE_SB_ValueToMsgId(CF_HK_TLM_MID), sizeof(CF_AppData.hk));
+    CFE_MSG_Init(&CF_AppData.hk.TelemetryHeader.Msg, CFE_SB_ValueToMsgId(CF_HK_TLM_MID), sizeof(CF_AppData.hk));
 
     status = CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY);
     if (status != CFE_SUCCESS)
@@ -301,7 +301,7 @@ void CF_ProcessMsg(CFE_SB_Buffer_t *msg)
             break;
 
         default:
-            ++CF_AppData.hk.counters.err;
+            ++CF_AppData.hk.Payload.counters.err;
             CFE_EVS_SendEvent(CF_EID_ERR_INIT_CMD_LENGTH, CFE_EVS_EventType_ERROR,
                               "CF: invalid command packet id=0x%lx", (unsigned long)CFE_SB_MsgIdToValue(msg_id));
             break;

--- a/fsw/src/cf_app.h
+++ b/fsw/src/cf_app.h
@@ -29,6 +29,7 @@
 #include "cfe.h"
 
 #include "cf_msg.h"
+#include "cf_tbl.h"
 #include "cf_msgids.h"
 #include "cf_tbldefs.h"
 #include "cf_platform_cfg.h"

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -599,7 +599,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_TRUNCATION, CFE_EVS_EventType_ERROR,
                           "CF: PDU rejected due to EID/seq number field truncation");
-        ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
     /*
@@ -612,7 +612,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
     {
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_LARGE_FILE, CFE_EVS_EventType_ERROR,
                           "CF: PDU with large file bit received (unsupported)");
-        ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
     else
@@ -626,13 +626,13 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_PDU_SHORT_HEADER, CFE_EVS_EventType_ERROR, "CF: PDU too short (%lu received)",
                               (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-            ++CF_AppData.hk.channel_hk[chan_num].counters.recv.error;
+            ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.error;
             ret = CF_SHORT_PDU_ERROR;
         }
         else
         {
             /* PDU is ok, so continue processing */
-            ++CF_AppData.hk.channel_hk[chan_num].counters.recv.pdu;
+            ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.pdu;
         }
     }
 
@@ -657,7 +657,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_MD_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: metadata packet too short: %lu bytes received",
                           (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
         ret = CF_PDU_METADATA_ERROR;
     }
     else
@@ -679,7 +679,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
             CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_SRC_LEN, CFE_EVS_EventType_ERROR,
                               "CF: metadata PDU rejected due to invalid length in source filename of 0x%02x",
                               md->source_filename.length);
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
             ret = CF_PDU_METADATA_ERROR;
         }
         else
@@ -691,7 +691,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                 CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_DST_LEN, CFE_EVS_EventType_ERROR,
                                   "CF: metadata PDU rejected due to invalid length in dest filename of 0x%02x",
                                   md->dest_filename.length);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
                 ret = CF_PDU_METADATA_ERROR;
             }
             else
@@ -736,7 +736,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: filedata PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_PROTOCOL_ERROR);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
         ret = CF_SHORT_PDU_ERROR;
     }
     else if (ph->pdu_header.segment_meta_flag)
@@ -745,7 +745,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_UNSUPPORTED, CFE_EVS_EventType_ERROR,
                           "CF: filedata PDU with segment metadata received");
         CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_PROTOCOL_ERROR);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
         ret = CF_ERROR;
     }
 
@@ -851,7 +851,7 @@ CFE_Status_t CF_CFDP_RecvNak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
  *-----------------------------------------------------------------*/
 void CF_CFDP_RecvDrop(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 {
-    ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.dropped;
+    ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.dropped;
 }
 
 /*----------------------------------------------------------------
@@ -919,14 +919,14 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                 {
                     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_IDLE_MD, CFE_EVS_EventType_ERROR,
                                       "CF: got invalid md PDU -- abandoning transaction");
-                    ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+                    ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
                     /* leave state as idle, which will reset below */
                 }
                 break;
             default:
                 CFE_EVS_SendEvent(CF_EID_ERR_CFDP_FD_UNHANDLED, CFE_EVS_EventType_ERROR,
                                   "CF: unhandled file directive code 0x%02x in idle state", fdh->directive_code);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
                 break;
         }
     }
@@ -1328,7 +1328,7 @@ static CFE_Status_t CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *pb, const char *
     {
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_OPENDIR, CFE_EVS_EventType_ERROR,
                           "CF: failed to open playback directory %s, error=%ld", src_filename, (long)ret);
-        ++CF_AppData.hk.channel_hk[chan].counters.fault.directory_read;
+        ++CF_AppData.hk.Payload.channel_hk[chan].counters.fault.directory_read;
     }
     else
     {
@@ -1483,7 +1483,7 @@ static void CF_CFDP_ProcessPlaybackDirectories(CF_Channel_t *chan)
     {
         CF_CFDP_ProcessPlaybackDirectory(chan, &chan->playback[i]);
         CF_CFDP_UpdatePollPbCounted(&chan->playback[i], chan->playback[i].busy,
-                                    &CF_AppData.hk.channel_hk[chan_index].playback_counter);
+                                    &CF_AppData.hk.Payload.channel_hk[chan_index].playback_counter);
     }
 }
 
@@ -1552,7 +1552,7 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *chan)
             count_check = 1;
         }
 
-        CF_CFDP_UpdatePollPbCounted(&poll->pb, count_check, &CF_AppData.hk.channel_hk[chan_index].poll_counter);
+        CF_CFDP_UpdatePollPbCounted(&poll->pb, count_check, &CF_AppData.hk.Payload.channel_hk[chan_index].poll_counter);
     }
 }
 
@@ -1577,7 +1577,7 @@ void CF_CFDP_CycleEngine(void)
             /* consume all received messages, even if channel is frozen */
             CF_CFDP_ReceiveMessage(chan);
 
-            if (!CF_AppData.hk.channel_hk[i].frozen)
+            if (!CF_AppData.hk.Payload.channel_hk[i].frozen)
             {
                 /* handle ticks before tx cycle. Do this because there may be a limited number of TX messages available
                  * this cycle, and it's important to respond to class 2 ACK/NAK more than it is to send new filedata
@@ -1610,10 +1610,10 @@ void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, int keep_history)
     CF_Channel_t *chan   = &CF_AppData.engine.channels[txn->chan_num];
     CF_Assert(txn->chan_num < CF_NUM_CHANNELS);
 
-    if ( txn->flags.com.q_index == CF_QueueIdx_FREE)
+    if (txn->flags.com.q_index == CF_QueueIdx_FREE)
     {
-        CFE_EVS_SendEvent(CF_EID_DBG_RESET_FREED_XACT, CFE_EVS_EventType_DEBUG, \
-        "CF: attempt to reset a transaction that has already been freed");
+        CFE_EVS_SendEvent(CF_EID_DBG_RESET_FREED_XACT, CFE_EVS_EventType_DEBUG,
+                          "CF: attempt to reset a transaction that has already been freed");
         return;
     }
 
@@ -1711,33 +1711,36 @@ void CF_CFDP_SetTxnStatus(CF_Transaction_t *txn, CF_TxnStatus_t txn_stat)
  *-----------------------------------------------------------------*/
 void CF_CFDP_SendEotPkt(CF_Transaction_t *txn)
 {
-    CF_EotPktBuf_t *PktBuf;
+    CF_EotPacket_t * EotPktPtr;
+    CFE_SB_Buffer_t *BufPtr;
 
     /*
     ** Get a Message block of memory and initialize it
     */
-    PktBuf = (CF_EotPktBuf_t *)CFE_SB_AllocateMessageBuffer(sizeof(*PktBuf));
+    BufPtr = CFE_SB_AllocateMessageBuffer(sizeof(*EotPktPtr));
 
-    if (PktBuf != NULL)
+    if (BufPtr != NULL)
     {
-        CFE_MSG_Init(&PktBuf->eot.tlm_header.Msg, CFE_SB_ValueToMsgId(CF_EOT_TLM_MID), sizeof(PktBuf->eot));
+        EotPktPtr = (void *)BufPtr;
 
-        PktBuf->eot.channel    = txn->chan_num;
-        PktBuf->eot.direction  = txn->history->dir;
-        PktBuf->eot.fnames     = txn->history->fnames;
-        PktBuf->eot.state      = txn->state;
-        PktBuf->eot.txn_stat   = txn->history->txn_stat;
-        PktBuf->eot.src_eid    = txn->history->src_eid;
-        PktBuf->eot.peer_eid   = txn->history->peer_eid;
-        PktBuf->eot.seq_num    = txn->history->seq_num;
-        PktBuf->eot.fsize      = txn->fsize;
-        PktBuf->eot.crc_result = txn->crc.result;
+        CFE_MSG_Init(&EotPktPtr->TelemetryHeader.Msg, CFE_SB_ValueToMsgId(CF_EOT_TLM_MID), sizeof(*EotPktPtr));
+
+        EotPktPtr->Payload.channel    = txn->chan_num;
+        EotPktPtr->Payload.direction  = txn->history->dir;
+        EotPktPtr->Payload.fnames     = txn->history->fnames;
+        EotPktPtr->Payload.state      = txn->state;
+        EotPktPtr->Payload.txn_stat   = txn->history->txn_stat;
+        EotPktPtr->Payload.src_eid    = txn->history->src_eid;
+        EotPktPtr->Payload.peer_eid   = txn->history->peer_eid;
+        EotPktPtr->Payload.seq_num    = txn->history->seq_num;
+        EotPktPtr->Payload.fsize      = txn->fsize;
+        EotPktPtr->Payload.crc_result = txn->crc.result;
 
         /*
         ** Timestamp and send eod of transaction telemetry
         */
-        CFE_SB_TimeStampMsg(&PktBuf->eot.tlm_header.Msg);
-        CFE_SB_TransmitBuffer(&PktBuf->SBBuf, true);
+        CFE_SB_TimeStampMsg(&EotPktPtr->TelemetryHeader.Msg);
+        CFE_SB_TransmitBuffer(BufPtr, true);
     }
 }
 
@@ -1837,7 +1840,7 @@ void CF_CFDP_DisableEngine(void)
         }
 
         /* finally all queue counters must be reset */
-        memset(&CF_AppData.hk.channel_hk[i].q_size, 0, sizeof(CF_AppData.hk.channel_hk[i].q_size));
+        memset(&CF_AppData.hk.Payload.channel_hk[i].q_size, 0, sizeof(CF_AppData.hk.Payload.channel_hk[i].q_size));
 
         CFE_SB_DeletePipe(chan->pipe);
     }

--- a/fsw/src/cf_cfdp_dispatch.c
+++ b/fsw/src/cf_cfdp_dispatch.c
@@ -59,7 +59,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph,
         }
         else
         {
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.spurious;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_DC_INV, CFE_EVS_EventType_ERROR,
                               "CF R%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
@@ -75,7 +75,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph,
         }
         else
         {
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.dropped;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.dropped;
         }
     }
 
@@ -119,7 +119,7 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph,
         }
         else
         {
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.spurious;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious;
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_DC_INV, CFE_EVS_EventType_ERROR,
                               "CF S%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -99,7 +99,7 @@ CFE_Status_t CF_CFDP_R_CheckCrc(CF_Transaction_t *txn, uint32 expected_crc)
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num, (unsigned long)txn->crc.result,
                           (unsigned long)expected_crc);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.crc_mismatch;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.crc_mismatch;
         ret = 1;
     }
 
@@ -156,7 +156,7 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *txn, int ok_to_send_nak)
                                   "CF R%d(%lu:%lu): NAK limited reach", (txn->state == CF_TxnState_R2),
                                   (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
                 send_fin = 1;
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.nak_limit;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.nak_limit;
                 /* don't use CF_CFDP_R2_SetFinTxnStatus because many places in this function set send_fin */
                 CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_NAK_LIMIT_REACHED);
                 txn->state_data.receive.r2.acknak_count = 0; /* reset for fin/ack */
@@ -213,7 +213,7 @@ CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *
                               (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                               (long)fd->offset, (long)fret);
             CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_FILE_SIZE_ERROR);
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek;
             ret = CF_ERROR; /* connection will reset in caller */
         }
     }
@@ -228,13 +228,13 @@ CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *
                               (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                               (long)fd->data_len, (long)fret);
             CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_FILESTORE_REJECTION);
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_write;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_write;
             ret = CF_ERROR; /* connection will reset in caller */
         }
         else
         {
             txn->state_data.receive.cached_pos = fd->data_len + fd->offset;
-            CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.file_data_bytes += fd->data_len;
+            CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.file_data_bytes += fd->data_len;
         }
     }
 
@@ -265,7 +265,7 @@ CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *txn, CF_Logical_PduBuff
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, (unsigned long)eof->size,
                               (unsigned long)txn->fsize);
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_size_mismatch;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_size_mismatch;
             ret = CF_REC_PDU_FSIZE_MISMATCH_ERROR;
         }
     }
@@ -274,7 +274,7 @@ CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *txn, CF_Logical_PduBuff
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_EOF, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid EOF packet",
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
         ret = CF_REC_PDU_BAD_EOF_ERROR;
     }
 
@@ -525,7 +525,7 @@ CFE_Status_t CF_CFDP_R_SubstateSendNak(CF_Transaction_t *txn)
                                                      that function we need to test handling it here */
                 if (sret == CFE_SUCCESS)
                 {
-                    CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.nak_segment_requests += cret;
+                    CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.nak_segment_requests += cret;
                     ret = CFE_SUCCESS;
                 }
             }
@@ -594,7 +594,7 @@ void CF_CFDP_R_Init(CF_Transaction_t *txn)
                           "CF R%d(%lu:%lu): failed to create file %s for writing, error=%ld",
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num, txn->history->fnames.dst_filename, (long)ret);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open;
         txn->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
         if (txn->state == CF_TxnState_R2)
         {
@@ -661,7 +661,7 @@ CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *txn)
                                   (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                                   (unsigned long)txn->state_data.receive.r2.rx_crc_calc_bytes, (long)fret);
                 CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_FILE_SIZE_ERROR);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek;
                 success = false;
                 break;
             }
@@ -675,7 +675,7 @@ CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *txn)
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, (unsigned long)read_size, (long)fret);
             CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_FILE_SIZE_ERROR);
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_read;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_read;
             success = false;
             break;
         }
@@ -766,7 +766,7 @@ void CF_CFDP_R2_Recv_fin_ack(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_FINACK, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid fin-ack",
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
     }
 }
 
@@ -808,7 +808,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                                       (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                                       (unsigned long)txn->history->seq_num, (unsigned long)txn->fsize,
                                       (unsigned long)txn->state_data.receive.r2.eof_size);
-                    ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_size_mismatch;
+                    ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_size_mismatch;
                     CF_CFDP_R2_SetFinTxnStatus(txn, CF_TxnStatus_FILE_SIZE_ERROR);
                     success = false;
                 }
@@ -832,7 +832,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                                       (unsigned long)txn->history->seq_num, (long)status);
                     txn->fd = OS_OBJECT_ID_UNDEFINED;
                     CF_CFDP_R2_SetFinTxnStatus(txn, CF_TxnStatus_FILESTORE_REJECTION);
-                    ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_rename;
+                    ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_rename;
                     success = false;
                 }
                 else
@@ -846,7 +846,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                                           (unsigned long)txn->history->seq_num, (long)ret);
                         CF_CFDP_R2_SetFinTxnStatus(txn, CF_TxnStatus_FILESTORE_REJECTION);
-                        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open;
+                        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open;
                         txn->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
                         success = false;
                     }
@@ -866,7 +866,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_MD, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid md received",
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num);
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
             /* do nothing here, since it will be NAK'd again later */
         }
     }
@@ -946,7 +946,7 @@ void CF_CFDP_R_SendInactivityEvent(CF_Transaction_t *txn)
     CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_INACT_TIMER, CFE_EVS_EventType_ERROR,
                       "CF R%d(%lu:%lu): inactivity timer expired", (txn->state == CF_TxnState_R2),
                       (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
-    ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.inactivity_timer;
+    ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.inactivity_timer;
 }
 
 /*----------------------------------------------------------------
@@ -1038,7 +1038,7 @@ void CF_CFDP_R_Tick(CF_Transaction_t *txn, int *cont /* unused */)
                                           "CF R2(%lu:%lu): ACK limit reached, no fin-ack",
                                           (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
                         CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_ACK_LIMIT_NO_FIN);
-                        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.ack_limit;
+                        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.ack_limit;
                         CF_CFDP_R2_Reset(txn);
                         success = false;
                     }

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -171,7 +171,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *txn, uint32 foffs, uint32 
                                   "CF S%d(%lu:%lu): error seeking to offset %ld, got %ld",
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, (long)foffs, (long)status);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek;
                 success = false;
             }
         }
@@ -185,7 +185,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *txn, uint32 foffs, uint32 
                                   "CF S%d(%lu:%lu): error reading bytes: expected %ld, got %ld",
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, (long)actual_bytes, (long)status);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_read;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_read;
                 success = false;
             }
         }
@@ -195,7 +195,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *txn, uint32 foffs, uint32 
             txn->state_data.send.cached_pos += status;
             CF_CFDP_SendFd(txn, ph); /* CF_CFDP_SendFd only returns CFE_SUCCESS */
 
-            CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes += actual_bytes;
+            CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes += actual_bytes;
             CF_Assert((foffs + actual_bytes) <= txn->fsize); /* sanity check */
             if (calc_crc)
             {
@@ -341,7 +341,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
                               "CF S%d(%lu:%lu): file %s already open", (txn->state == CF_TxnState_S2),
                               (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                               txn->history->fnames.src_filename);
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open;
             success = false;
         }
 
@@ -354,7 +354,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
                                   "CF S%d(%lu:%lu): failed to open file %s, error=%ld", (txn->state == CF_TxnState_S2),
                                   (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                                   txn->history->fnames.src_filename, (long)ret);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open;
                 txn->fd = OS_OBJECT_ID_UNDEFINED; /* just in case */
                 success = false;
             }
@@ -370,7 +370,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, txn->history->fnames.src_filename,
                                   (long)status);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek;
                 success = false;
             }
         }
@@ -387,7 +387,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, txn->history->fnames.src_filename,
                                   (long)status);
-                ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek;
+                ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek;
                 success = false;
             }
         }
@@ -516,7 +516,8 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
             }
         }
 
-        CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.nak_segment_requests += nak->segment_list.num_segments;
+        CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.nak_segment_requests +=
+            nak->segment_list.num_segments;
         if (bad_sr)
         {
             CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INVALID_SR, CFE_EVS_EventType_ERROR,
@@ -530,7 +531,7 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_NAK, CFE_EVS_EventType_ERROR,
                           "CF S%d(%lu:%lu): received invalid NAK PDU", (txn->state == CF_TxnState_S2),
                           (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
     }
 }
 
@@ -573,7 +574,7 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_EOF, CFE_EVS_EventType_ERROR,
                           "CF S%d(%lu:%lu): received invalid EOF PDU", (txn->state == CF_TxnState_S2),
                           (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
-        ++CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error;
+        ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
     }
 }
 
@@ -702,7 +703,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *txn, int *cont /* unused */)
                               (unsigned long)txn->history->seq_num);
             CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_INACTIVITY_DETECTED);
 
-            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.inactivity_timer;
+            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.inactivity_timer;
             CF_CFDP_S_Reset(txn);
         }
         else
@@ -727,7 +728,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *txn, int *cont /* unused */)
                                               (unsigned long)txn->history->src_eid,
                                               (unsigned long)txn->history->seq_num);
                             CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_ACK_LIMIT_NO_EOF);
-                            ++CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.ack_limit;
+                            ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.ack_limit;
 
                             /* no reason to reset this timer, as it isn't used again */
                             CF_CFDP_S_Reset(txn);

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -85,7 +85,7 @@ CF_Logical_PduBuffer_t *CF_CFDP_MsgOutGet(const CF_Transaction_t *txn, bool sile
         success   = false;
     }
 
-    if (success && !CF_AppData.hk.channel_hk[txn->chan_num].frozen && !txn->flags.com.suspended)
+    if (success && !CF_AppData.hk.Payload.channel_hk[txn->chan_num].frozen && !txn->flags.com.suspended)
     {
         /* first, check if there's room in the pipe for the message we want to build */
         if (OS_ObjectIdDefined(chan->sem_id))
@@ -161,7 +161,7 @@ void CF_CFDP_Send(uint8 chan_num, const CF_Logical_PduBuffer_t *ph)
     CFE_MSG_SetMsgTime(&CF_AppData.engine.out.msg->Msg, CFE_TIME_GetTime());
     CFE_SB_TransmitBuffer(CF_AppData.engine.out.msg, true);
 
-    ++CF_AppData.hk.channel_hk[chan_num].counters.sent.pdu;
+    ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.sent.pdu;
 
     CF_AppData.engine.out.msg = NULL;
 }
@@ -253,7 +253,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
                         }
 
                         /* NOTE: recv and recv_spurious will both be incremented */
-                        ++CF_AppData.hk.channel_hk[chan_num].counters.recv.spurious;
+                        ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.spurious;
                     }
 
                     CFE_ES_PerfLogExit(CF_PERF_ID_PDURCVD(chan_num));
@@ -265,7 +265,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
                 if (ph->pdu_header.destination_eid == CF_AppData.config_table->local_eid)
                 {
                     /* we didn't find a match, so assign it to a transaction */
-                    if (CF_AppData.hk.channel_hk[chan_num].q_size[CF_QueueIdx_RX] == CF_MAX_SIMULTANEOUS_RX)
+                    if (CF_AppData.hk.Payload.channel_hk[chan_num].q_size[CF_QueueIdx_RX] == CF_MAX_SIMULTANEOUS_RX)
                     {
                         CFE_EVS_SendEvent(
                             CF_EID_ERR_CFDP_RX_DROPPED, CFE_EVS_EventType_ERROR,

--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -72,9 +72,19 @@ typedef struct CF_ChanAction_SuspResArg
  */
 typedef struct CF_ChanAction_BoolMsgArg
 {
-    const CF_UnionArgsCmd_t *msg;
-    bool                     barg;
+    const CF_UnionArgs_Payload_t *data;
+    bool                          barg;
 } CF_ChanAction_BoolMsgArg_t;
+
+/**
+ * @brief An object to use with channel-scope actions that require the message value
+ *
+ * This combines a boolean action arg with the command message value
+ */
+typedef struct CF_ChanAction_MsgArg
+{
+    const CF_UnionArgs_Payload_t *data;
+} CF_ChanAction_MsgArg_t;
 
 /************************************************************************/
 /** @brief The no-operation command.
@@ -90,7 +100,7 @@ typedef struct CF_ChanAction_BoolMsgArg
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdNoop(CFE_SB_Buffer_t *msg);
+void CF_NoopCmd(const CF_NoopCmd_t *msg);
 
 /************************************************************************/
 /** @brief The reset counters command.
@@ -106,7 +116,7 @@ void CF_CmdNoop(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdReset(CFE_SB_Buffer_t *msg);
+void CF_ResetCmd(const CF_ResetCmd_t *msg);
 
 /************************************************************************/
 /** @brief Ground command to start a file transfer.
@@ -121,7 +131,7 @@ void CF_CmdReset(CFE_SB_Buffer_t *msg);
  * @param msg   Pointer to command message
  *
  */
-void CF_CmdTxFile(CFE_SB_Buffer_t *msg);
+void CF_TxFileCmd(const CF_TxFileCmd_t *msg);
 
 /************************************************************************/
 /** @brief Ground command to start directory playback.
@@ -135,7 +145,7 @@ void CF_CmdTxFile(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg);
+void CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg);
 
 /************************************************************************/
 /** @brief Common logic for all channel-based commands.
@@ -149,7 +159,7 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg);
  * @par Assumptions, External Events, and Notes:
  *       cmd must not be NULL, errstr must not be NULL, fn must be a valid function, context may be NULL.
  *
- * @param cmd       Pointer to command being processed
+ * @param data      Pointer to payload being processed
  * @param errstr    String to be included in the EVS event if command should fail
  * @param fn        Callback action function to invoke for each affected channel
  * @param context   Opaque pointer to pass through to callback (not used in this function)
@@ -157,7 +167,8 @@ void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg);
  * @returns The return value from the given action function.
  * @retval CF_ERROR on error
  */
-CFE_Status_t CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context);
+CFE_Status_t CF_DoChanAction(const CF_UnionArgs_Payload_t *data, const char *errstr, CF_ChanActionFn_t fn,
+                             void *context);
 
 /************************************************************************/
 /** @brief Channel action to set the frozen bit for a channel.
@@ -180,7 +191,7 @@ CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *cont
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdFreeze(CFE_SB_Buffer_t *msg);
+void CF_FreezeCmd(const CF_FreezeCmd_t *msg);
 
 /************************************************************************/
 /** @brief Thaw a channel.
@@ -190,7 +201,7 @@ void CF_CmdFreeze(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdThaw(CFE_SB_Buffer_t *msg);
+void CF_ThawCmd(const CF_ThawCmd_t *msg);
 
 /************************************************************************/
 /** @brief Search for a transaction across all channels.
@@ -218,7 +229,7 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSe
  * @par Assumptions, External Events, and Notes:
  *       cmd must not be NULL, fn must be a valid function, context may be NULL.
  *
- * @param cmd       Pointer to the command message
+ * @param data      Pointer to payload being processed
  * @param cmdstr    String to include in any generated EVS events
  * @param fn        Callback function to invoke for each matched transaction
  * @param context   Opaque object to pass through to the callback
@@ -226,7 +237,8 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSe
  * @returns returns the number of transactions acted upon
  *
  */
-CFE_Status_t CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context);
+CFE_Status_t CF_TsnChanAction(const CF_Transaction_Payload_t *data, const char *cmdstr, CF_TsnChanAction_fn_t fn,
+                              void *context);
 
 /************************************************************************/
 /** @brief Set the suspended bit in a transaction.
@@ -247,12 +259,12 @@ void CF_DoSuspRes_Txn(CF_Transaction_t *txn, CF_ChanAction_SuspResArg_t *context
  *       It uses the CF_TsnChanAction() function to perform the command.
  *
  * @par Assumptions, External Events, and Notes:
- *       cmd must not be NULL.
+ *       payload must not be NULL.
  *
- * @param cmd       Pointer to the command message
+ * @param payload   Pointer to the command message
  * @param action    Action to take (suspend or resume)
  */
-void CF_DoSuspRes(CF_TransactionCmd_t *cmd, uint8 action);
+void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action);
 
 /************************************************************************/
 /** @brief Handle transaction suspend command.
@@ -262,7 +274,7 @@ void CF_DoSuspRes(CF_TransactionCmd_t *cmd, uint8 action);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdSuspend(CFE_SB_Buffer_t *msg);
+void CF_SuspendCmd(const CF_SuspendCmd_t *msg);
 
 /************************************************************************/
 /** @brief Handle transaction resume command.
@@ -272,7 +284,7 @@ void CF_CmdSuspend(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdResume(CFE_SB_Buffer_t *msg);
+void CF_ResumeCmd(const CF_ResumeCmd_t *msg);
 
 /************************************************************************/
 /** @brief tsn chan action to cancel a transaction.
@@ -295,7 +307,7 @@ void CF_CmdCancel_Txn(CF_Transaction_t *txn, void *ignored);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdCancel(CFE_SB_Buffer_t *msg);
+void CF_CancelCmd(const CF_CancelCmd_t *msg);
 
 /************************************************************************/
 /** @brief tsn chan action to abandon a transaction.
@@ -318,7 +330,7 @@ void CF_CmdAbandon_Txn(CF_Transaction_t *txn, void *ignored);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdAbandon(CFE_SB_Buffer_t *msg);
+void CF_AbandonCmd(const CF_AbandonCmd_t *msg);
 
 /************************************************************************/
 /** @brief Sets the dequeue enable/disable flag for a channel.
@@ -342,7 +354,7 @@ CFE_Status_t CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolA
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdEnableDequeue(CFE_SB_Buffer_t *msg);
+void CF_EnableDequeueCmd(const CF_EnableDequeueCmd_t *msg);
 
 /************************************************************************/
 /** @brief Handle a disable dequeue ground command.
@@ -352,7 +364,7 @@ void CF_CmdEnableDequeue(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg);
+void CF_DisableDequeueCmd(const CF_DisableDequeueCmd_t *msg);
 
 /************************************************************************/
 /** @brief Sets the enable/disable flag for the specified polling directory.
@@ -377,7 +389,7 @@ CFE_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolM
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdEnablePolldir(CFE_SB_Buffer_t *msg);
+void CF_EnablePolldirCmd(const CF_EnableDirPollingCmd_t *msg);
 
 /************************************************************************/
 /** @brief Disable a polling dir ground command.
@@ -387,7 +399,7 @@ void CF_CmdEnablePolldir(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg);
+void CF_DisablePolldirCmd(const CF_DisableDirPollingCmd_t *msg);
 
 /************************************************************************/
 /** @brief Purge the history queue for the given channel.
@@ -430,13 +442,13 @@ CFE_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignored);
  *       None
  *
  * @param chan_num  CF channel number
- * @param cmd       Pointer to purge queue command
+ * @param arg       Pointer to purge queue command
  *
  * @returns integer status code indicating success or failure
  * @retval  CFE_SUCCESS if successful
  * @retval  CF_ERROR on error
  */
-CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd);
+CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, void *arg);
 
 /************************************************************************/
 /** @brief Ground command to purge either the history or pending queues.
@@ -446,7 +458,7 @@ CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdPurgeQueue(CFE_SB_Buffer_t *msg);
+void CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg);
 
 /************************************************************************/
 /** @brief Ground command to write a file with queue information.
@@ -456,7 +468,7 @@ void CF_CmdPurgeQueue(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg);
+void CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg);
 
 /************************************************************************/
 /** @brief Checks if the value is less than or equal to the max PDU size.
@@ -508,7 +520,7 @@ CFE_Status_t CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num);
  * @param chan_num  Channel number to operate on
  *
  */
-void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num);
+void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num);
 
 /************************************************************************/
 /** @brief Ground command to set a configuration parameter.
@@ -518,7 +530,7 @@ void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdSetParam(CFE_SB_Buffer_t *msg);
+void CF_SetParamCmd(const CF_SetParamCmd_t *msg);
 
 /************************************************************************/
 /** @brief Ground command to set a configuration parameter.
@@ -528,7 +540,7 @@ void CF_CmdSetParam(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdGetParam(CFE_SB_Buffer_t *msg);
+void CF_GetParamCmd(const CF_GetParamCmd_t *msg);
 
 /************************************************************************/
 /** @brief Ground command enable engine.
@@ -538,7 +550,7 @@ void CF_CmdGetParam(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdEnableEngine(CFE_SB_Buffer_t *msg);
+void CF_EnableEngineCmd(const CF_EnableEngineCmd_t *msg);
 
 /************************************************************************/
 /** @brief Ground command disable engine.
@@ -548,7 +560,7 @@ void CF_CmdEnableEngine(CFE_SB_Buffer_t *msg);
  *
  * @param msg   Pointer to command message
  */
-void CF_CmdDisableEngine(CFE_SB_Buffer_t *msg);
+void CF_DisableEngineCmd(const CF_DisableEngineCmd_t *msg);
 
 /************************************************************************/
 /** @brief Process any ground command contained in the given message.

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -123,39 +123,39 @@ static inline void CF_DequeueTransaction(CF_Transaction_t *txn)
 {
     CF_Assert(txn && (txn->chan_num < CF_NUM_CHANNELS));
     CF_CList_Remove(&CF_AppData.engine.channels[txn->chan_num].qs[txn->flags.com.q_index], &txn->cl_node);
-    CF_Assert(CF_AppData.hk.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index]); /* sanity check */
-    --CF_AppData.hk.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index];
+    CF_Assert(CF_AppData.hk.Payload.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index]); /* sanity check */
+    --CF_AppData.hk.Payload.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index];
 }
 
 static inline void CF_MoveTransaction(CF_Transaction_t *txn, CF_QueueIdx_t queue)
 {
     CF_Assert(txn && (txn->chan_num < CF_NUM_CHANNELS));
     CF_CList_Remove(&CF_AppData.engine.channels[txn->chan_num].qs[txn->flags.com.q_index], &txn->cl_node);
-    CF_Assert(CF_AppData.hk.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index]); /* sanity check */
-    --CF_AppData.hk.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index];
+    CF_Assert(CF_AppData.hk.Payload.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index]); /* sanity check */
+    --CF_AppData.hk.Payload.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index];
     CF_CList_InsertBack(&CF_AppData.engine.channels[txn->chan_num].qs[queue], &txn->cl_node);
     txn->flags.com.q_index = queue;
-    ++CF_AppData.hk.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index];
+    ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index];
 }
 
 static inline void CF_CList_Remove_Ex(CF_Channel_t *chan, CF_QueueIdx_t queueidx, CF_CListNode_t *node)
 {
     CF_CList_Remove(&chan->qs[queueidx], node);
-    CF_Assert(CF_AppData.hk.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx]); /* sanity check */
-    --CF_AppData.hk.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
+    CF_Assert(CF_AppData.hk.Payload.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx]); /* sanity check */
+    --CF_AppData.hk.Payload.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
 }
 
 static inline void CF_CList_InsertAfter_Ex(CF_Channel_t *chan, CF_QueueIdx_t queueidx, CF_CListNode_t *start,
                                            CF_CListNode_t *after)
 {
     CF_CList_InsertAfter(&chan->qs[queueidx], start, after);
-    ++CF_AppData.hk.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
+    ++CF_AppData.hk.Payload.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
 }
 
 static inline void CF_CList_InsertBack_Ex(CF_Channel_t *chan, CF_QueueIdx_t queueidx, CF_CListNode_t *node)
 {
     CF_CList_InsertBack(&chan->qs[queueidx], node);
-    ++CF_AppData.hk.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
+    ++CF_AppData.hk.Payload.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
 }
 
 /************************************************************************/

--- a/mission_build.cmake
+++ b/mission_build.cmake
@@ -1,4 +1,52 @@
-# App specific mission scope configuration
+###########################################################
+#
+# CF App mission build setup
+#
+# This file is evaluated as part of the "prepare" stage
+# and can be used to set up prerequisites for the build,
+# such as generating header files
+#
+###########################################################
 
 # Add stand alone documentation
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/docs/dox_src ${MISSION_BINARY_DIR}/docs/cf-usersguide)
+
+# The list of header files that control the CF configuration
+set(CF_MISSION_CONFIG_FILE_LIST
+  cf_extern_typedefs.h
+  cf_fcncodes.h
+  cf_interface_cfg.h
+  cf_mission_cfg.h
+  cf_msgdefs.h
+  cf_msg.h
+  cf_msgstruct.h
+  cf_tbldefs.h
+  cf_tbl.h
+  cf_tblstruct.h
+)
+
+if (CFE_EDS_ENABLED_BUILD)
+
+  # In an EDS-based build, these files come generated from the EDS tool
+  set(CF_CFGFILE_SRC_cf_interface_cfg "cf_eds_designparameters.h")
+  set(CF_CFGFILE_SRC_cf_fcncodes      "cf_eds_cc.h")
+  set(CF_CFGFILE_SRC_cf_msgstruct     "cf_eds_typedefs.h")
+  set(CF_CFGFILE_SRC_cf_tblstruct     "cf_eds_typedefs.h")
+
+endif(CFE_EDS_ENABLED_BUILD)
+
+# Create wrappers around the all the config header files
+# This makes them individually overridable by the missions, without modifying
+# the distribution default copies
+foreach(CF_CFGFILE ${CF_MISSION_CONFIG_FILE_LIST})
+  get_filename_component(CFGKEY "${CF_CFGFILE}" NAME_WE)
+  if (DEFINED CF_CFGFILE_SRC_${CFGKEY})
+    set(DEFAULT_SOURCE GENERATED_FILE "${CF_CFGFILE_SRC_${CFGKEY}}")
+  else()
+    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${CF_CFGFILE}")
+  endif()
+  generate_config_includefile(
+    FILE_NAME           "${CF_CFGFILE}"
+    ${DEFAULT_SOURCE}
+  )
+endforeach()

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -575,7 +575,7 @@ void Test_CF_ProcessMsg_UnrecognizedCommandEnterDefaultPath(void)
     CF_ProcessMsg(arg_msg);
 
     /* Assert */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_INIT_CMD_LENGTH);
 }
@@ -689,7 +689,7 @@ void Test_CF_AppMain_RunLoopCallTo_CFE_SB_ReceiveBuffer_Returns_CFE_SUCCESS_AndV
     /* Assert for CF_Init call and CF_ProcessMsg */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     /* Assert for CF_ProcessMsg */
-    UtAssert_UINT32_EQ(CF_AppData.hk.counters.err, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
 }
 
 /*******************************************************************************

--- a/unit-test/cf_cfdp_dispatch_tests.c
+++ b/unit-test/cf_cfdp_dispatch_tests.c
@@ -154,7 +154,7 @@ void Test_CF_CFDP_R_DispatchRecv(void)
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     ph->fdirective.directive_code = CF_CFDP_FileDirective_INVALID_MAX;
     UtAssert_VOIDCALL(CF_CFDP_R_DispatchRecv(txn, ph, &dispatch, NULL));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.spurious, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_DC_INV);
 
     /* file data with error */
@@ -162,7 +162,7 @@ void Test_CF_CFDP_R_DispatchRecv(void)
     ph->pdu_header.pdu_type = 1;
     UT_SetDeferredRetcode(UT_KEY(CF_TxnStatus_IsError), 1, true);
     UtAssert_VOIDCALL(CF_CFDP_R_DispatchRecv(txn, ph, &dispatch, NULL));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.dropped, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.dropped, 1);
 
     /* test actual dispatch */
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
@@ -206,7 +206,7 @@ void Test_CF_CFDP_S_DispatchRecv(void)
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     ph->fdirective.directive_code = CF_CFDP_FileDirective_INVALID_MAX;
     UtAssert_VOIDCALL(CF_CFDP_S_DispatchRecv(txn, ph, &dispatch));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.spurious, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_DC_INV);
 
     /* file data PDU, not expected in this type of txn */

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -300,7 +300,7 @@ void Test_CF_CFDP_R_Tick(void)
     UT_SetDeferredRetcode(UT_KEY(CF_Timer_Expired), 1, 1);
     UtAssert_VOIDCALL(CF_CFDP_R_Tick(txn, &cont));
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 2);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.ack_limit, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.ack_limit, 1);
 
     /* in R2 state, ack_timer_armed set, timer expires, not in finack substate */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, &config);
@@ -376,7 +376,7 @@ void Test_CF_CFDP_R_Init(void)
     txn->state = CF_TxnState_R1;
     UtAssert_VOIDCALL(CF_CFDP_R_Init(txn));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CREAT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 1);
 
     /* failure of file open, class 2 */
@@ -385,7 +385,7 @@ void Test_CF_CFDP_R_Init(void)
     txn->state = CF_TxnState_R2;
     UtAssert_VOIDCALL(CF_CFDP_R_Init(txn));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CREAT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open, 2);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 2);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 }
 
@@ -464,7 +464,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     txn->crc.result = 0xdeadbeef;
     UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x1badc0de), 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 1);
 
     /* CRC mismatch, class 2 */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
@@ -472,7 +472,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     txn->crc.result = 0xdeadbeef;
     UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x2badc0de), 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 2);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 2);
 
     /* CRC match */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
@@ -512,7 +512,7 @@ void Test_CF_CFDP_R2_Complete(void)
     UtAssert_BOOL_TRUE(txn->flags.rx.send_fin);
     UtAssert_BOOL_TRUE(txn->flags.rx.complete);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_NAK_LIMIT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.nak_limit, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.nak_limit, 1);
 
     /* test with md_recv - with no more setup this only sets filedata state */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, &config);
@@ -552,7 +552,7 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_WrappedWrite), fd->data_len);
     UtAssert_INT32_EQ(CF_CFDP_R_ProcessFd(txn, ph), 0);
     UtAssert_UINT32_EQ(txn->state_data.receive.cached_pos, 100);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.file_data_bytes, 100);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.file_data_bytes, 100);
     UtAssert_STUB_COUNT(CF_WrappedLseek, 0);
     UtAssert_STUB_COUNT(CF_WrappedWrite, 1);
 
@@ -564,7 +564,7 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_WrappedLseek), fd->offset);
     UtAssert_INT32_EQ(CF_CFDP_R_ProcessFd(txn, ph), 0);
     UtAssert_UINT32_EQ(txn->state_data.receive.cached_pos, 300);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.file_data_bytes, 200);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.file_data_bytes, 200);
     UtAssert_STUB_COUNT(CF_WrappedLseek, 1);
     UtAssert_STUB_COUNT(CF_WrappedWrite, 2);
     UtAssert_UINT32_EQ(txn->state_data.receive.cached_pos, 300);
@@ -594,8 +594,8 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
 
     /* these stats should have been updated during the course of this test */
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_write, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_write, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_seek, 1);
 }
 
 void Test_CF_CFDP_R_SubstateRecvEof(void)
@@ -635,8 +635,8 @@ void Test_CF_CFDP_R_SubstateRecvEof(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_EOF);
 
     /* these counters should have been updated during the test */
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_size_mismatch, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_size_mismatch, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].counters.recv.error, 1);
 }
 
 void Test_CF_CFDP_R1_SubstateRecvEof(void)
@@ -965,7 +965,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_READ);
     UtAssert_BOOL_FALSE(txn->flags.com.crc_calc);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_read, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_read, 1);
 
     /* failure of lseek */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, &config);
@@ -978,7 +978,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk(void)
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_SEEK_CRC);
     UtAssert_BOOL_FALSE(txn->flags.com.crc_calc);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
 }
 
 void Test_CF_CFDP_R2_SubstateSendFin(void)
@@ -1031,7 +1031,7 @@ void Test_CF_CFDP_R2_Recv_fin_ack(void)
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvAck), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_R2_Recv_fin_ack(txn, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_FINACK);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 }
 
 void Test_CF_CFDP_R2_RecvMd(void)
@@ -1091,7 +1091,7 @@ void Test_CF_CFDP_R2_RecvMd(void)
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvMd), 1, CF_PDU_METADATA_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(txn, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_MD);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 }
 
 void Test_CF_CFDP_R_SendInactivityEvent(void)
@@ -1104,7 +1104,7 @@ void Test_CF_CFDP_R_SendInactivityEvent(void)
     /* nominal */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
     UtAssert_VOIDCALL(CF_CFDP_R_SendInactivityEvent(txn));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.inactivity_timer, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.inactivity_timer, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_INACT_TIMER);
 }
 

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -246,7 +246,7 @@ void Test_CF_CFDP_S_Tick(void)
     UtAssert_VOIDCALL(CF_CFDP_S_Tick(txn, &cont));
     UtAssert_STUB_COUNT(CF_Timer_Tick, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_INACT_TIMER);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.inactivity_timer, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.inactivity_timer, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 1);
 
     /* in CF_TxnState_S2, ack_timer_armed */
@@ -284,7 +284,7 @@ void Test_CF_CFDP_S_Tick(void)
     txn->state_data.send.s2.acknak_count  = 9;
     UtAssert_VOIDCALL(CF_CFDP_S_Tick(txn, &cont));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_ACK_LIMIT);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.ack_limit, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.ack_limit, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 2);
 
     /* same, with CF_CFDP_S_SendEof no message */
@@ -395,7 +395,7 @@ void Test_CF_CFDP_S2_SubstateSendEof(void)
 
     /* nominal, this dequeues a transaction so q_size must be nonzero */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
-    CF_AppData.hk.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index] = 10;
+    CF_AppData.hk.Payload.channel_hk[txn->chan_num].q_size[txn->flags.com.q_index] = 10;
     UtAssert_VOIDCALL(CF_CFDP_S2_SubstateSendEof(txn));
     UtAssert_UINT32_EQ(txn->state_data.send.sub_state, CF_TxSubState_WAIT_FOR_EOF_ACK);
     UtAssert_BOOL_TRUE(txn->flags.com.ack_timer_armed);
@@ -419,7 +419,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     /* failure of CF_CFDP_ConstructPduHeader */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, NULL);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, true), 0);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* nominal, smaller than chunk, no CRC */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, &config);
@@ -428,7 +428,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedRead), 1, read_size);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, false), read_size);
     cumulative_read += read_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* nominal, larger than PDU, no CRC */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, &config);
@@ -438,7 +438,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedRead), 1, read_size);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size * 2, false), read_size);
     cumulative_read += read_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
     UtAssert_STUB_COUNT(CF_CRC_Digest, 0);
 
     /* nominal, larger than chunk, with CRC */
@@ -449,7 +449,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedRead), 1, config->outgoing_file_chunk_size);
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, true), config->outgoing_file_chunk_size);
     cumulative_read += config->outgoing_file_chunk_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
     UtAssert_STUB_COUNT(CF_CRC_Digest, 1);
 
     /* read w/failure */
@@ -458,8 +458,8 @@ void Test_CF_CFDP_S_SendFileData(void)
     config->outgoing_file_chunk_size = read_size;
     txn->fsize                       = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, true), -1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_read, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_read, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_READ);
 
     /* require lseek */
@@ -471,7 +471,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     txn->fsize                       = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, true), read_size);
     cumulative_read += read_size;
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
 
     /* lseek w/failure */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, &config);
@@ -479,8 +479,8 @@ void Test_CF_CFDP_S_SendFileData(void)
     config->outgoing_file_chunk_size = read_size;
     txn->fsize                       = 300;
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, true), -1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_FD);
 }
 
@@ -629,7 +629,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_ALREADY_OPEN);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 1);
 
     /* file already open */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
@@ -646,7 +646,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_OPEN);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_open, 2);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 2);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* first CF_WrappedLseek fails */
@@ -654,7 +654,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedLseek), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_END);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* second CF_WrappedLseek fails */
@@ -662,7 +662,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedLseek), 2, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_BEG);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.fault.file_seek, 2);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 2);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* CF_CFDP_SendMd fails w/ ERROR */
@@ -743,7 +743,7 @@ void Test_CF_CFDP_S2_Nak(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_NAK);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 
     /* nominal, re-send md request (0,0) */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
@@ -752,7 +752,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak->segment_list.segments[0]  = (CF_Logical_SegmentRequest_t) {0, 0};
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
     UtAssert_BOOL_TRUE(txn->flags.tx.md_need_send);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.nak_segment_requests, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.nak_segment_requests, 1);
 
     /* nominal, nonzero offsets */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
@@ -762,7 +762,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak->segment_list.segments[1]  = (CF_Logical_SegmentRequest_t) {200, 300};
     txn->fsize                     = 300;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.nak_segment_requests, 3);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.nak_segment_requests, 3);
 
     /* bad segments */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
@@ -773,7 +773,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak->segment_list.segments[2]  = (CF_Logical_SegmentRequest_t) {400, 0};
     txn->fsize                     = 300;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.nak_segment_requests, 6);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.nak_segment_requests, 6);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_INVALID_SR);
 
     /* bad decode */
@@ -782,7 +782,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak                            = &ph->int_header.nak;
     nak->segment_list.num_segments = 1;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error, 2);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 2);
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_NAK);
 }
 
@@ -818,7 +818,7 @@ void Test_CF_CFDP_S2_WaitForEofAck(void)
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvAck), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S2_WaitForEofAck(txn, ph));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_EOF);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.error, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 
     /* with error status */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -284,7 +284,7 @@ void Test_CF_CFDP_ReceiveMessage(void)
     ph->fdirective.directive_code = CF_CFDP_FileDirective_FIN;
     chan->cur                     = txn;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(chan));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.spurious, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious, 1);
     UtAssert_STUB_COUNT(CF_CFDP_SendAck, 1);
     UtAssert_NULL(chan->cur); /* cleared */
 
@@ -295,9 +295,9 @@ void Test_CF_CFDP_ReceiveMessage(void)
     ph->pdu_header.source_eid     = config->local_eid;
     ph->fdirective.directive_code = CF_CFDP_FileDirective_FIN;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(chan));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.spurious, 1); /* no increment */
-    UtAssert_STUB_COUNT(CF_CFDP_SendAck, 1);                                               /* no increment */
-    UtAssert_NULL(chan->cur);                                                              /* cleared */
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious, 1); /* no increment */
+    UtAssert_STUB_COUNT(CF_CFDP_SendAck, 1);                                                       /* no increment */
+    UtAssert_NULL(chan->cur);                                                                      /* cleared */
 
     /* FIN handling special case, but failure of CF_CFDP_SendAck */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &chan, NULL, &txn, &config);
@@ -307,8 +307,9 @@ void Test_CF_CFDP_ReceiveMessage(void)
     ph->fdirective.directive_code = CF_CFDP_FileDirective_FIN;
     chan->cur                     = txn;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(chan));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[txn->chan_num].counters.recv.spurious, 2); /* this does get increment */
-    UtAssert_ADDRESS_EQ(chan->cur, txn);                                                   /* not changed */
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious,
+                       2);               /* this does get increment */
+    UtAssert_ADDRESS_EQ(chan->cur, txn); /* not changed */
 
     /* recv but not the correct destination_eid */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &chan, NULL, &txn, &config);
@@ -319,9 +320,9 @@ void Test_CF_CFDP_ReceiveMessage(void)
 
     /* recv correct destination_eid but CF_MAX_SIMULTANEOUS_RX hit */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &chan, NULL, &txn, &config);
-    CF_AppData.hk.channel_hk[txn->chan_num].q_size[CF_QueueIdx_RX] = CF_MAX_SIMULTANEOUS_RX;
-    config->local_eid                                              = 123;
-    ph->pdu_header.destination_eid                                 = config->local_eid;
+    CF_AppData.hk.Payload.channel_hk[txn->chan_num].q_size[CF_QueueIdx_RX] = CF_MAX_SIMULTANEOUS_RX;
+    config->local_eid                                                      = 123;
+    ph->pdu_header.destination_eid                                         = config->local_eid;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(chan));
     UT_CF_AssertEventID(CF_EID_ERR_CFDP_RX_DROPPED);
 }
@@ -336,7 +337,7 @@ void Test_CF_CFDP_Send(void)
     /* nominal */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, NULL, NULL);
     UtAssert_VOIDCALL(CF_CFDP_Send(UT_CFDP_CHANNEL, ph));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].counters.sent.pdu, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].counters.sent.pdu, 1);
     UtAssert_STUB_COUNT(CFE_MSG_SetSize, 1);
     UtAssert_STUB_COUNT(CFE_SB_TransmitBuffer, 1);
 }
@@ -384,10 +385,10 @@ void Test_CF_CFDP_MsgOutGet(void)
 
     /* channel is frozen */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, NULL);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
     UtAssert_NULL(CF_CFDP_MsgOutGet(txn, false));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
 
     /* no msg available from SB */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, NULL);

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -479,7 +479,7 @@ void Test_CF_CFDP_RecvIdle(void)
     /* setup for FindUnusedChunks */
     memset(&ut_unused_chunks, 0, sizeof(ut_unused_chunks));
     CF_AppData.engine.channels[UT_CFDP_CHANNEL].cs[CF_Direction_RX] = &ut_unused_chunks.cl_node;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[0]             = 4;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].q_size[0]     = 4;
     UT_SetHandlerFunction(UT_KEY(CF_CList_Pop), UT_AltHandler_GenericPointerReturn, &ut_unused_chunks.cl_node);
 
     /* nominal call, file data, class 1 */
@@ -1015,9 +1015,9 @@ void Test_CF_CFDP_CycleTx(void)
 
     /* need to set dequeue_enabled so it enters the actual logic */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, &chan, NULL, &txn, &config);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[0] = 10;
-    CF_AppData.engine.enabled                           = 1;
-    config->chan[UT_CFDP_CHANNEL].dequeue_enabled       = 1;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].q_size[0] = 10;
+    CF_AppData.engine.enabled                                   = 1;
+    config->chan[UT_CFDP_CHANNEL].dequeue_enabled               = 1;
 
     /* nominal call, w/chan->cur non-null */
     chan->cur = txn;
@@ -1139,14 +1139,14 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
 
     /* nominal call, polldir disabled (noop) */
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(chan));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
 
     /* nominal call, polldir enabled but interval_sec == 0 */
     /* Will tick because CF_Timer_Expired stub returns 0 by default (not expired) */
     pdcfg->enabled = 1;
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(chan));
     UtAssert_BOOL_FALSE(poll->timer_set);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
     UtAssert_STUB_COUNT(CF_Timer_Tick, 1);
 
     /* with interval_sec nonzero the timer should get set, but not tick */
@@ -1154,7 +1154,7 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(chan));
     UtAssert_BOOL_TRUE(poll->timer_set);
     UtAssert_STUB_COUNT(CF_Timer_Tick, 1);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
 
     /* call again should tick */
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(chan));
@@ -1166,7 +1166,7 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(chan));
     UtAssert_BOOL_FALSE(poll->timer_set);
     UtAssert_BOOL_TRUE(poll->pb.busy);
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].poll_counter, 1);
 
     /* make an error occur in CF_CFDP_PlaybackDir_Initiate() */
     poll->pb.busy   = false; /* above would have set it true */
@@ -1196,7 +1196,7 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
     /* test that call to CF_CFDP_UpdatePollPbCounted will decrement back to 0 again */
     pdcfg->enabled = 0;
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(chan));
-    UtAssert_UINT32_EQ(CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
+    UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].poll_counter, 0);
 }
 
 void Test_CF_CFDP_ProcessPlaybackDirectory(void)
@@ -1339,11 +1339,11 @@ void Test_CF_CFDP_CycleEngine(void)
     UtAssert_VOIDCALL(CF_CFDP_CycleEngine());
 
     /* enabled but frozen */
-    CF_AppData.engine.enabled                        = 1;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
+    CF_AppData.engine.enabled                                = 1;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].frozen = 1;
     UtAssert_VOIDCALL(CF_CFDP_CycleEngine());
 
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].frozen = 0;
     UtAssert_VOIDCALL(CF_CFDP_CycleEngine());
 }
 
@@ -1364,11 +1364,11 @@ void Test_CF_CFDP_ResetTransaction(void)
     UT_ResetState(UT_KEY(CF_FreeTransaction));
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
     txn->flags.com.q_index = CF_QueueIdx_FREE;
-    UtAssert_VOIDCALL(CF_CFDP_ResetTransaction(txn, 0));  
+    UtAssert_VOIDCALL(CF_CFDP_ResetTransaction(txn, 0));
 
     /* nominal call */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, NULL);
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[txn->flags.com.q_index] = 10;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].q_size[txn->flags.com.q_index] = 10;
     UtAssert_VOIDCALL(CF_CFDP_ResetTransaction(txn, 1));
     UtAssert_STUB_COUNT(CF_FreeTransaction, 1);
 
@@ -1470,8 +1470,8 @@ void Test_CF_CFDP_SetTxnStatus(void)
 
 void Test_CF_CFDP_SendEotPkt(void)
 {
-    CF_EotPktBuf_t  PktBuf;
-    CF_EotPktBuf_t *PktBufPtr;
+    CF_EotPacket_t  PktBuf;
+    CF_EotPacket_t *PktBufPtr;
 
     CF_Transaction_t *txn;
     CF_Playback_t     pb;

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -127,7 +127,7 @@ void Test_CF_ResetHistory(void)
 
     memset(&history, 0, sizeof(history));
 
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST] = 4;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST] = 4;
 
     /* nominal call */
     UtAssert_VOIDCALL(CF_ResetHistory(&CF_AppData.engine.channels[UT_CFDP_CHANNEL], &history));
@@ -145,10 +145,10 @@ void Test_CF_FindUnusedTransaction(void)
     memset(&hist, 0, sizeof(hist));
     memset(&txn, 0, sizeof(txn));
     memset(&CF_AppData, 0, sizeof(CF_AppData));
-    chan                                                               = &CF_AppData.engine.channels[UT_CFDP_CHANNEL];
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_FREE] = 2;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST_FREE] = 1;
-    CF_AppData.hk.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST]      = 1;
+    chan = &CF_AppData.engine.channels[UT_CFDP_CHANNEL];
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_FREE]      = 2;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST_FREE] = 1;
+    CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].q_size[CF_QueueIdx_HIST]      = 1;
 
     UtAssert_NULL(CF_FindUnusedTransaction(chan));
 
@@ -272,12 +272,12 @@ void Test_cf_dequeue_transaction_Call_CF_CList_Remove_AndDecrement_q_size(void)
     expected_head    = &CF_AppData.engine.channels[arg_t.chan_num].qs[arg_t.flags.com.q_index];
     expected_cl_node = &arg_t.cl_node;
 
-    CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index] = initial_q_size;
+    CF_AppData.hk.Payload.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index] = initial_q_size;
 
     /* Act */
     CF_DequeueTransaction(&arg_t);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index];
+    updated_q_size = CF_AppData.hk.Payload.channel_hk[arg_t.chan_num].q_size[arg_t.flags.com.q_index];
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_clist_remove.head, expected_head);
@@ -317,7 +317,7 @@ void Test_cf_move_transaction_Call_CF_CList_InsertBack_AndSet_q_index_ToGiven_q(
     expected_insert_back_node = &arg_t->cl_node;
 
     /* Queue size needes to be >= 1 */
-    CF_AppData.hk.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] = 1;
+    CF_AppData.hk.Payload.channel_hk[arg_t->chan_num].q_size[arg_t->flags.com.q_index] = 1;
 
     /* Act */
     CF_MoveTransaction(arg_t, arg_q);
@@ -355,12 +355,12 @@ void Test_CF_CList_Remove_Ex_Call_CF_CList_Remove_AndDecrement_q_size(void)
     expected_remove_head = &arg_c->qs[arg_index];
     expected_remove_node = arg_node;
 
-    CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
+    CF_AppData.hk.Payload.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
 
     /* Act */
     CF_CList_Remove_Ex(arg_c, arg_index, arg_node);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.hk.Payload.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_Remove, 1);
@@ -390,12 +390,12 @@ void Test_CF_CList_InsertAfter_Ex_Call_CF_CList_InsertAfter_AndIncrement_q_size(
     UT_SetDataBuffer(UT_KEY(CF_CList_InsertAfter), &context_CF_CList_InsertAfter, sizeof(context_CF_CList_InsertAfter),
                      false);
 
-    CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
+    CF_AppData.hk.Payload.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
 
     /* Act */
     CF_CList_InsertAfter_Ex(arg_c, arg_index, arg_start, arg_after);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.hk.Payload.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_InsertAfter, 1);
@@ -426,12 +426,12 @@ void Test_CF_CList_InsertBack_Ex_Call_CF_CList_InsertBack_AndIncrement_q_size(vo
     expected_insert_back_head = &arg_c->qs[arg_index];
     expected_insert_back_node = arg_node;
 
-    CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
+    CF_AppData.hk.Payload.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index] = initial_q_size;
 
     /* Act */
     CF_CList_InsertBack_Ex(arg_c, arg_index, arg_node);
 
-    updated_q_size = CF_AppData.hk.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
+    updated_q_size = CF_AppData.hk.Payload.channel_hk[arg_c - CF_AppData.engine.channels].q_size[arg_index];
 
     /* Assert */
     UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -30,14 +30,26 @@ void UT_DefaultHandler_CF_ProcessGroundCommand(void *, UT_EntryKey_t, const UT_S
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CmdAbandon()
+ * Generated stub function for CF_AbandonCmd()
  * ----------------------------------------------------
  */
-void CF_CmdAbandon(CFE_SB_Buffer_t *msg)
+void CF_AbandonCmd(const CF_AbandonCmd_t *msg)
 {
-    UT_GenStub_AddParam(CF_CmdAbandon, CFE_SB_Buffer_t *, msg);
+    UT_GenStub_AddParam(CF_AbandonCmd, const CF_AbandonCmd_t *, msg);
 
-    UT_GenStub_Execute(CF_CmdAbandon, Basic, NULL);
+    UT_GenStub_Execute(CF_AbandonCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_CancelCmd()
+ * ----------------------------------------------------
+ */
+void CF_CancelCmd(const CF_CancelCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_CancelCmd, const CF_CancelCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_CancelCmd, Basic, NULL);
 }
 
 /*
@@ -55,18 +67,6 @@ void CF_CmdAbandon_Txn(CF_Transaction_t *txn, void *ignored)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CmdCancel()
- * ----------------------------------------------------
- */
-void CF_CmdCancel(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdCancel, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdCancel, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_CmdCancel_Txn()
  * ----------------------------------------------------
  */
@@ -76,225 +76,6 @@ void CF_CmdCancel_Txn(CF_Transaction_t *txn, void *ignored)
     UT_GenStub_AddParam(CF_CmdCancel_Txn, void *, ignored);
 
     UT_GenStub_Execute(CF_CmdCancel_Txn, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdDisableDequeue()
- * ----------------------------------------------------
- */
-void CF_CmdDisableDequeue(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdDisableDequeue, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdDisableDequeue, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdDisableEngine()
- * ----------------------------------------------------
- */
-void CF_CmdDisableEngine(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdDisableEngine, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdDisableEngine, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdDisablePolldir()
- * ----------------------------------------------------
- */
-void CF_CmdDisablePolldir(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdDisablePolldir, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdDisablePolldir, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdEnableDequeue()
- * ----------------------------------------------------
- */
-void CF_CmdEnableDequeue(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdEnableDequeue, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdEnableDequeue, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdEnableEngine()
- * ----------------------------------------------------
- */
-void CF_CmdEnableEngine(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdEnableEngine, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdEnableEngine, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdEnablePolldir()
- * ----------------------------------------------------
- */
-void CF_CmdEnablePolldir(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdEnablePolldir, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdEnablePolldir, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdFreeze()
- * ----------------------------------------------------
- */
-void CF_CmdFreeze(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdFreeze, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdFreeze, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdGetParam()
- * ----------------------------------------------------
- */
-void CF_CmdGetParam(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdGetParam, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdGetParam, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdGetSetParam()
- * ----------------------------------------------------
- */
-void CF_CmdGetSetParam(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num)
-{
-    UT_GenStub_AddParam(CF_CmdGetSetParam, uint8, is_set);
-    UT_GenStub_AddParam(CF_CmdGetSetParam, CF_GetSet_ValueID_t, param_id);
-    UT_GenStub_AddParam(CF_CmdGetSetParam, uint32, value);
-    UT_GenStub_AddParam(CF_CmdGetSetParam, uint8, chan_num);
-
-    UT_GenStub_Execute(CF_CmdGetSetParam, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdNoop()
- * ----------------------------------------------------
- */
-void CF_CmdNoop(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdNoop, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdNoop, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdPlaybackDir()
- * ----------------------------------------------------
- */
-void CF_CmdPlaybackDir(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdPlaybackDir, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdPlaybackDir, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdPurgeQueue()
- * ----------------------------------------------------
- */
-void CF_CmdPurgeQueue(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdPurgeQueue, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdPurgeQueue, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdReset()
- * ----------------------------------------------------
- */
-void CF_CmdReset(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdReset, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdReset, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdResume()
- * ----------------------------------------------------
- */
-void CF_CmdResume(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdResume, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdResume, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdSetParam()
- * ----------------------------------------------------
- */
-void CF_CmdSetParam(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdSetParam, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdSetParam, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdSuspend()
- * ----------------------------------------------------
- */
-void CF_CmdSuspend(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdSuspend, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdSuspend, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdThaw()
- * ----------------------------------------------------
- */
-void CF_CmdThaw(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdThaw, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdThaw, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CmdTxFile()
- * ----------------------------------------------------
- */
-void CF_CmdTxFile(CFE_SB_Buffer_t *msg)
-{
-    UT_GenStub_AddParam(CF_CmdTxFile, CFE_SB_Buffer_t *, msg);
-
-    UT_GenStub_Execute(CF_CmdTxFile, Basic, NULL);
 }
 
 /*
@@ -333,14 +114,38 @@ CFE_Status_t CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CmdWriteQueue()
+ * Generated stub function for CF_DisableDequeueCmd()
  * ----------------------------------------------------
  */
-void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
+void CF_DisableDequeueCmd(const CF_DisableDequeueCmd_t *msg)
 {
-    UT_GenStub_AddParam(CF_CmdWriteQueue, CFE_SB_Buffer_t *, msg);
+    UT_GenStub_AddParam(CF_DisableDequeueCmd, const CF_DisableDequeueCmd_t *, msg);
 
-    UT_GenStub_Execute(CF_CmdWriteQueue, Basic, NULL);
+    UT_GenStub_Execute(CF_DisableDequeueCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_DisableEngineCmd()
+ * ----------------------------------------------------
+ */
+void CF_DisableEngineCmd(const CF_DisableEngineCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_DisableEngineCmd, const CF_DisableEngineCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_DisableEngineCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_DisablePolldirCmd()
+ * ----------------------------------------------------
+ */
+void CF_DisablePolldirCmd(const CF_DisableDirPollingCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_DisablePolldirCmd, const CF_DisableDirPollingCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_DisablePolldirCmd, Basic, NULL);
 }
 
 /*
@@ -348,11 +153,12 @@ void CF_CmdWriteQueue(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_DoChanAction()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_DoChanAction(CF_UnionArgsCmd_t *cmd, const char *errstr, CF_ChanActionFn_t fn, void *context)
+CFE_Status_t CF_DoChanAction(const CF_UnionArgs_Payload_t *data, const char *errstr, CF_ChanActionFn_t fn,
+                             void *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_DoChanAction, CFE_Status_t);
 
-    UT_GenStub_AddParam(CF_DoChanAction, CF_UnionArgsCmd_t *, cmd);
+    UT_GenStub_AddParam(CF_DoChanAction, const CF_UnionArgs_Payload_t *, data);
     UT_GenStub_AddParam(CF_DoChanAction, const char *, errstr);
     UT_GenStub_AddParam(CF_DoChanAction, CF_ChanActionFn_t, fn);
     UT_GenStub_AddParam(CF_DoChanAction, void *, context);
@@ -418,12 +224,12 @@ CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *cont
  * Generated stub function for CF_DoPurgeQueue()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
+CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, void *arg)
 {
     UT_GenStub_SetupReturnBuffer(CF_DoPurgeQueue, CFE_Status_t);
 
     UT_GenStub_AddParam(CF_DoPurgeQueue, uint8, chan_num);
-    UT_GenStub_AddParam(CF_DoPurgeQueue, CF_UnionArgsCmd_t *, cmd);
+    UT_GenStub_AddParam(CF_DoPurgeQueue, void *, arg);
 
     UT_GenStub_Execute(CF_DoPurgeQueue, Basic, NULL);
 
@@ -435,9 +241,9 @@ CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, CF_UnionArgsCmd_t *cmd)
  * Generated stub function for CF_DoSuspRes()
  * ----------------------------------------------------
  */
-void CF_DoSuspRes(CF_TransactionCmd_t *cmd, uint8 action)
+void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action)
 {
-    UT_GenStub_AddParam(CF_DoSuspRes, CF_TransactionCmd_t *, cmd);
+    UT_GenStub_AddParam(CF_DoSuspRes, const CF_Transaction_Payload_t *, payload);
     UT_GenStub_AddParam(CF_DoSuspRes, uint8, action);
 
     UT_GenStub_Execute(CF_DoSuspRes, Basic, NULL);
@@ -458,6 +264,42 @@ void CF_DoSuspRes_Txn(CF_Transaction_t *txn, CF_ChanAction_SuspResArg_t *context
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_EnableDequeueCmd()
+ * ----------------------------------------------------
+ */
+void CF_EnableDequeueCmd(const CF_EnableDequeueCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_EnableDequeueCmd, const CF_EnableDequeueCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_EnableDequeueCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_EnableEngineCmd()
+ * ----------------------------------------------------
+ */
+void CF_EnableEngineCmd(const CF_EnableEngineCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_EnableEngineCmd, const CF_EnableEngineCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_EnableEngineCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_EnablePolldirCmd()
+ * ----------------------------------------------------
+ */
+void CF_EnablePolldirCmd(const CF_EnableDirPollingCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_EnablePolldirCmd, const CF_EnableDirPollingCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_EnablePolldirCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_FindTransactionBySequenceNumberAllChannels()
  * ----------------------------------------------------
  */
@@ -471,6 +313,69 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSe
     UT_GenStub_Execute(CF_FindTransactionBySequenceNumberAllChannels, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_FindTransactionBySequenceNumberAllChannels, CF_Transaction_t *);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_FreezeCmd()
+ * ----------------------------------------------------
+ */
+void CF_FreezeCmd(const CF_FreezeCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_FreezeCmd, const CF_FreezeCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_FreezeCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_GetParamCmd()
+ * ----------------------------------------------------
+ */
+void CF_GetParamCmd(const CF_GetParamCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_GetParamCmd, const CF_GetParamCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_GetParamCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_GetSetParamCmd()
+ * ----------------------------------------------------
+ */
+void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num)
+{
+    UT_GenStub_AddParam(CF_GetSetParamCmd, uint8, is_set);
+    UT_GenStub_AddParam(CF_GetSetParamCmd, CF_GetSet_ValueID_t, param_id);
+    UT_GenStub_AddParam(CF_GetSetParamCmd, uint32, value);
+    UT_GenStub_AddParam(CF_GetSetParamCmd, uint8, chan_num);
+
+    UT_GenStub_Execute(CF_GetSetParamCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_NoopCmd()
+ * ----------------------------------------------------
+ */
+void CF_NoopCmd(const CF_NoopCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_NoopCmd, const CF_NoopCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_NoopCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_PlaybackDirCmd()
+ * ----------------------------------------------------
+ */
+void CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_PlaybackDirCmd, const CF_PlaybackDirCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_PlaybackDirCmd, Basic, NULL);
 }
 
 /*
@@ -504,6 +409,18 @@ CFE_Status_t CF_PurgeHistory(CF_CListNode_t *node, CF_Channel_t *chan)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_PurgeQueueCmd()
+ * ----------------------------------------------------
+ */
+void CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_PurgeQueueCmd, const CF_PurgeQueueCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_PurgeQueueCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_PurgeTransaction()
  * ----------------------------------------------------
  */
@@ -521,14 +438,75 @@ CFE_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignored)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_ResetCmd()
+ * ----------------------------------------------------
+ */
+void CF_ResetCmd(const CF_ResetCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_ResetCmd, const CF_ResetCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_ResetCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_ResumeCmd()
+ * ----------------------------------------------------
+ */
+void CF_ResumeCmd(const CF_ResumeCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_ResumeCmd, const CF_ResumeCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_ResumeCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_SetParamCmd()
+ * ----------------------------------------------------
+ */
+void CF_SetParamCmd(const CF_SetParamCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_SetParamCmd, const CF_SetParamCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_SetParamCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_SuspendCmd()
+ * ----------------------------------------------------
+ */
+void CF_SuspendCmd(const CF_SuspendCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_SuspendCmd, const CF_SuspendCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_SuspendCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_ThawCmd()
+ * ----------------------------------------------------
+ */
+void CF_ThawCmd(const CF_ThawCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_ThawCmd, const CF_ThawCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_ThawCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_TsnChanAction()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_TsnChanAction_fn_t fn, void *context)
+CFE_Status_t CF_TsnChanAction(const CF_Transaction_Payload_t *payload, const char *cmdstr, CF_TsnChanAction_fn_t fn,
+                              void *context)
 {
     UT_GenStub_SetupReturnBuffer(CF_TsnChanAction, CFE_Status_t);
 
-    UT_GenStub_AddParam(CF_TsnChanAction, CF_TransactionCmd_t *, cmd);
+    UT_GenStub_AddParam(CF_TsnChanAction, const CF_Transaction_Payload_t *, payload);
     UT_GenStub_AddParam(CF_TsnChanAction, const char *, cmdstr);
     UT_GenStub_AddParam(CF_TsnChanAction, CF_TsnChanAction_fn_t, fn);
     UT_GenStub_AddParam(CF_TsnChanAction, void *, context);
@@ -536,4 +514,28 @@ CFE_Status_t CF_TsnChanAction(CF_TransactionCmd_t *cmd, const char *cmdstr, CF_T
     UT_GenStub_Execute(CF_TsnChanAction, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_TsnChanAction, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_TxFileCmd()
+ * ----------------------------------------------------
+ */
+void CF_TxFileCmd(const CF_TxFileCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_TxFileCmd, const CF_TxFileCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_TxFileCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_WriteQueueCmd()
+ * ----------------------------------------------------
+ */
+void CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
+{
+    UT_GenStub_AddParam(CF_WriteQueueCmd, const CF_WriteQueueCmd_t *, msg);
+
+    UT_GenStub_Execute(CF_WriteQueueCmd, Basic, NULL);
 }

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -41,7 +41,7 @@ void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *, UT_EntryKey_t, const U
  * Generated stub function for CF_FindTransactionBySequenceNumber()
  * ----------------------------------------------------
  */
-CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *      chan,
+CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t       *chan,
                                                      CF_TransactionSeq_t transaction_sequence_number,
                                                      CF_EntityId_t       src_eid)
 {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Move the header files to a "config" directory as documented in the CFE guidelines, which allows easier override.

Organize the content to adhere to the patterns.

Specifically - adds a dedicated structure type for each cmd, and also puts the payload into a separate sub-structure.

Command handlers and tests updated accordingly (many of which were simplified).

Fixes #418

**Testing performed**
Build and run all tests
Execute local file transfer using 2 instances of CFS + CFDP app

**Expected behavior changes**
Nothing on the external interface changes

**System(s) tested on**
Debian

**Additional context**
First step of making CF adhere to current patterns

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
