### PR TITLE
Fix #430, correct type mismatches

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -1054,15 +1054,15 @@ CFE_Status_t CF_CFDP_InitEngine(void)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
 {
-    CF_CFDP_CycleTx_args_t *args = (CF_CFDP_CycleTx_args_t *)context;
-    CF_Transaction_t *      txn  = container_of(node, CF_Transaction_t, cl_node);
-    CFE_Status_t            ret  = 1; /* default option is exit traversal */
+    CF_CFDP_CycleTx_args_t *  args = (CF_CFDP_CycleTx_args_t *)context;
+    CF_Transaction_t *        txn  = container_of(node, CF_Transaction_t, cl_node);
+    CF_CListTraverse_Status_t ret  = CF_CLIST_EXIT; /* default option is exit traversal */
 
     if (txn->flags.com.suspended)
     {
-        ret = 0; /* suspended, so move on to next */
+        ret = CF_CLIST_CONT; /* suspended, so move on to next */
     }
     else
     {
@@ -1133,11 +1133,11 @@ void CF_CFDP_CycleTx(CF_Channel_t *chan)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
 {
-    CFE_Status_t         ret  = CF_CLIST_CONT; /* CF_CLIST_CONT means don't tick one, keep looking for cur */
-    CF_CFDP_Tick_args_t *args = (CF_CFDP_Tick_args_t *)context;
-    CF_Transaction_t *   txn  = container_of(node, CF_Transaction_t, cl_node);
+    CF_CListTraverse_Status_t ret  = CF_CLIST_CONT; /* CF_CLIST_CONT means don't tick one, keep looking for cur */
+    CF_CFDP_Tick_args_t *     args = (CF_CFDP_Tick_args_t *)context;
+    CF_Transaction_t *        txn  = container_of(node, CF_Transaction_t, cl_node);
     if (!args->chan->cur || (args->chan->cur == txn))
     {
         /* found where we left off, so clear that and move on */
@@ -1787,7 +1787,7 @@ void CF_CFDP_CancelTransaction(CF_Transaction_t *txn)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *node, void *context)
 {
     CF_Transaction_t *txn = container_of(node, CF_Transaction_t, cl_node);
     if (OS_ObjectIdDefined(txn->fd))

--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -602,7 +602,7 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
  * @returns integer traversal code
  * @retval Always CF_LIST_CONT indicate list traversal should not exit early.
  */
-CFE_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *node, void *context);
+CF_CListTraverse_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *node, void *context);
 
 /************************************************************************/
 /** @brief Cycle the current active tx or make a new one active.
@@ -640,7 +640,7 @@ void CF_CFDP_CycleTx(CF_Channel_t *chan);
  * @retval CF_CLIST_EXIT when it's found, which terminates list traversal
  * @retval CF_CLIST_CONT when it's isn't found, which causes list traversal to continue
  */
-CFE_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context);
+CF_CListTraverse_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context);
 
 /************************************************************************/
 /** @brief Call R and then S tick functions for all active transactions.
@@ -701,6 +701,6 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *chan);
  * @retval CF_CLIST_EXIT when it's found, which terminates list traversal
  * @retval CF_CLIST_CONT when it's isn't found, which causes list traversal to continue
  */
-CFE_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context);
+CF_CListTraverse_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context);
 
 #endif /* !CF_CFDP_H */

--- a/fsw/src/cf_clist.c
+++ b/fsw/src/cf_clist.c
@@ -202,7 +202,7 @@ void CF_CList_Traverse(CF_CListNode_t *start, CF_CListFn_t fn, void *context)
             {
                 last = 1;
             }
-            if (fn(node, context))
+            if (!CF_CListTraverse_Status_IS_CONTINUE(fn(node, context)))
             {
                 break;
             }
@@ -246,7 +246,7 @@ void CF_CList_Traverse_R(CF_CListNode_t *end, CF_CListFn_t fn, void *context)
                     last = 1;
                 }
 
-                if (fn(node, context))
+                if (!CF_CListTraverse_Status_IS_CONTINUE(fn(node, context)))
                 {
                     break;
                 }

--- a/fsw/src/cf_clist.h
+++ b/fsw/src/cf_clist.h
@@ -27,9 +27,24 @@
 #define CF_CLIST_H
 
 #include <stddef.h>
+#include <stdbool.h>
 
-#define CF_CLIST_CONT (0) /**< \brief Constant indicating to continue traversal */
-#define CF_CLIST_EXIT (1) /**< \brief Constant indicating to stop traversal */
+typedef enum
+{
+    CF_CListTraverse_Status_CONTINUE = 0,
+    CF_CListTraverse_Status_EXIT     = 1
+} CF_CListTraverse_Status_t;
+
+#define CF_CLIST_CONT CF_CListTraverse_Status_CONTINUE /**< \brief Constant indicating to continue traversal */
+#define CF_CLIST_EXIT CF_CListTraverse_Status_EXIT     /**< \brief Constant indicating to stop traversal */
+
+/**
+ * Checks if the list traversal should continue
+ */
+static inline bool CF_CListTraverse_Status_IS_CONTINUE(CF_CListTraverse_Status_t stat)
+{
+    return (stat == CF_CListTraverse_Status_CONTINUE);
+}
 
 /**
  * @brief Node link structure
@@ -63,7 +78,7 @@ typedef struct CF_CListNode CF_CListNode_t;
  * @retval  #CF_CLIST_CONT Indicates to continue traversing the list
  * @retval  #CF_CLIST_EXIT Indicates to stop traversing the list
  */
-typedef int (*CF_CListFn_t)(CF_CListNode_t *node, void *context);
+typedef CF_CListTraverse_Status_t (*CF_CListFn_t)(CF_CListNode_t *node, void *context);
 
 /************************************************************************/
 /** @brief Initialize a clist node.

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -96,7 +96,7 @@ typedef struct CF_TraverseAll_Arg
 {
     CF_TraverseAllTransactions_fn_t fn;      /**< \brief internal callback to use for each CList_Traverse */
     void *                          context; /**< \brief opaque object to pass to internal callback */
-    int                             counter; /**< \brief Running tally of all nodes traversed from all lists */
+    int32                           counter; /**< \brief Running tally of all nodes traversed from all lists */
 } CF_TraverseAll_Arg_t;
 
 /**
@@ -312,7 +312,7 @@ void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue);
  *
  * @returns Number of transactions traversed
  */
-CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransactions_fn_t fn, void *context);
+int32 CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransactions_fn_t fn, void *context);
 
 /************************************************************************/
 /** @brief Traverses all transactions on all channels and performs an operation on them.
@@ -325,7 +325,7 @@ CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransa
  *
  * @returns Number of transactions traversed
  */
-CFE_Status_t CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context);
+int32 CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context);
 
 /************************************************************************/
 /** @brief List traversal function performs operation on every active transaction.
@@ -337,12 +337,12 @@ CFE_Status_t CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_
  * @par Assumptions, External Events, and Notes:
  *       node must not be NULL. args must not be NULL.
  *
- * @param node    Node being currently traversed
- * @param args Intermediate context object from initial call
+ * @param node  Node being currently traversed
+ * @param arg   Intermediate context object from initial call
  *
  * @retval 0 for do not exit early (always continue)
  */
-CFE_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *node, CF_TraverseAll_Arg_t *args);
+CF_CListTraverse_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *node, void *arg);
 
 /************************************************************************/
 /** @brief Writes a human readable representation of a history queue entry to a file
@@ -362,7 +362,7 @@ CFE_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *node, CF_TraverseAl
  * @retval CF_CLIST_CONT if everything is going well
  * @retval CF_CLIST_EXIT if a write error occurred, which means traversal should stop
  */
-CFE_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *node, void *arg);
+CF_CListTraverse_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *node, void *arg);
 
 /************************************************************************/
 /** @brief Writes a human readable representation of a transaction history entry to a file
@@ -379,7 +379,7 @@ CFE_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *node, void
  * @retval CF_CLIST_CONT if everything is going well
  * @retval CF_CLIST_EXIT if a write error occurred, which means traversal should stop
  */
-CFE_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *node, void *arg);
+CF_CListTraverse_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *node, void *arg);
 
 /************************************************************************/
 /** @brief Searches for the first transaction with a lower priority than given.
@@ -394,7 +394,7 @@ CFE_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *node, void *ar
  * @retval CF_CLIST_CONT when it isn't found, which causes list traversal to continue
  *
  */
-CFE_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context);
+CF_CListTraverse_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context);
 
 /************************************************************************/
 /** @brief Wrap the filesystem open call with a perf counter.

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -1057,13 +1057,13 @@ void Test_CF_CFDP_CycleTxFirstActive(void)
     /* suspended, should return 0 */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
     txn->flags.com.suspended = 1;
-    UtAssert_INT32_EQ(CF_CFDP_CycleTxFirstActive(&txn->cl_node, &args), 0);
+    UtAssert_INT32_EQ(CF_CFDP_CycleTxFirstActive(&txn->cl_node, &args), CF_CListTraverse_Status_CONTINUE);
 
     /* nominal, with chan->cur set non-null, should skip loop and return 1 */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, &args.chan, NULL, &txn, NULL);
     txn->flags.com.q_index = CF_QueueIdx_TXA; /* must be this */
     args.chan->cur         = txn;
-    UtAssert_INT32_EQ(CF_CFDP_CycleTxFirstActive(&txn->cl_node, &args), 1);
+    UtAssert_INT32_EQ(CF_CFDP_CycleTxFirstActive(&txn->cl_node, &args), CF_CListTraverse_Status_EXIT);
     UtAssert_BOOL_TRUE(args.ran_one);
 
     /* nominal, with chan->cur set null, should do loop and return 1 */
@@ -1074,7 +1074,7 @@ void Test_CF_CFDP_CycleTxFirstActive(void)
     txn->flags.com.q_index = CF_QueueIdx_TXA; /* must be this */
     args.chan->cur         = NULL;
     UT_SetHookFunction(UT_KEY(CF_CFDP_TxStateDispatch), Ut_Hook_StateHandler_SetQIndex, NULL);
-    UtAssert_INT32_EQ(CF_CFDP_CycleTxFirstActive(&txn->cl_node, &args), 1);
+    UtAssert_INT32_EQ(CF_CFDP_CycleTxFirstActive(&txn->cl_node, &args), CF_CListTraverse_Status_EXIT);
 }
 
 static void DoTickFnClearCont(CF_Transaction_t *txn, int *cont)

--- a/unit-test/cf_clist_tests.c
+++ b/unit-test/cf_clist_tests.c
@@ -27,10 +27,10 @@
 **
 *******************************************************************************/
 
-int UT_CListFn(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t UT_CListFn(CF_CListNode_t *node, void *context)
 {
-    int  status = CF_CLIST_CONT;
-    int *param  = context;
+    CF_CListTraverse_Status_t status = CF_CLIST_CONT;
+    int *                     param  = context;
 
     /* Passing in a negative value will exit when zero is hit */
     (*param)++;
@@ -42,7 +42,7 @@ int UT_CListFn(CF_CListNode_t *node, void *context)
     return status;
 }
 
-int UT_CListFn_Rm(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t UT_CListFn_Rm(CF_CListNode_t *node, void *context)
 {
     (*((int *)context))--;
     node->next = node;

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -23,7 +23,6 @@
 #include "cf_events.h"
 #include "cf_test_alt_handler.h"
 
-
 /*******************************************************************************
 **
 **  cf_cmd_tests Setup and Teardown
@@ -97,7 +96,7 @@ typedef struct
     void *            context;
 } CF_TsnChanAction_fn_t_context_t;
 
-int Chan_action_fn_t(uint8 chan_num, void *context)
+CF_ChanAction_Status_t Chan_action_fn_t(uint8 chan_num, void *context)
 {
     /* This one does not need to save its context, just call default so count works */
     return UT_DEFAULT_IMPL(Chan_action_fn_t);
@@ -594,7 +593,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
     int                     context;
     void *                  arg_context    = &context;
     uint8                   random_fn_call = Any_uint8_LessThan(CF_NUM_CHANNELS) + 1;
-    int                     local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -611,7 +610,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
     /* Assert */
     UtAssert_STUB_COUNT(Chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (an fn returned 1)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS | 1);
 }
 
 void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
@@ -623,7 +622,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
     CF_ChanActionFn_t       arg_fn     = &Chan_action_fn_t;
     int                     context;
     void *                  arg_context = &context;
-    int                     local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -640,7 +639,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
     /* Assert */
     UtAssert_STUB_COUNT(Chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (an fn returned 1)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS | 1);
 }
 
 void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
@@ -652,7 +651,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
     CF_ChanActionFn_t       arg_fn     = &Chan_action_fn_t;
     int                     context;
     void *                  arg_context = &context;
-    int                     local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -669,7 +668,7 @@ void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
     /* Assert */
     UtAssert_STUB_COUNT(Chan_action_fn_t, CF_NUM_CHANNELS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(local_result == 0, "CF_DoChanAction returned %d and should be 0 (all fn returned 0)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
@@ -681,7 +680,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
     CF_ChanActionFn_t       arg_fn     = &Chan_action_fn_t;
     int                     context;
     void *                  arg_context = &context;
-    int                     local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -698,7 +697,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
     /* Assert */
     UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(local_result == 1, "CF_DoChanAction returned %d and should be 1 (fn returned 1)", local_result);
+    UtAssert_INT32_EQ(local_result, 1);
 }
 
 void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
@@ -710,7 +709,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
     CF_ChanActionFn_t       arg_fn     = &Chan_action_fn_t;
     int                     context;
     void *                  arg_context = &context;
-    int                     local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -727,7 +726,7 @@ void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
     /* Assert */
     UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(local_result == 0, "CF_DoChanAction returned %d and should be 0 (fn returned 0)", local_result);
+    UtAssert_INT32_EQ(local_result, 0);
 }
 
 void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendEvent_(void)
@@ -739,7 +738,7 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
     CF_ChanActionFn_t       arg_fn     = &Chan_action_fn_t;
     int                     context;
     void *                  arg_context = &context;
-    int                     local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -756,8 +755,7 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
-    UtAssert_True(local_result == -1,
-                  "CF_DoChanAction returned %d and should be -1 (cmd->data.byte[0] >= CF_NUM_CHANNELS)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
 
 void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
@@ -769,7 +767,7 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     CF_ChanActionFn_t       arg_fn     = &Chan_action_fn_t;
     int                     context;
     void *                  arg_context = &context;
-    int                     local_result;
+    CF_ChanAction_Status_t  local_result;
     int                     catastrophe_count = 0;
 
     memset(&utbuf, 0, sizeof(utbuf));
@@ -799,8 +797,7 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
-    UtAssert_True(local_result == -1,
-                  "CF_DoChanAction returned %d and should be -1 (cmd->data.byte[0] >= CF_NUM_CHANNELS)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
 
 /*******************************************************************************
@@ -812,28 +809,24 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
 void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
 {
     /* Arrange */
-    uint8                          arg_chan_num = Any_cf_channel();
-    CF_ChanAction_BoolArg_t        context;
-    const CF_ChanAction_BoolArg_t *arg_context;
-    CFE_Status_t                   local_result;
+    uint8                   arg_chan_num = Any_cf_channel();
+    CF_ChanAction_BoolArg_t context;
+    CF_ChanAction_Status_t  local_result;
 
     context.barg = Any_bool_arg_t_barg();
-
-    arg_context = &context;
 
     /* set frozen to opposite to ensure change was done - not required for test,
      * but it is helpful for verification that the function did the change */
     CF_AppData.hk.Payload.channel_hk[arg_chan_num].frozen = !context.barg;
 
     /* Act */
-    local_result = CF_DoFreezeThaw(arg_chan_num, arg_context);
+    local_result = CF_DoFreezeThaw(arg_chan_num, &context);
 
     /* Assert */
     UtAssert_True(CF_AppData.hk.Payload.channel_hk[arg_chan_num].frozen == context.barg,
                   "CF_DoFreezeThaw set frozen to %d and should be %d (context->barg))",
                   CF_AppData.hk.Payload.channel_hk[arg_chan_num].frozen, context.barg);
-    UtAssert_True(local_result == CFE_SUCCESS,
-                  "CF_DoFreezeThaw returned %d and should be 0 (CFE_SUCCESS) (only returns 0)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 /**************************************************************************
@@ -1705,7 +1698,7 @@ void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannel
     uint8                       arg_chan_num = Any_cf_channel();
     uint8                       expected_enabled;
     uint8                       current_polldir = 0;
-    CFE_Status_t                local_result;
+    CF_ChanAction_Status_t      local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&config_table, 0, sizeof(config_table));
@@ -1729,8 +1722,7 @@ void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannel
                       CF_AppData.config_table->chan[arg_chan_num].polldir[current_polldir].enabled, expected_enabled);
     }
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_DoEnableDisablePolldir returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg(void)
@@ -1744,7 +1736,7 @@ void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_conte
     CF_ChanAction_BoolMsgArg_t *arg_context = &context;
     CF_ConfigTable_t            config_table;
     uint8                       expected_enabled;
-    int                         local_result;
+    CF_ChanAction_Status_t      local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
     memset(&config_table, 0, sizeof(config_table));
@@ -1765,7 +1757,7 @@ void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_conte
                   "Channel %u Polldir %u set to %u and should be %u (context->barg)", arg_chan_num, polldir,
                   CF_AppData.config_table->chan[arg_chan_num].polldir[polldir].enabled, expected_enabled);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_True(local_result == 0, "CF_DoEnableDisablePolldir returned %d and should be 0", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent(void)
@@ -1777,7 +1769,7 @@ void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_An
     CF_ChanAction_BoolMsgArg_t  context;
     CF_ChanAction_BoolMsgArg_t *arg_context = &context;
     CF_ConfigTable_t            config_table;
-    CFE_Status_t                local_result;
+    CF_ChanAction_Status_t      local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -1794,8 +1786,7 @@ void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_An
     /* Assert */
     UT_CF_AssertEventID(CF_EID_ERR_CMD_POLLDIR_INVALID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_True(local_result == CF_ERROR, "CF_DoEnableDisablePolldir returned %d and should be -1 (CF_ERROR)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
 
 void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
@@ -1807,7 +1798,7 @@ void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
     CF_ChanAction_BoolMsgArg_t  context;
     CF_ChanAction_BoolMsgArg_t *arg_context = &context;
     CF_ConfigTable_t            config_table;
-    CFE_Status_t                local_result;
+    CF_ChanAction_Status_t      local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -1824,8 +1815,7 @@ void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
     /* Assert */
     UT_CF_AssertEventID(CF_EID_ERR_CMD_POLLDIR_INVALID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_True(local_result == CF_ERROR, "CF_DoEnableDisablePolldir returned %d and should be -1 (CF_ERROR)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
 
 /*******************************************************************************
@@ -1995,7 +1985,7 @@ void Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT(void)
     CF_CListNode_t *               arg_n = &history.cl_node;
     CF_Channel_t                   chan;
     CF_Channel_t *                 arg_c = &chan;
-    int                            local_result;
+    CF_CListTraverse_Status_t      local_result;
     CF_CFDP_ResetHistory_context_t context_CF_CFDP_ResetHistory;
 
     UT_SetDataBuffer(UT_KEY(CF_ResetHistory), &context_CF_CFDP_ResetHistory, sizeof(context_CF_CFDP_ResetHistory),
@@ -2024,7 +2014,7 @@ void Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT
     CF_CListNode_t *                   arg_n = &txn.cl_node;
     int                                ignored;
     void *                             arg_ignored = &ignored;
-    int                                local_result;
+    CF_CListTraverse_Status_t          local_result;
     CF_CFDP_ResetTransaction_context_t context_CF_CFDP_ResetTransaction;
 
     UT_SetDataBuffer(UT_KEY(CF_CFDP_ResetTransaction), &context_CF_CFDP_ResetTransaction,
@@ -2058,7 +2048,7 @@ void Test_CF_DoPurgeQueue_PendOnly(void)
     CF_Channel_t *                      chan;
     CF_CListNode_t                      start;
     CF_CListNode_t *                    expected_start = &start;
-    CFE_Status_t                        local_result;
+    CF_ChanAction_Status_t              local_result;
     CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse;
 
     memset(&utbuf, 0, sizeof(utbuf));
@@ -2081,8 +2071,7 @@ void Test_CF_DoPurgeQueue_PendOnly(void)
     UtAssert_True(context_CF_CList_Traverse.fn == CF_PurgeTransaction,
                   "context_CF_CList_Traverse.fn ==  CF_PurgeTransaction");
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, NULL);
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_DoPurgeQueue returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_DoPurgeQueue_HistoryOnly(void)
@@ -2095,7 +2084,7 @@ void Test_CF_DoPurgeQueue_HistoryOnly(void)
     CF_Channel_t *                      chan;
     CF_CListNode_t                      start;
     CF_CListNode_t *                    expected_start = &start;
-    CFE_Status_t                        local_result;
+    CF_ChanAction_Status_t              local_result;
     CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse;
 
     memset(&utbuf, 0, sizeof(utbuf));
@@ -2120,8 +2109,7 @@ void Test_CF_DoPurgeQueue_HistoryOnly(void)
     UtAssert_True(context_CF_CList_Traverse.fn == (CF_CListFn_t)CF_PurgeHistory,
                   "context_CF_CList_Traverse.fn ==  (CF_CListFn_t )CF_PurgeHistory");
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, chan);
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_DoPurgeQueue returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_DoPurgeQueue_Both(void)
@@ -2136,7 +2124,7 @@ void Test_CF_DoPurgeQueue_Both(void)
     CF_CListNode_t *                    expected_pend_start = &pend_start;
     CF_CListNode_t                      history_start;
     CF_CListNode_t *                    expected_history_start = &history_start;
-    CFE_Status_t                        local_result;
+    CF_ChanAction_Status_t              local_result;
     CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse[2];
 
     memset(&utbuf, 0, sizeof(utbuf));
@@ -2167,8 +2155,7 @@ void Test_CF_DoPurgeQueue_Both(void)
     UtAssert_True(context_CF_CList_Traverse[1].fn == (CF_CListFn_t)CF_PurgeHistory,
                   "context_CF_CList_Traverse[1].fn ==  (CF_CListFn_t )CF_PurgeHistory");
     UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[1].context, chan);
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_DoPurgeQueue returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
@@ -2178,7 +2165,7 @@ void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     CF_UnionArgs_Payload_t  utbuf;
     CF_UnionArgs_Payload_t *data   = &utbuf;
     CF_ChanAction_MsgArg_t  msgarg = {data};
-    CFE_Status_t            local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2190,7 +2177,7 @@ void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     UT_GetStubCount(UT_KEY(CF_CList_Traverse));
 
     /* Assert */
-    UtAssert_True(local_result == CF_ERROR, "CF_DoPurgeQueue returned %d and should be -1 (CF_ERROR)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_ARG);
     UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
@@ -2203,7 +2190,7 @@ void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     CF_UnionArgs_Payload_t  utbuf;
     CF_UnionArgs_Payload_t *data   = &utbuf;
     CF_ChanAction_MsgArg_t  msgarg = {data};
-    CFE_Status_t            local_result;
+    CF_ChanAction_Status_t  local_result;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
@@ -2215,7 +2202,7 @@ void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     UT_GetStubCount(UT_KEY(CF_CList_Traverse));
 
     /* Assert */
-    UtAssert_True(local_result == CF_ERROR, "CF_DoPurgeQueue returned %d and should be -1 (CF_ERROR)", local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_ARG);
     UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
@@ -3319,61 +3306,57 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
 void Test_CF_CmdValidateChunkSize_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(void)
 {
     /* Arrange */
-    uint8        arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
-    uint32       arg_val      = sizeof(CF_CFDP_PduFileDataContent_t) + 1;
-    CFE_Status_t local_result;
+    uint8                  arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
+    uint32                 arg_val      = sizeof(CF_CFDP_PduFileDataContent_t) + 1;
+    CF_ChanAction_Status_t local_result;
 
     /* Act */
     local_result = CF_CmdValidateChunkSize(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == CF_ERROR, "CF_CmdValidateChunkSize returned %d and should be -1 (CF_ERROR)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
 
 void Test_CF_CmdValidateChunkSize_Any_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(void)
 {
     /* Arrange */
-    uint8        arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
-    uint32       arg_val      = Any_uint32_GreaterThan(sizeof(CF_CFDP_PduFileDataContent_t));
-    CFE_Status_t local_result;
+    uint8                  arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
+    uint32                 arg_val      = Any_uint32_GreaterThan(sizeof(CF_CFDP_PduFileDataContent_t));
+    CF_ChanAction_Status_t local_result;
 
     /* Act */
     local_result = CF_CmdValidateChunkSize(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == CF_ERROR, "CF_CmdValidateChunkSize returned %d and should be -1 (CF_ERROR)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
 
 void Test_CF_CmdValidateChunkSize_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0(void)
 {
     /* Arrange */
-    uint8        arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
-    uint32       arg_val      = sizeof(CF_CFDP_PduFileDataContent_t);
-    CFE_Status_t local_result;
+    uint8                  arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
+    uint32                 arg_val      = sizeof(CF_CFDP_PduFileDataContent_t);
+    CF_ChanAction_Status_t local_result;
 
     /* Act */
     local_result = CF_CmdValidateChunkSize(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_CmdValidateChunkSize returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_CmdValidateChunkSize_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0(void)
 {
     /* Arrange */
-    uint8        arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
-    uint32       arg_val      = Any_uint32_LessThan_or_EqualTo(sizeof(CF_CFDP_PduFileDataContent_t));
-    CFE_Status_t local_result;
+    uint8                  arg_chan_num = Any_uint8(); /* value labeled as 'ignored' in func def */
+    uint32                 arg_val      = Any_uint32_LessThan_or_EqualTo(sizeof(CF_CFDP_PduFileDataContent_t));
+    CF_ChanAction_Status_t local_result;
 
     /* Act */
     local_result = CF_CmdValidateChunkSize(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_CmdValidateChunkSize returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 /*******************************************************************************
@@ -3387,14 +3370,13 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_IsNot_0_Return_0_Success(void)
     /* Arrange */
     uint32 arg_val      = Any_uint32_Except(0);
     uint8  arg_chan_num = Any_uint8(); /* Any_uint8() used here because it shows value does not matter in this test */
-    CFE_Status_t local_result;
+    CF_ChanAction_Status_t local_result;
 
     /* Act */
     local_result = CF_CmdValidateMaxOutgoing(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_CmdValidateMaxOutgoing returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_Return_0_Success(void)
@@ -3402,8 +3384,8 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_R
     /* Arrange */
     uint32 arg_val      = 0;
     uint8  arg_chan_num = Any_cf_chan_num(); /* Any_cf_chan_num used here because value matters to this test */
-    CF_ConfigTable_t config_table;
-    CFE_Status_t     local_result;
+    CF_ConfigTable_t       config_table;
+    CF_ChanAction_Status_t local_result;
 
     CF_AppData.config_table = &config_table;
     memset(CF_AppData.config_table->chan[arg_chan_num].sem_name, (char)Any_uint8_Except(0), 1);
@@ -3412,8 +3394,7 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_R
     local_result = CF_CmdValidateMaxOutgoing(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == CFE_SUCCESS, "CF_CmdValidateMaxOutgoing returned %d and should be 0 (CFE_SUCCESS)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail(void)
@@ -3421,8 +3402,8 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Retu
     /* Arrange */
     uint32 arg_val      = 0;
     uint8  arg_chan_num = Any_cf_chan_num(); /* Any_cf_chan_num used here because value matters to this test */
-    CF_ConfigTable_t config_table;
-    CFE_Status_t     local_result;
+    CF_ConfigTable_t       config_table;
+    CF_ChanAction_Status_t local_result;
 
     CF_AppData.config_table = &config_table;
     memset(CF_AppData.config_table->chan[arg_chan_num].sem_name, (char)0, 1);
@@ -3431,8 +3412,7 @@ void Test_CF_CmdValidateMaxOutgoing_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Retu
     local_result = CF_CmdValidateMaxOutgoing(arg_val, arg_chan_num);
 
     /* Assert */
-    UtAssert_True(local_result == CF_ERROR, "CF_CmdValidateMaxOutgoing returned %d and should be -1 (CF_ERROR)",
-                  local_result);
+    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
 
 /*******************************************************************************
@@ -3608,7 +3588,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
 {
     /* Arrange */
     CF_EnableEngineCmd_t utbuf;
-    uint32               forced_return_CF_CFDP_InitEngine = Any_uint32_Except(CFE_SUCCESS);
+    uint32               forced_return_CF_CFDP_InitEngine = Any_uint32_Except(CF_ChanAction_Status_SUCCESS);
     uint16               initial_hk_err_counter           = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -844,9 +844,9 @@ void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_T
     CF_CListNode_t *      arg_n = &txn.cl_node;
     CF_TraverseAll_Arg_t  args;
     CF_TraverseAll_Arg_t *arg_args;
-    int                   context_val;
+    int32                 context_val;
     void *                context              = &context_val;
-    int                   initial_args_counter = Any_int();
+    int32                 initial_args_counter = 57;
     CF_Transaction_t *    expected_t;
     void *                expected_context;
     int32                 result;
@@ -872,9 +872,7 @@ void Test_CF_TraverseAllTransactions_Impl_GetContainer_t_Call_args_fn_AndAdd_1_T
     /* Assert */
     UtAssert_ADDRESS_EQ(func_ptr_context.txn, expected_t);
     UtAssert_ADDRESS_EQ(func_ptr_context.context, expected_context);
-    UtAssert_True(arg_args->counter == initial_args_counter + 1,
-                  "CF_TraverseAllTransactions_Impl set args->counter to %d which is 1 more than initial value %d",
-                  arg_args->counter, initial_args_counter);
+    UtAssert_UINT32_EQ(arg_args->counter, initial_args_counter + 1);
     UtAssert_INT32_EQ(result, CF_CLIST_CONT);
 }
 

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -74,16 +74,16 @@ void CF_CFDP_CancelTransaction(CF_Transaction_t *txn)
  * Generated stub function for CF_CFDP_CloseFiles()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t CF_CFDP_CloseFiles(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_CloseFiles, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_CloseFiles, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_CloseFiles, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_CFDP_CloseFiles, void *, context);
 
     UT_GenStub_Execute(CF_CFDP_CloseFiles, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_CloseFiles, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_CloseFiles, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -156,16 +156,16 @@ void CF_CFDP_CycleTx(CF_Channel_t *chan)
  * Generated stub function for CF_CFDP_CycleTxFirstActive()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t CF_CFDP_CycleTxFirstActive(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_CycleTxFirstActive, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_CycleTxFirstActive, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_CycleTxFirstActive, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_CFDP_CycleTxFirstActive, void *, context);
 
     UT_GenStub_Execute(CF_CFDP_CycleTxFirstActive, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_CycleTxFirstActive, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_CycleTxFirstActive, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -214,16 +214,16 @@ void CF_CFDP_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_DoTick()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CFDP_DoTick, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_DoTick, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_CFDP_DoTick, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_CFDP_DoTick, void *, context);
 
     UT_GenStub_Execute(CF_CFDP_DoTick, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CFDP_DoTick, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_CFDP_DoTick, CF_CListTraverse_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -83,16 +83,16 @@ void CF_CmdCancel_Txn(CF_Transaction_t *txn, void *ignored)
  * Generated stub function for CF_CmdValidateChunkSize()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num)
+CF_ChanAction_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CmdValidateChunkSize, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_CmdValidateChunkSize, CF_ChanAction_Status_t);
 
     UT_GenStub_AddParam(CF_CmdValidateChunkSize, uint32, val);
     UT_GenStub_AddParam(CF_CmdValidateChunkSize, uint8, chan_num);
 
     UT_GenStub_Execute(CF_CmdValidateChunkSize, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CmdValidateChunkSize, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_CmdValidateChunkSize, CF_ChanAction_Status_t);
 }
 
 /*
@@ -100,16 +100,16 @@ CFE_Status_t CF_CmdValidateChunkSize(uint32 val, uint8 chan_num)
  * Generated stub function for CF_CmdValidateMaxOutgoing()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
+CF_ChanAction_Status_t CF_CmdValidateMaxOutgoing(uint32 val, uint8 chan_num)
 {
-    UT_GenStub_SetupReturnBuffer(CF_CmdValidateMaxOutgoing, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_CmdValidateMaxOutgoing, CF_ChanAction_Status_t);
 
     UT_GenStub_AddParam(CF_CmdValidateMaxOutgoing, uint32, val);
     UT_GenStub_AddParam(CF_CmdValidateMaxOutgoing, uint8, chan_num);
 
     UT_GenStub_Execute(CF_CmdValidateMaxOutgoing, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_CmdValidateMaxOutgoing, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_CmdValidateMaxOutgoing, CF_ChanAction_Status_t);
 }
 
 /*
@@ -153,10 +153,10 @@ void CF_DisablePolldirCmd(const CF_DisableDirPollingCmd_t *msg)
  * Generated stub function for CF_DoChanAction()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_DoChanAction(const CF_UnionArgs_Payload_t *data, const char *errstr, CF_ChanActionFn_t fn,
-                             void *context)
+CF_ChanAction_Status_t CF_DoChanAction(const CF_UnionArgs_Payload_t *data, const char *errstr, CF_ChanActionFn_t fn,
+                                       void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoChanAction, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_DoChanAction, CF_ChanAction_Status_t);
 
     UT_GenStub_AddParam(CF_DoChanAction, const CF_UnionArgs_Payload_t *, data);
     UT_GenStub_AddParam(CF_DoChanAction, const char *, errstr);
@@ -165,7 +165,7 @@ CFE_Status_t CF_DoChanAction(const CF_UnionArgs_Payload_t *data, const char *err
 
     UT_GenStub_Execute(CF_DoChanAction, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoChanAction, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_DoChanAction, CF_ChanAction_Status_t);
 }
 
 /*
@@ -173,16 +173,16 @@ CFE_Status_t CF_DoChanAction(const CF_UnionArgs_Payload_t *data, const char *err
  * Generated stub function for CF_DoEnableDisableDequeue()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
+CF_ChanAction_Status_t CF_DoEnableDisableDequeue(uint8 chan_num, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisableDequeue, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisableDequeue, CF_ChanAction_Status_t);
 
     UT_GenStub_AddParam(CF_DoEnableDisableDequeue, uint8, chan_num);
-    UT_GenStub_AddParam(CF_DoEnableDisableDequeue, const CF_ChanAction_BoolArg_t *, context);
+    UT_GenStub_AddParam(CF_DoEnableDisableDequeue, void *, arg);
 
     UT_GenStub_Execute(CF_DoEnableDisableDequeue, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoEnableDisableDequeue, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_DoEnableDisableDequeue, CF_ChanAction_Status_t);
 }
 
 /*
@@ -190,16 +190,16 @@ CFE_Status_t CF_DoEnableDisableDequeue(uint8 chan_num, const CF_ChanAction_BoolA
  * Generated stub function for CF_DoEnableDisablePolldir()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolMsgArg_t *context)
+CF_ChanAction_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisablePolldir, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisablePolldir, CF_ChanAction_Status_t);
 
     UT_GenStub_AddParam(CF_DoEnableDisablePolldir, uint8, chan_num);
-    UT_GenStub_AddParam(CF_DoEnableDisablePolldir, const CF_ChanAction_BoolMsgArg_t *, context);
+    UT_GenStub_AddParam(CF_DoEnableDisablePolldir, void *, arg);
 
     UT_GenStub_Execute(CF_DoEnableDisablePolldir, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoEnableDisablePolldir, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_DoEnableDisablePolldir, CF_ChanAction_Status_t);
 }
 
 /*
@@ -207,16 +207,16 @@ CFE_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, const CF_ChanAction_BoolM
  * Generated stub function for CF_DoFreezeThaw()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *context)
+CF_ChanAction_Status_t CF_DoFreezeThaw(uint8 chan_num, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoFreezeThaw, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_DoFreezeThaw, CF_ChanAction_Status_t);
 
     UT_GenStub_AddParam(CF_DoFreezeThaw, uint8, chan_num);
-    UT_GenStub_AddParam(CF_DoFreezeThaw, const CF_ChanAction_BoolArg_t *, context);
+    UT_GenStub_AddParam(CF_DoFreezeThaw, void *, arg);
 
     UT_GenStub_Execute(CF_DoFreezeThaw, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoFreezeThaw, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_DoFreezeThaw, CF_ChanAction_Status_t);
 }
 
 /*
@@ -224,16 +224,16 @@ CFE_Status_t CF_DoFreezeThaw(uint8 chan_num, const CF_ChanAction_BoolArg_t *cont
  * Generated stub function for CF_DoPurgeQueue()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_DoPurgeQueue(uint8 chan_num, void *arg)
+CF_ChanAction_Status_t CF_DoPurgeQueue(uint8 chan_num, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_DoPurgeQueue, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_DoPurgeQueue, CF_ChanAction_Status_t);
 
     UT_GenStub_AddParam(CF_DoPurgeQueue, uint8, chan_num);
     UT_GenStub_AddParam(CF_DoPurgeQueue, void *, arg);
 
     UT_GenStub_Execute(CF_DoPurgeQueue, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_DoPurgeQueue, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_DoPurgeQueue, CF_ChanAction_Status_t);
 }
 
 /*
@@ -395,16 +395,16 @@ void CF_ProcessGroundCommand(CFE_SB_Buffer_t *msg)
  * Generated stub function for CF_PurgeHistory()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_PurgeHistory(CF_CListNode_t *node, CF_Channel_t *chan)
+CF_CListTraverse_Status_t CF_PurgeHistory(CF_CListNode_t *node, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_PurgeHistory, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_PurgeHistory, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_PurgeHistory, CF_CListNode_t *, node);
-    UT_GenStub_AddParam(CF_PurgeHistory, CF_Channel_t *, chan);
+    UT_GenStub_AddParam(CF_PurgeHistory, void *, arg);
 
     UT_GenStub_Execute(CF_PurgeHistory, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_PurgeHistory, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_PurgeHistory, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -424,16 +424,16 @@ void CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg)
  * Generated stub function for CF_PurgeTransaction()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignored)
+CF_CListTraverse_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignored)
 {
-    UT_GenStub_SetupReturnBuffer(CF_PurgeTransaction, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_PurgeTransaction, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_PurgeTransaction, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_PurgeTransaction, void *, ignored);
 
     UT_GenStub_Execute(CF_PurgeTransaction, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_PurgeTransaction, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_PurgeTransaction, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -501,19 +501,19 @@ void CF_ThawCmd(const CF_ThawCmd_t *msg)
  * Generated stub function for CF_TsnChanAction()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_TsnChanAction(const CF_Transaction_Payload_t *payload, const char *cmdstr, CF_TsnChanAction_fn_t fn,
-                              void *context)
+int32 CF_TsnChanAction(const CF_Transaction_Payload_t *data, const char *cmdstr, CF_TsnChanAction_fn_t fn,
+                       void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TsnChanAction, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_TsnChanAction, int32);
 
-    UT_GenStub_AddParam(CF_TsnChanAction, const CF_Transaction_Payload_t *, payload);
+    UT_GenStub_AddParam(CF_TsnChanAction, const CF_Transaction_Payload_t *, data);
     UT_GenStub_AddParam(CF_TsnChanAction, const char *, cmdstr);
     UT_GenStub_AddParam(CF_TsnChanAction, CF_TsnChanAction_fn_t, fn);
     UT_GenStub_AddParam(CF_TsnChanAction, void *, context);
 
     UT_GenStub_Execute(CF_TsnChanAction, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_TsnChanAction, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_TsnChanAction, int32);
 }
 
 /*

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -119,16 +119,16 @@ void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue)
  * Generated stub function for CF_PrioSearch()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context)
+CF_CListTraverse_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_PrioSearch, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_PrioSearch, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_PrioSearch, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_PrioSearch, void *, context);
 
     UT_GenStub_Execute(CF_PrioSearch, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_PrioSearch, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_PrioSearch, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -149,9 +149,9 @@ void CF_ResetHistory(CF_Channel_t *chan, CF_History_t *history)
  * Generated stub function for CF_TraverseAllTransactions()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransactions_fn_t fn, void *context)
+int32 CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransactions_fn_t fn, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions, int32);
 
     UT_GenStub_AddParam(CF_TraverseAllTransactions, CF_Channel_t *, chan);
     UT_GenStub_AddParam(CF_TraverseAllTransactions, CF_TraverseAllTransactions_fn_t, fn);
@@ -159,7 +159,7 @@ CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransa
 
     UT_GenStub_Execute(CF_TraverseAllTransactions, Basic, UT_DefaultHandler_CF_TraverseAllTransactions);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions, int32);
 }
 
 /*
@@ -167,9 +167,9 @@ CFE_Status_t CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransa
  * Generated stub function for CF_TraverseAllTransactions_All_Channels()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
+int32 CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_All_Channels, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_All_Channels, int32);
 
     UT_GenStub_AddParam(CF_TraverseAllTransactions_All_Channels, CF_TraverseAllTransactions_fn_t, fn);
     UT_GenStub_AddParam(CF_TraverseAllTransactions_All_Channels, void *, context);
@@ -177,7 +177,7 @@ CFE_Status_t CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_
     UT_GenStub_Execute(CF_TraverseAllTransactions_All_Channels, Basic,
                        UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_All_Channels, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_All_Channels, int32);
 }
 
 /*
@@ -185,16 +185,16 @@ CFE_Status_t CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_
  * Generated stub function for CF_TraverseAllTransactions_Impl()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *node, CF_TraverseAll_Arg_t *args)
+CF_CListTraverse_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *node, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_Impl, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_Impl, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_TraverseAllTransactions_Impl, CF_CListNode_t *, node);
-    UT_GenStub_AddParam(CF_TraverseAllTransactions_Impl, CF_TraverseAll_Arg_t *, args);
+    UT_GenStub_AddParam(CF_TraverseAllTransactions_Impl, void *, arg);
 
     UT_GenStub_Execute(CF_TraverseAllTransactions_Impl, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_Impl, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_Impl, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -202,16 +202,16 @@ CFE_Status_t CF_TraverseAllTransactions_Impl(CF_CListNode_t *node, CF_TraverseAl
  * Generated stub function for CF_Traverse_WriteHistoryQueueEntryToFile()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *node, void *arg)
+CF_CListTraverse_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *node, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteHistoryQueueEntryToFile, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteHistoryQueueEntryToFile, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_Traverse_WriteHistoryQueueEntryToFile, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_Traverse_WriteHistoryQueueEntryToFile, void *, arg);
 
     UT_GenStub_Execute(CF_Traverse_WriteHistoryQueueEntryToFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_Traverse_WriteHistoryQueueEntryToFile, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_Traverse_WriteHistoryQueueEntryToFile, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -219,16 +219,16 @@ CFE_Status_t CF_Traverse_WriteHistoryQueueEntryToFile(CF_CListNode_t *node, void
  * Generated stub function for CF_Traverse_WriteTxnQueueEntryToFile()
  * ----------------------------------------------------
  */
-CFE_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *node, void *arg)
+CF_CListTraverse_Status_t CF_Traverse_WriteTxnQueueEntryToFile(CF_CListNode_t *node, void *arg)
 {
-    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteTxnQueueEntryToFile, CFE_Status_t);
+    UT_GenStub_SetupReturnBuffer(CF_Traverse_WriteTxnQueueEntryToFile, CF_CListTraverse_Status_t);
 
     UT_GenStub_AddParam(CF_Traverse_WriteTxnQueueEntryToFile, CF_CListNode_t *, node);
     UT_GenStub_AddParam(CF_Traverse_WriteTxnQueueEntryToFile, void *, arg);
 
     UT_GenStub_Execute(CF_Traverse_WriteTxnQueueEntryToFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CF_Traverse_WriteTxnQueueEntryToFile, CFE_Status_t);
+    return UT_GenStub_GetReturnValue(CF_Traverse_WriteTxnQueueEntryToFile, CF_CListTraverse_Status_t);
 }
 
 /*


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Correction for various type mismatches across CF.
Notably, many iterators do not use the CFE_Status_t return type, it should be a custom enum.

Fixes #430

**Testing performed**
Build and run all tests
Run BP/DTN sanity check (uses CF to transfer file)

**Expected behavior changes**
Builds and runs on strict type-checking platforms

**System(s) tested on**
Debian with RTEMS 4.11 toolchain

**Additional context**
This may have been recently complicated as some return codes were changed to `CFE_Status_t` that should have remained as an integer (e.g. cases where it was a count or not one of the CFE error codes)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
