### PR TITLE
Fix #441, cf delete files during error when tx

### DIFF
--- a/config/default_cf_fcncodes.h
+++ b/config/default_cf_fcncodes.h
@@ -90,7 +90,7 @@ typedef enum
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid counter type, #CF_CMD_RESET_INVALID_ERR_EID
+     *       - Invalid counter type, #CF_EID_ERR_CMD_RESET_INVALID
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -113,13 +113,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_TX_FILE_INF_EID
+     *       - #CF_EID_INF_CMD_TX_FILE
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid parameter, #CF_CMD_BAD_PARAM_ERR_EID
-     *       - Transaction initialization failure, #CF_CMD_TX_FILE_ERR_EID
+     *       - Invalid parameter, #CF_EID_ERR_CMD_BAD_PARAM
+     *       - Transaction initialization failure, #CF_EID_ERR_CMD_TX_FILE
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -145,13 +145,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_PLAYBACK_DIR_INF_EID
+     *       - #CF_EID_INF_CMD_PLAYBACK_DIR
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid parameter, #CF_CMD_BAD_PARAM_ERR_EID
-     *       - Playback initialization failure, #CF_CMD_PLAYBACK_DIR_ERR_EID
+     *       - Invalid parameter, #CF_EID_ERR_CMD_BAD_PARAM
+     *       - Playback initialization failure, #CF_EID_ERR_CMD_PLAYBACK_DIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -180,13 +180,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_FREEZE_INF_EID
+     *       - #CF_EID_INF_CMD_FREEZE
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-     *       - Command processing failure, #CF_CMD_FREEZE_ERR_EID
+     *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+     *       - Command processing failure, #CF_EID_ERR_CMD_FREEZE
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -214,13 +214,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_THAW_INF_EID
+     *       - #CF_EID_INF_CMD_THAW
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-     *       - Command processing failure, #CF_CMD_THAW_ERR_EID
+     *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+     *       - Command processing failure, #CF_EID_ERR_CMD_THAW
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -248,15 +248,15 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_SUSPRES_INF_EID
+     *       - #CF_EID_INF_CMD_SUSPRES
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-     *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-     *       - Already in requested state, #CF_CMD_SUSPRES_SAME_ERR_EID
-     *       - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
+     *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+     *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+     *       - Already in requested state, #CF_EID_ERR_CMD_SUSPRES_SAME
+     *       - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -284,15 +284,15 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_SUSPRES_INF_EID
+     *       - #CF_EID_INF_CMD_SUSPRES
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-     *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-     *       - Already in requested state, #CF_CMD_SUSPRES_SAME_ERR_EID
-     *       - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
+     *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+     *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+     *       - Already in requested state, #CF_EID_ERR_CMD_SUSPRES_SAME
+     *       - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -319,14 +319,14 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_CANCEL_INF_EID
+     *       - #CF_EID_INF_CMD_CANCEL
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-     *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-     *       - No matching transaction, #CF_CMD_CANCEL_CHAN_ERR_EID
+     *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+     *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+     *       - No matching transaction, #CF_EID_ERR_CMD_CANCEL_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -353,14 +353,14 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_ABANDON_INF_EID
+     *       - #CF_EID_INF_CMD_ABANDON
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-     *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-     *       - No matching transaction, #CF_CMD_ABANDON_CHAN_ERR_EID
+     *       - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+     *       - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+     *       - No matching transaction, #CF_EID_ERR_CMD_ABANDON_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -385,14 +385,14 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_GETSET1_INF_EID
+     *       - #CF_EID_INF_CMD_GETSET1
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
-     *       - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
-     *       - Parameter value failed validation, #CF_CMD_GETSET_VALIDATE_ERR_EID
+     *       - Invalid configuration parameter key, #CF_EID_ERR_CMD_GETSET_PARAM
+     *       - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
+     *       - Parameter value failed validation, #CF_EID_ERR_CMD_GETSET_VALIDATE
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -417,13 +417,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_GETSET2_INF_EID
+     *       - #CF_EID_INF_CMD_GETSET2
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
-     *       - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
+     *       - Invalid configuration parameter key, #CF_EID_ERR_CMD_GETSET_PARAM
+     *       - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -448,18 +448,18 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_WQ_INF_EID
+     *       - #CF_EID_INF_CMD_WQ
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid parameter combination, #CF_CMD_WQ_ARGS_ERR_EID
-     *       - Invalid channel number, #CF_CMD_WQ_CHAN_ERR_EID
-     *       - Open file to write failed, #CF_CMD_WQ_OPEN_ERR_EID
-     *       - Write RX data failed, #CF_CMD_WQ_WRITEQ_RX_ERR_EID
-     *       - Write RX history data failed, #CF_CMD_WQ_WRITEHIST_RX_ERR_EID
-     *       - Write TX data failed, #CF_CMD_WQ_WRITEQ_TX_ERR_EID
-     *       - Write TX history data failed, #CF_CMD_WQ_WRITEHIST_TX_ERR_EID
+     *       - Invalid parameter combination, #CF_EID_ERR_CMD_WQ_ARGS
+     *       - Invalid channel number, #CF_EID_ERR_CMD_WQ_CHAN
+     *       - Open file to write failed, #CF_EID_ERR_CMD_WQ_OPEN
+     *       - Write RX data failed, #CF_EID_ERR_CMD_WQ_WRITEQ_RX
+     *       - Write RX history data failed, #CF_EID_ERR_CMD_WQ_WRITEHIST_RX
+     *       - Write TX data failed, #CF_EID_ERR_CMD_WQ_WRITEQ_TX
+     *       - Write TX history data failed, #CF_EID_ERR_CMD_WQ_WRITEHIST_TX
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -486,13 +486,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_ENABLE_DEQUEUE_INF_EID
+     *       - #CF_EID_INF_CMD_ENABLE_DEQUEUE
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-     *       - Enable dequeue failed, #CF_CMD_ENABLE_DEQUEUE_ERR_EID
+     *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+     *       - Enable dequeue failed, #CF_EID_ERR_CMD_ENABLE_DEQUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -519,13 +519,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_DISABLE_DEQUEUE_INF_EID
+     *       - #CF_EID_INF_CMD_DISABLE_DEQUEUE
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-     *       - Disable dequeue failed, #CF_CMD_DISABLE_DEQUEUE_INF_EID
+     *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+     *       - Disable dequeue failed, #CF_EID_INF_CMD_DISABLE_DEQUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -558,14 +558,14 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_ENABLE_POLLDIR_INF_EID
+     *       - #CF_EID_INF_CMD_ENABLE_POLLDIR
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-     *       - Invalid polling directory index, #CF_CMD_POLLDIR_INVALID_ERR_EID
-     *       - Enable directory polling failed, #CF_CMD_ENABLE_POLLDIR_ERR_EID
+     *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+     *       - Invalid polling directory index, #CF_EID_ERR_CMD_POLLDIR_INVALID
+     *       - Enable directory polling failed, #CF_EID_ERR_CMD_ENABLE_POLLDIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -598,14 +598,14 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_DISABLE_POLLDIR_INF_EID
+     *       - #CF_EID_INF_CMD_DISABLE_POLLDIR
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-     *       - Invalid polling directory index, #CF_CMD_POLLDIR_INVALID_ERR_EID
-     *       - Disable directory polling failed, #CF_CMD_DISABLE_POLLDIR_ERR_EID
+     *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+     *       - Invalid polling directory index, #CF_EID_ERR_CMD_POLLDIR_INVALID
+     *       - Disable directory polling failed, #CF_EID_ERR_CMD_DISABLE_POLLDIR
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -639,14 +639,14 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_PURGE_QUEUE_INF_EID
+     *       - #CF_EID_INF_CMD_PURGE_QUEUE
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-     *       - Invalid purge queue argument, #CF_CMD_PURGE_ARG_ERR_EID
-     *       - Purge queue failed, #CF_CMD_PURGE_QUEUE_ERR_EID
+     *       - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+     *       - Invalid purge queue argument, #CF_EID_ERR_CMD_PURGE_ARG
+     *       - Purge queue failed, #CF_EID_ERR_CMD_PURGE_QUEUE
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -672,13 +672,13 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_ENABLE_ENGINE_INF_EID
+     *       - #CF_EID_INF_CMD_ENABLE_ENGINE
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Engine initialization failed, #CF_CMD_ENABLE_ENGINE_ERR_EID
-     *       - Engine already enabled, #CF_CMD_ENG_ALREADY_ENA_ERR_EID
+     *       - Engine initialization failed, #CF_EID_ERR_CMD_ENABLE_ENGINE
+     *       - Engine already enabled, #CF_EID_ERR_CMD_ENG_ALREADY_ENA
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -705,12 +705,12 @@ typedef enum
      *       Successful execution of this command may be verified with
      *       the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.cmd will increment
-     *       - #CF_CMD_DISABLE_ENGINE_INF_EID
+     *       - #CF_EID_INF_CMD_DISABLE_ENGINE
      *
      *  \par Error Conditions
      *       This command may fail for the following reason(s):
      *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-     *       - Engine already disabled, #CF_CMD_ENG_ALREADY_DIS_ERR_EID
+     *       - Engine already disabled, #CF_EID_ERR_CMD_ENG_ALREADY_DIS
      *
      *  \par Evidence of failure may be found in the following telemetry:
      *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment

--- a/config/default_cf_tblstruct.h
+++ b/config/default_cf_tblstruct.h
@@ -51,6 +51,7 @@ typedef struct CF_ConfigTable
     uint16 outgoing_file_chunk_size;    /**< \brief maximum size of outgoing file data chunk in a PDU.
                                          *   Limited by CF_MAX_PDU_SIZE minus the PDU header(s) */
     char tmp_dir[CF_FILENAME_MAX_PATH]; /**< \brief directory to put temp files */
+    char fail_dir[CF_FILENAME_MAX_PATH]; /**< \brief fail directory */
 } CF_ConfigTable_t;
 
 #endif

--- a/eds/cf.xml
+++ b/eds/cf.xml
@@ -422,11 +422,11 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_NOOP_INF_EID
+            - #CF_EID_INF_CMD_NOOP
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -458,12 +458,12 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_RESET_INF_EID
+            - #CF_EID_INF_CMD_RESET
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid counter type, #CF_CMD_RESET_INVALID_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid counter type, #CF_EID_ERR_CMD_RESET_INVALID
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -493,13 +493,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_TX_FILE_INF_EID
+            - #CF_EID_INF_CMD_TX_FILE
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid parameter, #CF_CMD_BAD_PARAM_ERR_EID
-            - Transaction initialization failure, #CF_CMD_TX_FILE_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid parameter, #CF_EID_ERR_CMD_BAD_PARAM
+            - Transaction initialization failure, #CF_EID_ERR_CMD_TX_FILE
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -532,13 +532,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_PLAYBACK_DIR_INF_EID
+            - #CF_EID_INF_CMD_PLAYBACK_DIR
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid parameter, #CF_CMD_BAD_PARAM_ERR_EID
-            - Playback initialization failure, #CF_CMD_PLAYBACK_DIR_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid parameter, #CF_EID_ERR_CMD_BAD_PARAM
+            - Playback initialization failure, #CF_EID_ERR_CMD_PLAYBACK_DIR
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -574,13 +574,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_FREEZE_INF_EID
+            - #CF_EID_INF_CMD_FREEZE
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-            - Command processing failure, #CF_CMD_FREEZE_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+            - Command processing failure, #CF_EID_ERR_CMD_FREEZE
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -615,13 +615,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_THAW_INF_EID
+            - #CF_EID_INF_CMD_THAW
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-            - Command processing failure, #CF_CMD_THAW_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+            - Command processing failure, #CF_EID_ERR_CMD_THAW
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -656,15 +656,15 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_SUSPRES_INF_EID
+            - #CF_EID_INF_CMD_SUSPRES
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-            - Already in requested state, #CF_CMD_SUSPRES_SAME_ERR_EID
-            - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+            - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+            - Already in requested state, #CF_EID_ERR_CMD_SUSPRES_SAME
+            - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -699,15 +699,15 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_SUSPRES_INF_EID
+            - #CF_EID_INF_CMD_SUSPRES
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-            - Already in requested state, #CF_CMD_SUSPRES_SAME_ERR_EID
-            - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+            - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+            - Already in requested state, #CF_EID_ERR_CMD_SUSPRES_SAME
+            - No matching transaction, #CF_EID_ERR_CMD_SUSPRES_CHAN
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -741,14 +741,14 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_CANCEL_INF_EID
+            - #CF_EID_INF_CMD_CANCEL
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-            - No matching transaction, #CF_CMD_CANCEL_CHAN_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+            - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+            - No matching transaction, #CF_EID_ERR_CMD_CANCEL_CHAN
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -782,14 +782,14 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_ABANDON_INF_EID
+            - #CF_EID_INF_CMD_ABANDON
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
-            - No matching transaction, #CF_CMD_ABANDON_CHAN_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Transaction not found using compound key, #CF_EID_ERR_CMD_TRANS_NOT_FOUND
+            - Invalid channel number, #CF_EID_ERR_CMD_TSN_CHAN_INVALID
+            - No matching transaction, #CF_EID_ERR_CMD_ABANDON_CHAN
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -821,14 +821,14 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_GETSET1_INF_EID
+            - #CF_EID_INF_CMD_GETSET1
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
-            - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
-            - Parameter value failed validation, #CF_CMD_GETSET_VALIDATE_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid configuration parameter key, #CF_EID_ERR_CMD_GETSET_PARAM
+            - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
+            - Parameter value failed validation, #CF_EID_ERR_CMD_GETSET_VALIDATE
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -860,13 +860,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_GETSET2_INF_EID
+            - #CF_EID_INF_CMD_GETSET2
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
-            - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid configuration parameter key, #CF_EID_ERR_CMD_GETSET_PARAM
+            - Invalid channel number, #CF_EID_ERR_CMD_GETSET_CHAN
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -898,18 +898,18 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_WQ_INF_EID
+            - #CF_EID_INF_CMD_WQ
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid parameter combination, #CF_CMD_WQ_ARGS_ERR_EID
-            - Invalid channel number, #CF_CMD_WQ_CHAN_ERR_EID
-            - Open file to write failed, #CF_CMD_WQ_OPEN_ERR_EID
-            - Write RX data failed, #CF_CMD_WQ_WRITEQ_RX_ERR_EID
-            - Write RX history data failed, #CF_CMD_WQ_WRITEHIST_RX_ERR_EID
-            - Write TX data failed, #CF_CMD_WQ_WRITEQ_TX_ERR_EID
-            - Write TX history data failed, #CF_CMD_WQ_WRITEHIST_TX_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid parameter combination, #CF_EID_ERR_CMD_WQ_ARGS
+            - Invalid channel number, #CF_EID_ERR_CMD_WQ_CHAN
+            - Open file to write failed, #CF_EID_ERR_CMD_WQ_OPEN
+            - Write RX data failed, #CF_EID_ERR_CMD_WQ_WRITEQ_RX
+            - Write RX history data failed, #CF_EID_ERR_CMD_WQ_WRITEHIST_RX
+            - Write TX data failed, #CF_EID_ERR_CMD_WQ_WRITEQ_TX
+            - Write TX history data failed, #CF_EID_ERR_CMD_WQ_WRITEHIST_TX
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -943,13 +943,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_ENABLE_DEQUEUE_INF_EID
+            - #CF_EID_INF_CMD_ENABLE_DEQUEUE
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-            - Enable dequeue failed, #CF_CMD_ENABLE_DEQUEUE
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+            - Enable dequeue failed, #CF_EID_ERR_CMD_ENABLE_DEQUEUE
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -983,13 +983,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_DISABLE_DEQUEUE_INF_EID
+            - #CF_EID_INF_CMD_DISABLE_DEQUEUE
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-            - Disable dequeue failed, #CF_CMD_DISABLE_DEQUEUE_INF_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+            - Disable dequeue failed, #CF_EID_INF_CMD_DISABLE_DEQUEUE
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -1029,14 +1029,14 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_ENABLE_POLLDIR_INF_EID
+            - #CF_EID_INF_CMD_ENABLE_POLLDIR
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-            - Invalid polling directory index, #CF_CMD_POLLDIR_INVALID_ERR_EID
-            - Enable directory polling failed, #CF_CMD_ENABLE_POLLDIR_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+            - Invalid polling directory index, #CF_EID_ERR_CMD_POLLDIR_INVALID
+            - Enable directory polling failed, #CF_EID_ERR_CMD_ENABLE_POLLDIR
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -1076,14 +1076,14 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_DISABLE_POLLDIR_INF_EID
+            - #CF_EID_INF_CMD_DISABLE_POLLDIR
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-            - Invalid polling directory index, #CF_CMD_POLLDIR_INVALID_ERR_EID
-            - Disable directory polling failed, #CF_CMD_DISABLE_POLLDIR_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+            - Invalid polling directory index, #CF_EID_ERR_CMD_POLLDIR_INVALID
+            - Disable directory polling failed, #CF_EID_ERR_CMD_DISABLE_POLLDIR
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -1124,14 +1124,14 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_PURGE_QUEUE_INF_EID
+            - #CF_EID_INF_CMD_PURGE_QUEUE
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
-            - Invalid purge queue argument, #CF_CMD_PURGE_ARG_ERR_EID
-            - Purge queue failed, #CF_CMD_PURGE_QUEUE_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Invalid channel number, #CF_EID_ERR_CMD_CHAN_PARAM
+            - Invalid purge queue argument, #CF_EID_ERR_CMD_PURGE_ARG
+            - Purge queue failed, #CF_EID_ERR_CMD_PURGE_QUEUE
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -1164,13 +1164,13 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_ENABLE_ENGINE_INF_EID
+            - #CF_EID_INF_CMD_ENABLE_ENGINE
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Engine initialization failed, #CF_CMD_ENABLE_ENGINE_ERR_EID
-            - Engine already enabled, #CF_CMD_ENG_ALREADY_ENA_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Engine initialization failed, #CF_EID_ERR_CMD_ENABLE_ENGINE
+            - Engine already enabled, #CF_EID_ERR_CMD_ENG_ALREADY_ENA
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -1201,12 +1201,12 @@
             Successful execution of this command may be verified with
             the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.cmd will increment
-            - #CF_CMD_DISABLE_ENGINE_INF_EID
+            - #CF_EID_INF_CMD_DISABLE_ENGINE
 
        \par Error Conditions
             This command may fail for the following reason(s):
-            - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
-            - Engine already disabled, #CF_CMD_ENG_ALREADY_DIS_ERR_EID
+            - Command packet length not as expected, #CF_EID_ERR_CMD_GCMD_LEN
+            - Engine already disabled, #CF_EID_ERR_CMD_ENG_ALREADY_DIS
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment

--- a/fsw/inc/cf_events.h
+++ b/fsw/inc/cf_events.h
@@ -55,7 +55,7 @@
  *
  *  Failure from release table address call during periodic table check
  */
-#define CF_INIT_TBL_CHECK_REL_ERR_EID (21)
+#define CF_EID_ERR_INIT_TBL_CHECK_REL (21)
 
 /**
  * \brief CF Check Table Manage Failed Event ID
@@ -66,7 +66,7 @@
  *
  *  Failure from manage table call during periodic table check
  */
-#define CF_INIT_TBL_CHECK_MAN_ERR_EID (22)
+#define CF_EID_ERR_INIT_TBL_CHECK_MAN (22)
 
 /**
  * \brief CF Check Table Get Address Failed Event ID
@@ -77,7 +77,7 @@
  *
  *  Failure from get table call during periodic table check
  */
-#define CF_INIT_TBL_CHECK_GA_ERR_EID (23)
+#define CF_EID_ERR_INIT_TBL_CHECK_GA (23)
 
 /**
  * \brief CF Table Registration At Initialization Failed Event ID
@@ -88,7 +88,7 @@
  *
  *  Failure from table register call during application initialization
  */
-#define CF_INIT_TBL_REG_ERR_EID (24)
+#define CF_EID_ERR_INIT_TBL_REG (24)
 
 /**
  * \brief CF Table Load At Initialization Failed Event ID
@@ -99,7 +99,7 @@
  *
  *  Failure from table load call during application initialization
  */
-#define CF_INIT_TBL_LOAD_ERR_EID (25)
+#define CF_EID_ERR_INIT_TBL_LOAD (25)
 
 /**
  * \brief CF Table Manage At Initialization Failed Event ID
@@ -110,7 +110,7 @@
  *
  *  Failure from table manage call during application initialization
  */
-#define CF_INIT_TBL_MANAGE_ERR_EID (26)
+#define CF_EID_ERR_INIT_TBL_MANAGE (26)
 
 /**
  * \brief CF Table Get Address At Initialization Failed Event ID
@@ -121,7 +121,7 @@
  *
  *  Failure from table get address call during application initialization
  */
-#define CF_INIT_TBL_GETADDR_ERR_EID (27)
+#define CF_EID_ERR_INIT_TBL_GETADDR (27)
 
 /**
  * \brief CF Message ID Invalid Event ID
@@ -143,7 +143,7 @@
  *
  *  Failure from SB Receive Buffer call in application run loop
  */
-#define CF_INIT_MSG_RECV_ERR_EID (29)
+#define CF_EID_ERR_INIT_MSG_RECV (29)
 
 /**
  * \brief CF Channel Semaphore Initialization Failed Event ID
@@ -155,7 +155,7 @@
  *  Failure from get semaphore by name call during engine channel initialization,
  *  semaphore needs to exist before engine is initialized.
  */
-#define CF_INIT_SEM_ERR_EID (30)
+#define CF_EID_ERR_INIT_SEM (30)
 
 /**
  * \brief CF Channel Create Pipe Failed Event ID
@@ -177,7 +177,7 @@
  *
  *  Failure from message subscription call during engine channel initialization
  */
-#define CF_INIT_SUB_ERR_EID (32)
+#define CF_EID_ERR_INIT_SUB (32)
 
 /**
  * \brief CF Ticks Per Second Config Table Validation Failed Event ID
@@ -188,7 +188,7 @@
  *
  *  Configuration table ticks per second set to zero
  */
-#define CF_INIT_TPS_ERR_EID (33)
+#define CF_EID_ERR_INIT_TPS (33)
 
 /**
  * \brief CF CRC Bytes Per Wakeup Config Table Validation Failed Event ID
@@ -199,7 +199,7 @@
  *
  *  Configuration table CRC bytes per wakeup not aligned or zero
  */
-#define CF_INIT_CRC_ALIGN_ERR_EID (34)
+#define CF_EID_ERR_INIT_CRC_ALIGN (34)
 
 /**
  * \brief CF Outgoing Chunk Size Config Table Validation Failed Event ID
@@ -210,7 +210,7 @@
  *
  *  Configuration table outgoing chunk size larger than PDU data size
  */
-#define CF_INIT_OUTGOING_SIZE_ERR_EID (35)
+#define CF_EID_ERR_INIT_OUTGOING_SIZE (35)
 
 /**************************************************************************
  * CF_PDU event IDs - Protocol data unit
@@ -225,7 +225,7 @@
  *
  *  Successful processing of metadata PDU
  */
-#define CF_PDU_MD_RECVD_INF_EID (40)
+#define CF_EID_INF_PDU_MD_RECVD (40)
 
 /**
  * \brief CF PDU Header Too Short Event ID
@@ -236,7 +236,7 @@
  *
  *  Failure processing PDU header
  */
-#define CF_PDU_SHORT_HEADER_ERR_EID (41)
+#define CF_EID_ERR_PDU_SHORT_HEADER (41)
 
 /**
  * \brief CF Metadata PDU Too Short Event ID
@@ -247,7 +247,7 @@
  *
  *  Failure processing metadata PDU
  */
-#define CF_PDU_MD_SHORT_ERR_EID (43)
+#define CF_EID_ERR_PDU_MD_SHORT (43)
 
 /**
  * \brief CF Metadata PDU Source Filename Length Invalid Event ID
@@ -258,7 +258,7 @@
  *
  *  Metadata PDU source filename length exceeds buffer size
  */
-#define CF_PDU_INVALID_SRC_LEN_ERR_EID (44)
+#define CF_EID_ERR_PDU_INVALID_SRC_LEN (44)
 
 /**
  * \brief CF Metadata PDU Destination Filename Length Invalid Event ID
@@ -269,7 +269,7 @@
  *
  *  Metadata PDU destination filename length exceeds buffer size
  */
-#define CF_PDU_INVALID_DST_LEN_ERR_EID (45)
+#define CF_EID_ERR_PDU_INVALID_DST_LEN (45)
 
 /**
  * \brief CF File Data PDU Too Short Event ID
@@ -280,7 +280,7 @@
  *
  *  Failure processing file data PDU
  */
-#define CF_PDU_FD_SHORT_ERR_EID (46)
+#define CF_EID_ERR_PDU_FD_SHORT (46)
 
 /**
  * \brief CF End-Of-File PDU Too Short Event ID
@@ -291,7 +291,7 @@
  *
  *  Failure processing end-of-file PDU
  */
-#define CF_PDU_EOF_SHORT_ERR_EID (47)
+#define CF_EID_ERR_PDU_EOF_SHORT (47)
 
 /**
  * \brief CF Acknowledgment PDU Too Short Event ID
@@ -302,7 +302,7 @@
  *
  *  Failure processing acknowledgment PDU
  */
-#define CF_PDU_ACK_SHORT_ERR_EID (48)
+#define CF_EID_ERR_PDU_ACK_SHORT (48)
 
 /**
  * \brief CF Finished PDU Too Short Event ID
@@ -313,7 +313,7 @@
  *
  *  Failure processing finished PDU
  */
-#define CF_PDU_FIN_SHORT_ERR_EID (49)
+#define CF_EID_ERR_PDU_FIN_SHORT (49)
 
 /**
  * \brief CF Negative Acknowledgment PDU Too Short Event ID
@@ -324,7 +324,7 @@
  *
  *  Failure processing negative acknowledgment PDU
  */
-#define CF_PDU_NAK_SHORT_ERR_EID (50)
+#define CF_EID_ERR_PDU_NAK_SHORT (50)
 
 /**
  * \brief CF File Data PDU Unsupported Option Event ID
@@ -335,7 +335,7 @@
  *
  *  File Data PDU received with the segment metadata flag set
  */
-#define CF_PDU_FD_UNSUPPORTED_ERR_EID (54)
+#define CF_EID_ERR_PDU_FD_UNSUPPORTED (54)
 
 /**
  * \brief CF PDU Header Large File Flag Set Event ID
@@ -346,7 +346,7 @@
  *
  *  PDU Header received with the unsupported large file flag set
  */
-#define CF_PDU_LARGE_FILE_ERR_EID (55)
+#define CF_EID_ERR_PDU_LARGE_FILE (55)
 
 /**
  * \brief CF PDU Header Field Truncation
@@ -357,7 +357,7 @@
  *
  *  PDU Header received with fields that would be truncated with the cf configuration
  */
-#define CF_PDU_TRUNCATION_ERR_EID (56)
+#define CF_EID_ERR_PDU_TRUNCATION (56)
 
 /**************************************************************************
  * CF_CFDP event IDs - Engine
@@ -374,7 +374,7 @@
  *  with an invalid file destination.
  *
  */
-#define CF_RESET_FREED_XACT_DBG_EID (59)
+#define CF_EID_DBG_RESET_FREED_XACT (59)
 
 /**
  * \brief CF PDU Received Without Existing Transaction, Dropped Due To Max RX Reached Event ID
@@ -386,7 +386,7 @@
  *  PDU without a matching/existing transaction received when channel receive queue is already
  *  handling the maximum number of concurrent receive transactions
  */
-#define CF_CFDP_RX_DROPPED_ERR_EID (60)
+#define CF_EID_ERR_CFDP_RX_DROPPED (60)
 
 /**
  * \brief CF PDU Received With Invalid Destination Entity ID Event ID
@@ -398,7 +398,7 @@
  *  PDU without a matching/existing transaction received with an entity ID that doesn't
  *  match the receiving channel's entity ID
  */
-#define CF_CFDP_INVALID_DST_ERR_EID (61)
+#define CF_EID_ERR_CFDP_INVALID_DST_EID (61)
 
 /**
  * \brief CF Invalid Metadata PDU Received On Idle Transaction Event ID
@@ -409,7 +409,7 @@
  *
  *  Metadata PDU received for an idle transaction failed decoding
  */
-#define CF_CFDP_IDLE_MD_ERR_EID (62)
+#define CF_EID_ERR_CFDP_IDLE_MD (62)
 
 /**
  * \brief CF Non-metadata File Directive PDU Received On Idle Transaction Event ID
@@ -420,7 +420,7 @@
  *
  *  File Directive PDU received without the metadata directive code on an idle transaction
  */
-#define CF_CFDP_FD_UNHANDLED_ERR_EID (63)
+#define CF_EID_ERR_CFDP_FD_UNHANDLED (63)
 
 /**
  * \brief CF Transmission Request Rejected Due To Max Commanded TX Reached Event ID
@@ -432,7 +432,7 @@
  *  Command request to transmit a file received when channel is already
  *  handling the maximum number of concurrent command transmit transactions
  */
-#define CF_CFDP_MAX_CMD_TX_ERR_EID (64)
+#define CF_EID_ERR_CFDP_MAX_CMD_TX (64)
 
 /**
  * \brief CF Playback/Polling Directory Open Failed Event ID
@@ -443,7 +443,7 @@
  *
  *  Failure opening directory during playback or polling initialization
  */
-#define CF_CFDP_OPENDIR_ERR_EID (65)
+#define CF_EID_ERR_CFDP_OPENDIR (65)
 
 /**
  * \brief CF Playback Request Rejected Due to Max Playback Directories Reached Event ID
@@ -455,7 +455,7 @@
  *  Command request to playback a directory received when channel is already
  *  handling the maximum number of concurrent playback directories
  */
-#define CF_CFDP_DIR_SLOT_ERR_EID (66)
+#define CF_EID_ERR_CFDP_DIR_SLOT (66)
 
 /**
  * \brief CF No Message Buffer Available Event ID
@@ -466,7 +466,7 @@
  *
  *  Failure from SB allocate message buffer call when constructing PDU
  */
-#define CF_CFDP_NO_MSG_ERR_EID (67)
+#define CF_EID_ERR_CFDP_NO_MSG (67)
 
 /**
  * \brief CF Close File Failed Event ID
@@ -477,7 +477,7 @@
  *
  *  Failure from file close call
  */
-#define CF_CFDP_CLOSE_ERR_EID (68)
+#define CF_EID_ERR_CFDP_CLOSE_ERR (68)
 
 /**************************************************************************
  * CF_CFDP_R event IDs - Engine receive
@@ -493,7 +493,7 @@
  *  RX transaction missing metadata which results in a NAK being sent to
  *  request a metadata PDU for the transaction
  */
-#define CF_CFDP_R_REQUEST_MD_INF_EID (70)
+#define CF_EID_INF_CFDP_R_REQUEST_MD (70)
 
 /**
  * \brief CF Creating Temp File For RX Transaction Without Metadata PDU
@@ -505,7 +505,7 @@
  *  RX transaction missing metadata causing creation of a temporary
  *  filename to store the data
  */
-#define CF_CFDP_R_TEMP_FILE_INF_EID (71)
+#define CF_EID_INF_CFDP_R_TEMP_FILE (71)
 
 /**
  * \brief CF RX Transaction NAK Limit Reached Event ID
@@ -516,7 +516,7 @@
  *
  *  Condition that triggers a NAK occurred that would meet or exceed the NAK limit
  */
-#define CF_CFDP_R_NAK_LIMIT_ERR_EID (72)
+#define CF_EID_ERR_CFDP_R_NAK_LIMIT (72)
 
 /**
  * \brief CF RX Transaction ACK Limit Reached Event ID
@@ -527,7 +527,7 @@
  *
  *  Condition that triggers an ACK occurred that would meet or exceed the ACK limit
  */
-#define CF_CFDP_R_ACK_LIMIT_ERR_EID (73)
+#define CF_EID_ERR_CFDP_R_ACK_LIMIT (73)
 
 /**
  * \brief CF RX Transaction CRC Mismatch Event ID
@@ -538,7 +538,7 @@
  *
  *  RX Transaction final CRC mismatch
  */
-#define CF_CFDP_R_CRC_ERR_EID (74)
+#define CF_EID_ERR_CFDP_R_CRC (74)
 
 /**
  * \brief CF RX File Data PDU Seek Failed Event ID
@@ -549,7 +549,7 @@
  *
  *  Failure of lseek call when processing out of order file data PDUs
  */
-#define CF_CFDP_R_SEEK_FD_ERR_EID (75)
+#define CF_EID_ERR_CFDP_R_SEEK_FD (75)
 
 /**
  * \brief CF RX Class 2 CRC Seek Failed Event ID
@@ -561,7 +561,7 @@
  *  Failure of lseek call when calculating CRC from the file at
  *  the end of a Class 2 RX transaction
  */
-#define CF_CFDP_R_SEEK_CRC_ERR_EID (76)
+#define CF_EID_ERR_CFDP_R_SEEK_CRC (76)
 
 /**
  * \brief CF RX File Data PDU Write Failed Event ID
@@ -572,7 +572,7 @@
  *
  * Failure of write to file call when processing file data PDUs
  */
-#define CF_CFDP_R_WRITE_ERR_EID (77)
+#define CF_EID_ERR_CFDP_R_WRITE (77)
 
 /**
  * \brief CF RX End-Of-File PDU File Size Mismatch Event ID
@@ -583,7 +583,7 @@
  *
  *  End-of-file PDU file size does not match transaction expected file size
  */
-#define CF_CFDP_R_SIZE_MISMATCH_ERR_EID (78)
+#define CF_EID_ERR_CFDP_R_SIZE_MISMATCH (78)
 
 /**
  * \brief CF Invalid End-Of-File PDU Event ID
@@ -594,7 +594,7 @@
  *
  *  End-of-file PDU failed decoding
  */
-#define CF_CFDP_R_PDU_EOF_ERR_EID (79)
+#define CF_EID_ERR_CFDP_R_PDU_EOF (79)
 
 /**
  * \brief CF RX Transaction File Create Failed Event ID
@@ -605,7 +605,7 @@
  *
  *  Failure in opencreate file call for an RX transaction
  */
-#define CF_CFDP_R_CREAT_ERR_EID (80)
+#define CF_EID_ERR_CFDP_R_CREAT (80)
 
 /**
  * \brief CF Class 2 RX Transaction Invalid FIN-ACK PDU Event ID
@@ -616,7 +616,7 @@
  *
  *  ACK PDU failed decoding during Class 2 RX Transaction
  */
-#define CF_CFDP_R_PDU_FINACK_ERR_EID (81)
+#define CF_EID_ERR_CFDP_R_PDU_FINACK (81)
 
 /**
  * \brief CF RX Class 2 Metadata PDU Size Mismatch Event ID
@@ -628,7 +628,7 @@
  *  Out-of-order RX Class 2 Metadata PDU received with file size that doesn't
  *  match already received EOF PDU file size
  */
-#define CF_CFDP_R_EOF_MD_SIZE_ERR_EID (82)
+#define CF_EID_ERR_CFDP_R_EOF_MD_SIZE (82)
 
 /**
  * \brief CF RX Class 2 Metadata PDU File Rename Failed Event ID
@@ -640,7 +640,7 @@
  *  Failure from file rename call after reception of an out-of-order RX
  *  Class 2 Metadata PDU
  */
-#define CF_CFDP_R_RENAME_ERR_EID (83)
+#define CF_EID_ERR_CFDP_R_RENAME (83)
 
 /**
  * \brief CF RX Class 2 Metadata PDU File Open Failed Event ID
@@ -652,7 +652,7 @@
  *  Failure from file open call after reception of an out-of-order RX
  *  Class 2 Metadata PDU
  */
-#define CF_CFDP_R_OPEN_ERR_EID (84)
+#define CF_EID_ERR_CFDP_R_OPEN (84)
 
 /**
  * \brief CF Invalid Out-of-order Metadata PDU Received Event ID
@@ -663,7 +663,7 @@
  *
  *  Failure to decode out-of-order metadata PDU
  */
-#define CF_CFDP_R_PDU_MD_ERR_EID (85)
+#define CF_EID_ERR_CFDP_R_PDU_MD (85)
 
 /**
  * \brief CF Class 2 CRC Read From File Failed Event ID
@@ -674,7 +674,7 @@
  *
  *  Failure from file read call during RX Class 2 CRC calculation
  */
-#define CF_CFDP_R_READ_ERR_EID (86)
+#define CF_EID_ERR_CFDP_R_READ (86)
 
 /**
  * \brief CF RX Invalid File Directive PDU Code Received Event ID
@@ -686,7 +686,7 @@
  *  Unrecognized file directive PDU directive code received for
  *  a current transaction
  */
-#define CF_CFDP_R_DC_INV_ERR_EID (87)
+#define CF_EID_ERR_CFDP_R_DC_INV (87)
 
 /**
  * \brief CF RX Inactivity Timer Expired Event ID
@@ -697,7 +697,7 @@
  *
  *  Expiration of the RX inactivity timer
  */
-#define CF_CFDP_R_INACT_TIMER_ERR_EID (88)
+#define CF_EID_ERR_CFDP_R_INACT_TIMER (88)
 
 /**************************************************************************
  * CF_CFDP_S event IDs - Engine send
@@ -712,7 +712,7 @@
  *
  *  File TX transaction initiated
  */
-#define CF_CFDP_S_START_SEND_INF_EID (90)
+#define CF_EID_INF_CFDP_S_START_SEND (90)
 
 /**
  * \brief CF TX File Data PDU Seek Failed Event ID
@@ -723,7 +723,7 @@
  *
  *  Failure of lseek call when preparing to send file data PDU
  */
-#define CF_CFDP_S_SEEK_FD_ERR_EID (91)
+#define CF_EID_ERR_CFDP_S_SEEK_FD (91)
 
 /**
  * \brief CF TX File Data PDU Read Failed Event ID
@@ -734,7 +734,7 @@
  *
  *  Failure of read file call when preparing to send file data PDU
  */
-#define CF_CFDP_S_READ_ERR_EID (92)
+#define CF_EID_ERR_CFDP_S_READ (92)
 
 /**
  * \brief CF TX File Data PDU Send Failed Event ID
@@ -745,7 +745,7 @@
  *
  *  Failure to send the file data PDU
  */
-#define CF_CFDP_S_SEND_FD_ERR_EID (93)
+#define CF_EID_ERR_CFDP_S_SEND_FD (93)
 
 /**
  * \brief CF TX Metadata PDU File Already Open Event ID
@@ -756,7 +756,7 @@
  *
  *  Failure to send metadata PDU due to file already being open
  */
-#define CF_CFDP_S_ALREADY_OPEN_ERR_EID (94)
+#define CF_EID_ERR_CFDP_S_ALREADY_OPEN (94)
 
 /**
  * \brief CF TX Metadata PDU File Open Failed Event ID
@@ -767,7 +767,7 @@
  *
  *  Failure in file open call when preparing to send metadata PDU
  */
-#define CF_CFDP_S_OPEN_ERR_EID (95)
+#define CF_EID_ERR_CFDP_S_OPEN (95)
 
 /**
  * \brief CF TX Metadata PDU File Seek End Failed Event ID
@@ -779,7 +779,7 @@
  *  Failure in file lseek to end of file call when preparing
  *  to send metadata PDU
  */
-#define CF_CFDP_S_SEEK_END_ERR_EID (96)
+#define CF_EID_ERR_CFDP_S_SEEK_END (96)
 
 /**
  * \brief CF TX Metadata PDU File Seek Beginning Failed Event ID
@@ -791,7 +791,7 @@
  *  Failure in file lseek to beginning of file call when
  *  preparing to send metadata PDU
  */
-#define CF_CFDP_S_SEEK_BEG_ERR_EID (97)
+#define CF_EID_ERR_CFDP_S_SEEK_BEG (97)
 
 /**
  * \brief CF TX Metadata PDU Send Failed Event ID
@@ -802,7 +802,7 @@
  *
  *  Failure to send the metadata PDU
  */
-#define CF_CFDP_S_SEND_MD_ERR_EID (98)
+#define CF_EID_ERR_CFDP_S_SEND_MD (98)
 
 /**
  * \brief CF TX Received NAK PDU Bad Segment Request Event ID
@@ -814,7 +814,7 @@
  *  Bad segment request values in received NAK PDU relating
  *  to a current transaction
  */
-#define CF_CFDP_S_INVALID_SR_ERR_EID (100)
+#define CF_EID_ERR_CFDP_S_INVALID_SR (100)
 
 /**
  * \brief CF TX Received NAK PDU Invalid Event ID
@@ -826,7 +826,7 @@
  *  Failure processing received NAK PDU relating
  *  to a current transaction
  */
-#define CF_CFDP_S_PDU_NAK_ERR_EID (101)
+#define CF_EID_ERR_CFDP_S_PDU_NAK (101)
 
 /**
  * \brief CF TX Received EOF ACK PDU Invalid Event ID
@@ -838,7 +838,7 @@
  *  Failure processing received ACK PDU relating
  *  to a current transaction
  */
-#define CF_CFDP_S_PDU_EOF_ERR_EID (102)
+#define CF_EID_ERR_CFDP_S_PDU_EOF (102)
 
 /**
  * \brief CF TX Received Early FIN PDU Event ID
@@ -849,7 +849,7 @@
  *
  *  Early FIN PDU received prior to completion of a current transaction
  */
-#define CF_CFDP_S_EARLY_FIN_ERR_EID (103)
+#define CF_EID_ERR_CFDP_S_EARLY_FIN (103)
 
 /**
  * \brief CF Invalid TX File Directive PDU Code Event ID
@@ -861,7 +861,7 @@
  *  Unrecognized file directive PDU directive code received for
  *  a current transaction
  */
-#define CF_CFDP_S_DC_INV_ERR_EID (104)
+#define CF_EID_ERR_CFDP_S_DC_INV (104)
 
 /**
  * \brief CF Received TX Non-File Directive PDU Event ID
@@ -872,7 +872,7 @@
  *
  *  Received a non-file directive PDU on a send transaction
  */
-#define CF_CFDP_S_NON_FD_PDU_ERR_EID (105)
+#define CF_EID_ERR_CFDP_S_NON_FD_PDU (105)
 
 /**
  * \brief CF TX EOF PDU Send Limit Reached Event ID
@@ -884,7 +884,7 @@
  *  Timed out the limit number of times waiting for an ACK PDU for the EOF PDU on a
  *  current transaction
  */
-#define CF_CFDP_S_ACK_LIMIT_ERR_EID (106)
+#define CF_EID_ERR_CFDP_S_ACK_LIMIT (106)
 
 /**
  * \brief CF TX Inactivity Timer Expired Event ID
@@ -895,7 +895,7 @@
  *
  *  Send transaction activity timeout expired
  */
-#define CF_CFDP_S_INACT_TIMER_ERR_EID (107)
+#define CF_EID_ERR_CFDP_S_INACT_TIMER (107)
 
 /**************************************************************************
  * CF_CMD event IDs - Command processing
@@ -932,7 +932,7 @@
  *
  *  Receipt and successful processing of set parameter command
  */
-#define CF_CMD_GETSET1_INF_EID (112)
+#define CF_EID_INF_CMD_GETSET1 (112)
 
 /**
  * \brief CF Get Parameter Command Received Event ID
@@ -943,7 +943,7 @@
  *
  *  Receipt and successful processing of get parameter command
  */
-#define CF_CMD_GETSET2_INF_EID (113)
+#define CF_EID_INF_CMD_GETSET2 (113)
 
 /**
  * \brief CF Suspend/Resume Command Received Event ID
@@ -954,7 +954,7 @@
  *
  *  Receipt and successful processing of suspend/resume command
  */
-#define CF_CMD_SUSPRES_INF_EID (114)
+#define CF_EID_INF_CMD_SUSPRES (114)
 
 /**
  * \brief CF Write Queue Command Received Event ID
@@ -965,7 +965,7 @@
  *
  *  Receipt and successful processing of write queue command
  */
-#define CF_CMD_WQ_INF_EID (115)
+#define CF_EID_INF_CMD_WQ (115)
 
 /**
  * \brief CF Enable Engine Command Received Event ID
@@ -976,7 +976,7 @@
  *
  *  Receipt and successful processing of enable engine command
  */
-#define CF_CMD_ENABLE_ENGINE_INF_EID (116)
+#define CF_EID_INF_CMD_ENABLE_ENGINE (116)
 
 /**
  * \brief CF Disable Engine Command Received Event ID
@@ -987,7 +987,7 @@
  *
  *  Receipt and successful processing of disable engine command
  */
-#define CF_CMD_DISABLE_ENGINE_INF_EID (117)
+#define CF_EID_INF_CMD_DISABLE_ENGINE (117)
 
 /**
  * \brief CF Transfer File Command Received Event ID
@@ -998,7 +998,7 @@
  *
  *  Receipt and successful processing of transfer file command
  */
-#define CF_CMD_TX_FILE_INF_EID (118)
+#define CF_EID_INF_CMD_TX_FILE (118)
 
 /**
  * \brief CF Playback Directory Command Received Event ID
@@ -1009,7 +1009,7 @@
  *
  *  Receipt and successful processing of playback directory command
  */
-#define CF_CMD_PLAYBACK_DIR_INF_EID (119)
+#define CF_EID_INF_CMD_PLAYBACK_DIR (119)
 
 /**
  * \brief CF Freeze Command Received Event ID
@@ -1020,7 +1020,7 @@
  *
  *  Receipt and successful processing of freeze command
  */
-#define CF_CMD_FREEZE_INF_EID (120)
+#define CF_EID_INF_CMD_FREEZE (120)
 
 /**
  * \brief CF Thaw Command Received Event ID
@@ -1031,7 +1031,7 @@
  *
  *  Receipt and successful processing of thaw command
  */
-#define CF_CMD_THAW_INF_EID (121)
+#define CF_EID_INF_CMD_THAW (121)
 
 /**
  * \brief CF Cancel Command Received Event ID
@@ -1042,7 +1042,7 @@
  *
  *  Receipt and successful processing of cancel command
  */
-#define CF_CMD_CANCEL_INF_EID (122)
+#define CF_EID_INF_CMD_CANCEL (122)
 
 /**
  * \brief CF Abandon Command Received Event ID
@@ -1053,7 +1053,7 @@
  *
  *  Receipt and successful processing of abandon command
  */
-#define CF_CMD_ABANDON_INF_EID (123)
+#define CF_EID_INF_CMD_ABANDON (123)
 
 /**
  * \brief CF Enable Dequeue Command Received Event ID
@@ -1064,7 +1064,7 @@
  *
  *  Receipt and successful processing of enable dequeue command
  */
-#define CF_CMD_ENABLE_DEQUEUE_INF_EID (124)
+#define CF_EID_INF_CMD_ENABLE_DEQUEUE (124)
 
 /**
  * \brief CF Disable Dequeue Command Received Event ID
@@ -1075,7 +1075,7 @@
  *
  *  Receipt and successful processing of disable dequeue command
  */
-#define CF_CMD_DISABLE_DEQUEUE_INF_EID (125)
+#define CF_EID_INF_CMD_DISABLE_DEQUEUE (125)
 
 /**
  * \brief CF Enable Polldir Command Received Event ID
@@ -1086,7 +1086,7 @@
  *
  *  Receipt and successful processing of enable polldir command
  */
-#define CF_CMD_ENABLE_POLLDIR_INF_EID (126)
+#define CF_EID_INF_CMD_ENABLE_POLLDIR (126)
 
 /**
  * \brief CF Disable Polldir Command Received Event ID
@@ -1097,7 +1097,7 @@
  *
  *  Receipt and successful processing of disable polldir command
  */
-#define CF_CMD_DISABLE_POLLDIR_INF_EID (127)
+#define CF_EID_INF_CMD_DISABLE_POLLDIR (127)
 
 /**
  * \brief CF Purge Queue Command Received Event ID
@@ -1108,7 +1108,7 @@
  *
  *  Receipt and successful processing of purge queue command
  */
-#define CF_CMD_PURGE_QUEUE_INF_EID (128)
+#define CF_EID_INF_CMD_PURGE_QUEUE (128)
 
 /**
  * \brief CF Reset Counters Command Invalid Event ID
@@ -1119,7 +1119,7 @@
  *
  *  Reset counters command received with invalid parameter
  */
-#define CF_CMD_RESET_INVALID_ERR_EID (129)
+#define CF_EID_ERR_CMD_RESET_INVALID (129)
 
 /**
  * \brief CF Command Channel Invalid Event ID
@@ -1130,7 +1130,7 @@
  *
  *  Command received with channel parameter out of range
  */
-#define CF_CMD_CHAN_PARAM_ERR_EID (130)
+#define CF_EID_ERR_CMD_CHAN_PARAM (130)
 
 /**
  * \brief CF Command Transaction Invalid Event ID
@@ -1141,7 +1141,7 @@
  *
  *  Command received without a matching transaction
  */
-#define CF_CMD_TRANS_NOT_FOUND_ERR_EID (131)
+#define CF_EID_ERR_CMD_TRANS_NOT_FOUND (131)
 
 /**
  * \brief CF Command All Transaction Channel Invalid Event ID
@@ -1152,7 +1152,7 @@
  *
  *  Command received to act on all transactions with invalid channel
  */
-#define CF_CMD_TSN_CHAN_INVALID_ERR_EID (132)
+#define CF_EID_ERR_CMD_TSN_CHAN_INVALID (132)
 
 /**
  * \brief CF Suspend/Resume Command For Single Transaction State Unchanged Event ID
@@ -1163,7 +1163,7 @@
  *
  *  Suspend/resume command received affecting single transaction already set to that state
  */
-#define CF_CMD_SUSPRES_SAME_ERR_EID (133)
+#define CF_EID_ERR_CMD_SUSPRES_SAME (133)
 
 /**
  * \brief CF Suspend/Resume Command No Matching Transaction Event ID
@@ -1174,7 +1174,7 @@
  *
  *  Suspend/resume command received without a matching transaction
  */
-#define CF_CMD_SUSPRES_CHAN_ERR_EID (134)
+#define CF_EID_ERR_CMD_SUSPRES_CHAN (134)
 
 /**
  * \brief CF Enable/Disable Polling Directory Command Invalid Polling Directory Index Event ID
@@ -1185,7 +1185,7 @@
  *
  *  Enable/disable polling directory command received with invalid poling directory index
  */
-#define CF_CMD_POLLDIR_INVALID_ERR_EID (135)
+#define CF_EID_ERR_CMD_POLLDIR_INVALID (135)
 
 /**
  * \brief CF Purge Queue Command Invalid Argument Event ID
@@ -1196,7 +1196,7 @@
  *
  *  Purge Queue command received with invalid queue argument
  */
-#define CF_CMD_PURGE_ARG_ERR_EID (136)
+#define CF_EID_ERR_CMD_PURGE_ARG (136)
 
 /**
  * \brief CF Write Queue Command Invalid Channel Event ID
@@ -1207,7 +1207,7 @@
  *
  *  Write Queue command received with invalid channel argument
  */
-#define CF_CMD_WQ_CHAN_ERR_EID (137)
+#define CF_EID_ERR_CMD_WQ_CHAN (137)
 
 /**
  * \brief CF Write Queue Command Invalid Queue Event ID
@@ -1218,7 +1218,7 @@
  *
  *  Write Queue command received with invalid queue selection arguments
  */
-#define CF_CMD_WQ_ARGS_ERR_EID (138)
+#define CF_EID_ERR_CMD_WQ_ARGS (138)
 
 /**
  * \brief CF Write Queue Command File Open Failed Event ID
@@ -1229,7 +1229,7 @@
  *
  *  Failure of open file call during processing of write queue command
  */
-#define CF_CMD_WQ_OPEN_ERR_EID (139)
+#define CF_EID_ERR_CMD_WQ_OPEN (139)
 
 /**
  * \brief CF Write Queue Command RX Active File Write Failed Event ID
@@ -1240,7 +1240,7 @@
  *
  *  Failure of file write call for RX active transactions during processing of write queue command
  */
-#define CF_CMD_WQ_WRITEQ_RX_ERR_EID (140)
+#define CF_EID_ERR_CMD_WQ_WRITEQ_RX (140)
 
 /**
  * \brief CF Write Queue Command RX History File Write Failed Event ID
@@ -1251,7 +1251,7 @@
  *
  *  Failure of file write call for RX history during processing of write queue command
  */
-#define CF_CMD_WQ_WRITEHIST_RX_ERR_EID (141)
+#define CF_EID_ERR_CMD_WQ_WRITEHIST_RX (141)
 
 /**
  * \brief CF Write Queue Command TX Active File Write Failed Event ID
@@ -1262,7 +1262,7 @@
  *
  *  Failure of file write call for TX active transactions during processing of write queue command
  */
-#define CF_CMD_WQ_WRITEQ_TX_ERR_EID (142)
+#define CF_EID_ERR_CMD_WQ_WRITEQ_TX (142)
 
 /**
  * \brief CF Write Queue Command TX Pending File Write Failed Event ID
@@ -1273,7 +1273,7 @@
  *
  *  Failure of file write call for TX pending transactions during processing of write queue command
  */
-#define CF_CMD_WQ_WRITEQ_PEND_ERR_EID (143)
+#define CF_EID_ERR_CMD_WQ_WRITEQ_PEND (143)
 
 /**
  * \brief CF Write Queue Command TX History File Write Failed Event ID
@@ -1284,7 +1284,7 @@
  *
  *  Failure of file write call for TX history during processing of write queue command
  */
-#define CF_CMD_WQ_WRITEHIST_TX_ERR_EID (144)
+#define CF_EID_ERR_CMD_WQ_WRITEHIST_TX (144)
 
 /**
  * \brief CF Set Parameter Command Parameter Validation Failed Event ID
@@ -1295,7 +1295,7 @@
  *
  *  Parameter validation failed during processing of set parameter command
  */
-#define CF_CMD_GETSET_VALIDATE_ERR_EID (145)
+#define CF_EID_ERR_CMD_GETSET_VALIDATE (145)
 
 /**
  * \brief CF Set/Get Parameter Command Invalid Parameter ID Event ID
@@ -1306,7 +1306,7 @@
  *
  *  Invalid parameter id value received in set or get parameter command
  */
-#define CF_CMD_GETSET_PARAM_ERR_EID (146)
+#define CF_EID_ERR_CMD_GETSET_PARAM (146)
 
 /**
  * \brief CF Set/Get Parameter Command Invalid Channel Event ID
@@ -1317,7 +1317,7 @@
  *
  *  Invalid channel value received in set or get parameter command
  */
-#define CF_CMD_GETSET_CHAN_ERR_EID (147)
+#define CF_EID_ERR_CMD_GETSET_CHAN (147)
 
 /**
  * \brief CF Enable Engine Command Failed Event ID
@@ -1328,7 +1328,7 @@
  *
  *  Failed to initialize engine when processing engine enable command
  */
-#define CF_CMD_ENABLE_ENGINE_ERR_EID (148)
+#define CF_EID_ERR_CMD_ENABLE_ENGINE (148)
 
 /**
  * \brief CF Enable Engine Command Engine Already Enabled Event ID
@@ -1339,7 +1339,7 @@
  *
  *  Enable engine command received while engine is already enabled
  */
-#define CF_CMD_ENG_ALREADY_ENA_ERR_EID (149)
+#define CF_EID_ERR_CMD_ENG_ALREADY_ENA (149)
 
 /**
  * \brief CF Disable Engine Command Engine Already Disabled Event ID
@@ -1350,7 +1350,7 @@
  *
  *  Disable engine command received while engine is already disabled
  */
-#define CF_CMD_ENG_ALREADY_DIS_ERR_EID (150)
+#define CF_EID_ERR_CMD_ENG_ALREADY_DIS (150)
 
 /**
  * \brief CF Command Length Verification Failed Event ID
@@ -1383,7 +1383,7 @@
  *
  *  Write entry to file did not match expected length
  */
-#define CF_CMD_WHIST_WRITE_ERR_EID (153)
+#define CF_EID_ERR_CMD_WHIST_WRITE (153)
 
 /**
  * \brief CF Playback Dir Or TX File Command Bad Parameter Event ID
@@ -1394,7 +1394,7 @@
  *
  *  Bad parameter received in playback directory or transfer file command
  */
-#define CF_CMD_BAD_PARAM_ERR_EID (154)
+#define CF_EID_ERR_CMD_BAD_PARAM (154)
 
 /**
  * \brief CF Cancel Command No Matching Transaction Event ID
@@ -1405,7 +1405,7 @@
  *
  *  Cancel command received without a matching transaction
  */
-#define CF_CMD_CANCEL_CHAN_ERR_EID (155)
+#define CF_EID_ERR_CMD_CANCEL_CHAN (155)
 
 /**
  * \brief CF Abandon Command No Matching Transaction Event ID
@@ -1416,7 +1416,7 @@
  *
  *  Abandon command received without a matching transaction
  */
-#define CF_CMD_ABANDON_CHAN_ERR_EID (156)
+#define CF_EID_ERR_CMD_ABANDON_CHAN (156)
 
 /**
  * \brief CF Transfer File Command Failed Event ID
@@ -1427,7 +1427,7 @@
  *
  *  Transfer file command was unsuccessful
  */
-#define CF_CMD_TX_FILE_ERR_EID (157)
+#define CF_EID_ERR_CMD_TX_FILE (157)
 
 /**
  * \brief CF Playback Directory Command Failed Event ID
@@ -1438,7 +1438,7 @@
  *
  *  Playback directory command was unsuccessful
  */
-#define CF_CMD_PLAYBACK_DIR_ERR_EID (158)
+#define CF_EID_ERR_CMD_PLAYBACK_DIR (158)
 
 /**
  * \brief CF Freeze Command Failed Event ID
@@ -1449,7 +1449,7 @@
  *
  *  Freeze command was unsuccessful
  */
-#define CF_CMD_FREEZE_ERR_EID (159)
+#define CF_EID_ERR_CMD_FREEZE (159)
 
 /**
  * \brief CF Thaw Command Failed Event ID
@@ -1460,7 +1460,7 @@
  *
  *  Thaw command was unsuccessful
  */
-#define CF_CMD_THAW_ERR_EID (160)
+#define CF_EID_ERR_CMD_THAW (160)
 
 /**
  * \brief CF Enable Dequeue Command Failed Event ID
@@ -1471,7 +1471,7 @@
  *
  *  Enable Dequeue command was unsuccessful
  */
-#define CF_CMD_ENABLE_DEQUEUE_ERR_EID (161)
+#define CF_EID_ERR_CMD_ENABLE_DEQUEUE (161)
 
 /**
  * \brief CF Disable Dequeue Command Failed Event ID
@@ -1482,7 +1482,7 @@
  *
  *  Disable dequeue command was unsuccessful
  */
-#define CF_CMD_DISABLE_DEQUEUE_ERR_EID (162)
+#define CF_EID_ERR_CMD_DISABLE_DEQUEUE (162)
 
 /**
  * \brief CF Enable Polldir Command Failed Event ID
@@ -1493,7 +1493,7 @@
  *
  *  Enable polldir command was unsuccessful
  */
-#define CF_CMD_ENABLE_POLLDIR_ERR_EID (163)
+#define CF_EID_ERR_CMD_ENABLE_POLLDIR (163)
 
 /**
  * \brief CF Disable Polldir Command Failed Event ID
@@ -1504,7 +1504,7 @@
  *
  *  Disable polldir command was unsuccessful
  */
-#define CF_CMD_DISABLE_POLLDIR_ERR_EID (164)
+#define CF_EID_ERR_CMD_DISABLE_POLLDIR (164)
 
 /**
  * \brief CF Purge Queue Command Failed Event ID
@@ -1515,7 +1515,7 @@
  *
  *  Purge queue command was unsuccessful
  */
-#define CF_CMD_PURGE_QUEUE_ERR_EID (165)
+#define CF_EID_ERR_CMD_PURGE_QUEUE (165)
 
 /**\}*/
 

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -69,7 +69,7 @@ void CF_CheckTables(void)
         status = CFE_TBL_ReleaseAddress(CF_AppData.config_handle);
         if (status < CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_INIT_TBL_CHECK_REL_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_CHECK_REL, CFE_EVS_EventType_ERROR,
                               "CF: error in CFE_TBL_ReleaseAddress (check), returned 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }
@@ -77,7 +77,7 @@ void CF_CheckTables(void)
         status = CFE_TBL_Manage(CF_AppData.config_handle);
         if (status < CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_INIT_TBL_CHECK_MAN_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_CHECK_MAN, CFE_EVS_EventType_ERROR,
                               "CF: error in CFE_TBL_Manage (check), returned 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }
@@ -85,7 +85,7 @@ void CF_CheckTables(void)
         status = CFE_TBL_GetAddress((void *)&CF_AppData.config_table, CF_AppData.config_handle);
         if (status < CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_INIT_TBL_CHECK_GA_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_CHECK_GA, CFE_EVS_EventType_ERROR,
                               "CF: failed to get table address (check), returned 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }
@@ -105,16 +105,16 @@ CFE_Status_t CF_ValidateConfigTable(void *tbl_ptr)
 
     if (!tbl->ticks_per_second)
     {
-        CFE_EVS_SendEvent(CF_INIT_TPS_ERR_EID, CFE_EVS_EventType_ERROR, "CF: config table has zero ticks per second");
+        CFE_EVS_SendEvent(CF_EID_ERR_INIT_TPS, CFE_EVS_EventType_ERROR, "CF: config table has zero ticks per second");
     }
     else if (!tbl->rx_crc_calc_bytes_per_wakeup || (tbl->rx_crc_calc_bytes_per_wakeup & 0x3ff))
     {
-        CFE_EVS_SendEvent(CF_INIT_CRC_ALIGN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_INIT_CRC_ALIGN, CFE_EVS_EventType_ERROR,
                           "CF: config table has rx CRC size not aligned with 1024");
     }
     else if (tbl->outgoing_file_chunk_size > sizeof(CF_CFDP_PduFileDataContent_t))
     {
-        CFE_EVS_SendEvent(CF_INIT_OUTGOING_SIZE_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_INIT_OUTGOING_SIZE, CFE_EVS_EventType_ERROR,
                           "CF: config table has outgoing file chunk size too large");
     }
     else
@@ -139,7 +139,7 @@ CFE_Status_t CF_TableInit(void)
                               CFE_TBL_OPT_SNGL_BUFFER | CFE_TBL_OPT_LOAD_DUMP, CF_ValidateConfigTable);
     if (status != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_INIT_TBL_REG_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_REG, CFE_EVS_EventType_ERROR,
                           "CF: error registering table, returned 0x%08lx", (unsigned long)status);
     }
     else
@@ -147,7 +147,7 @@ CFE_Status_t CF_TableInit(void)
         status = CFE_TBL_Load(CF_AppData.config_handle, CFE_TBL_SRC_FILE, CF_CONFIG_TABLE_FILENAME);
         if (status != CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_INIT_TBL_LOAD_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_LOAD, CFE_EVS_EventType_ERROR,
                               "CF: error loading table, returned 0x%08lx", (unsigned long)status);
         }
     }
@@ -157,7 +157,7 @@ CFE_Status_t CF_TableInit(void)
         status = CFE_TBL_Manage(CF_AppData.config_handle);
         if (status != CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_INIT_TBL_MANAGE_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_MANAGE, CFE_EVS_EventType_ERROR,
                               "CF: error in CFE_TBL_Manage, returned 0x%08lx", (unsigned long)status);
         }
     }
@@ -168,7 +168,7 @@ CFE_Status_t CF_TableInit(void)
         /* status will be CFE_TBL_INFO_UPDATED because it was just loaded, but we can use CFE_SUCCESS too */
         if ((status != CFE_TBL_INFO_UPDATED) && (status != CFE_SUCCESS))
         {
-            CFE_EVS_SendEvent(CF_INIT_TBL_GETADDR_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_TBL_GETADDR, CFE_EVS_EventType_ERROR,
                               "CF: error getting table address, returned 0x%08lx", (unsigned long)status);
         }
         else
@@ -287,7 +287,7 @@ void CF_AppMain(void)
         }
         else if (status != CFE_SB_TIME_OUT && status != CFE_SB_NO_MESSAGE)
         {
-            CFE_EVS_SendEvent(CF_INIT_MSG_RECV_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_MSG_RECV, CFE_EVS_EventType_ERROR,
                               "CF: exiting due to CFE_SB_ReceiveBuffer error 0x%08lx", (unsigned long)status);
             CF_AppData.run_status = CFE_ES_RunStatus_APP_ERROR;
         }

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -301,6 +301,22 @@ CF_Logical_PduBuffer_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *txn, 
 
 /*----------------------------------------------------------------
  *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
+static inline size_t CF_strnlen(const char *str, size_t maxlen)
+{
+    const char *end = memchr(str, 0, maxlen);
+    if (end != NULL)
+    {
+        /* actual length of string is difference */
+        maxlen = end - str;
+    }
+    return maxlen;
+}
+
+/*----------------------------------------------------------------
+ *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -328,10 +344,10 @@ CFE_Status_t CF_CFDP_SendMd(CF_Transaction_t *txn)
         /* at this point, need to append filenames into md packet */
         /* this does not actually copy here - that is done during encode */
         md->source_filename.length =
-            OS_strnlen(txn->history->fnames.src_filename, sizeof(txn->history->fnames.src_filename));
+            CF_strnlen(txn->history->fnames.src_filename, sizeof(txn->history->fnames.src_filename));
         md->source_filename.data_ptr = txn->history->fnames.src_filename;
         md->dest_filename.length =
-            OS_strnlen(txn->history->fnames.dst_filename, sizeof(txn->history->fnames.dst_filename));
+            CF_strnlen(txn->history->fnames.dst_filename, sizeof(txn->history->fnames.dst_filename));
         md->dest_filename.data_ptr = txn->history->fnames.dst_filename;
 
         CF_CFDP_EncodeMd(ph->penc, md);
@@ -581,7 +597,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
      */
     if (CF_CFDP_DecodeHeader(ph->pdec, &ph->pdu_header) != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_PDU_TRUNCATION_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_TRUNCATION, CFE_EVS_EventType_ERROR,
                           "CF: PDU rejected due to EID/seq number field truncation");
         ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
@@ -594,7 +610,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
      */
     else if (CF_CODEC_IS_OK(ph->pdec) && ph->pdu_header.large_flag)
     {
-        CFE_EVS_SendEvent(CF_PDU_LARGE_FILE_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_LARGE_FILE, CFE_EVS_EventType_ERROR,
                           "CF: PDU with large file bit received (unsupported)");
         ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.error;
         ret = CF_ERROR;
@@ -608,7 +624,7 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
 
         if (!CF_CODEC_IS_OK(ph->pdec))
         {
-            CFE_EVS_SendEvent(CF_PDU_SHORT_HEADER_ERR_EID, CFE_EVS_EventType_ERROR, "CF: PDU too short (%lu received)",
+            CFE_EVS_SendEvent(CF_EID_ERR_PDU_SHORT_HEADER, CFE_EVS_EventType_ERROR, "CF: PDU too short (%lu received)",
                               (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
             ++CF_AppData.hk.Payload.channel_hk[chan_num].counters.recv.error;
             ret = CF_SHORT_PDU_ERROR;
@@ -638,7 +654,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
     CF_CFDP_DecodeMd(ph->pdec, &ph->int_header.md);
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
-        CFE_EVS_SendEvent(CF_PDU_MD_SHORT_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_MD_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: metadata packet too short: %lu bytes received",
                           (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -660,7 +676,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                                           &md->source_filename);
         if (lv_ret < 0)
         {
-            CFE_EVS_SendEvent(CF_PDU_INVALID_SRC_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_SRC_LEN, CFE_EVS_EventType_ERROR,
                               "CF: metadata PDU rejected due to invalid length in source filename of 0x%02x",
                               md->source_filename.length);
             ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -672,7 +688,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                                               sizeof(txn->history->fnames.dst_filename), &md->dest_filename);
             if (lv_ret < 0)
             {
-                CFE_EVS_SendEvent(CF_PDU_INVALID_DST_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_PDU_INVALID_DST_LEN, CFE_EVS_EventType_ERROR,
                                   "CF: metadata PDU rejected due to invalid length in dest filename of 0x%02x",
                                   md->dest_filename.length);
                 ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -680,7 +696,7 @@ CFE_Status_t CF_CFDP_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
             }
             else
             {
-                CFE_EVS_SendEvent(CF_PDU_MD_RECVD_INF_EID, CFE_EVS_EventType_INFORMATION,
+                CFE_EVS_SendEvent(CF_EID_INF_PDU_MD_RECVD, CFE_EVS_EventType_INFORMATION,
                                   "CF: md received for source: %s, dest: %s", txn->history->fnames.src_filename,
                                   txn->history->fnames.dst_filename);
             }
@@ -717,7 +733,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
-        CFE_EVS_SendEvent(CF_PDU_FD_SHORT_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: filedata PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_PROTOCOL_ERROR);
         ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -726,7 +742,7 @@ CFE_Status_t CF_CFDP_RecvFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
     else if (ph->pdu_header.segment_meta_flag)
     {
         /* If recv PDU has the "segment_meta_flag" set, this is not currently handled in CF. */
-        CFE_EVS_SendEvent(CF_PDU_FD_UNSUPPORTED_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_FD_UNSUPPORTED, CFE_EVS_EventType_ERROR,
                           "CF: filedata PDU with segment metadata received");
         CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_PROTOCOL_ERROR);
         ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -750,7 +766,7 @@ CFE_Status_t CF_CFDP_RecvEof(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
-        CFE_EVS_SendEvent(CF_PDU_EOF_SHORT_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_EOF_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: EOF PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
@@ -772,7 +788,7 @@ CFE_Status_t CF_CFDP_RecvAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
-        CFE_EVS_SendEvent(CF_PDU_ACK_SHORT_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_ACK_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: ACK PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
@@ -795,7 +811,7 @@ CFE_Status_t CF_CFDP_RecvFin(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
-        CFE_EVS_SendEvent(CF_PDU_FIN_SHORT_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_FIN_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: FIN PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
@@ -819,7 +835,7 @@ CFE_Status_t CF_CFDP_RecvNak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 
     if (!CF_CODEC_IS_OK(ph->pdec))
     {
-        CFE_EVS_SendEvent(CF_PDU_NAK_SHORT_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_PDU_NAK_SHORT, CFE_EVS_EventType_ERROR,
                           "CF: NAK PDU too short: %lu bytes received", (unsigned long)CF_CODEC_GET_SIZE(ph->pdec));
         ret = CF_SHORT_PDU_ERROR;
     }
@@ -901,14 +917,14 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CF_CFDP_IDLE_MD_ERR_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_IDLE_MD, CFE_EVS_EventType_ERROR,
                                       "CF: got invalid md PDU -- abandoning transaction");
                     ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
                     /* leave state as idle, which will reset below */
                 }
                 break;
             default:
-                CFE_EVS_SendEvent(CF_CFDP_FD_UNHANDLED_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_FD_UNHANDLED, CFE_EVS_EventType_ERROR,
                                   "CF: unhandled file directive code 0x%02x in idle state", fdh->directive_code);
                 ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
                 break;
@@ -963,7 +979,7 @@ CFE_Status_t CF_CFDP_InitEngine(void)
                                     CF_AppData.config_table->chan[i].pipe_depth_input);
         if (ret != CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_INIT_SUB_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_INIT_SUB, CFE_EVS_EventType_ERROR,
                               "CF: failed to subscribe to MID 0x%lx, returned 0x%08lx",
                               (unsigned long)CF_AppData.config_table->chan[i].mid_input, (unsigned long)ret);
             break;
@@ -994,7 +1010,7 @@ CFE_Status_t CF_CFDP_InitEngine(void)
 
             if (ret != OS_SUCCESS)
             {
-                CFE_EVS_SendEvent(CF_INIT_SEM_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_INIT_SEM, CFE_EVS_EventType_ERROR,
                                   "CF: failed to get sem id for name %s, error=%ld",
                                   CF_AppData.config_table->chan[i].sem_name, (long)ret);
                 break;
@@ -1229,7 +1245,7 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *txn, CF_CFDP_Class_t cfdp_class, ui
 static void CF_CFDP_TxFile_Initiate(CF_Transaction_t *txn, CF_CFDP_Class_t cfdp_class, uint8 keep, uint8 chan,
                                     uint8 priority, CF_EntityId_t dest_id)
 {
-    CFE_EVS_SendEvent(CF_CFDP_S_START_SEND_INF_EID, CFE_EVS_EventType_INFORMATION,
+    CFE_EVS_SendEvent(CF_EID_INF_CFDP_S_START_SEND, CFE_EVS_EventType_INFORMATION,
                       "CF: start class %d tx of file %lu:%.*s -> %lu:%.*s", cfdp_class + 1,
                       (unsigned long)CF_AppData.config_table->local_eid, CF_FILENAME_MAX_LEN,
                       txn->history->fnames.src_filename, (unsigned long)dest_id, CF_FILENAME_MAX_LEN,
@@ -1270,7 +1286,7 @@ CFE_Status_t CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, 
 
     if (chan->num_cmd_tx == CF_MAX_COMMANDED_PLAYBACK_FILES_PER_CHAN)
     {
-        CFE_EVS_SendEvent(CF_CFDP_MAX_CMD_TX_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_MAX_CMD_TX, CFE_EVS_EventType_ERROR,
                           "CF: max number of commanded files reached");
         ret = CF_ERROR;
     }
@@ -1310,7 +1326,7 @@ static CFE_Status_t CF_CFDP_PlaybackDir_Initiate(CF_Playback_t *pb, const char *
     ret = OS_DirectoryOpen(&pb->dir_id, src_filename);
     if (ret != OS_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_CFDP_OPENDIR_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_OPENDIR, CFE_EVS_EventType_ERROR,
                           "CF: failed to open playback directory %s, error=%ld", src_filename, (long)ret);
         ++CF_AppData.hk.Payload.channel_hk[chan].counters.fault.directory_read;
     }
@@ -1357,7 +1373,7 @@ CFE_Status_t CF_CFDP_PlaybackDir(const char *src_filename, const char *dst_filen
 
     if (i == CF_MAX_COMMANDED_PLAYBACK_DIRECTORIES_PER_CHAN)
     {
-        CFE_EVS_SendEvent(CF_CFDP_DIR_SLOT_ERR_EID, CFE_EVS_EventType_ERROR, "CF: no playback dir slot available");
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_DIR_SLOT, CFE_EVS_EventType_ERROR, "CF: no playback dir slot available");
         return CF_ERROR;
     }
 
@@ -1594,7 +1610,7 @@ void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, int keep_history)
 
     if (txn->flags.com.q_index == CF_QueueIdx_FREE)
     {
-        CFE_EVS_SendEvent(CF_RESET_FREED_XACT_DBG_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CF_EID_DBG_RESET_FREED_XACT, CFE_EVS_EventType_DEBUG,
                           "CF: attempt to reset a transaction that has already been freed");
         return;
     }

--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -703,4 +703,34 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *chan);
  */
 CF_CListTraverse_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context);
 
+/************************************************************************/
+/** @brief Check if source file came from polling directory
+ *
+ *
+ * @par Assumptions, External Events, and Notes:
+ *
+ * @retval true/false
+ */
+bool CF_CFDP_IsPollingDir(const char * src_file, uint8 chan_num);
+
+/************************************************************************/
+/** @brief Remove/Move file after transaction
+ * 
+ * This helper is used to handle "not keep" file option after a transaction.  
+ *
+ * @par Assumptions, External Events, and Notes:
+ *
+ */
+void CF_CFDP_HandleNotKeepFile(CF_Transaction_t *txn);
+
+/************************************************************************/
+/** @brief Move File 
+ * 
+ * This helper is used to move a file.  
+ *
+ * @par Assumptions, External Events, and Notes:
+ *
+ */
+void CF_CFDP_MoveFile(const char *src, const char *dest_dir);
+
 #endif /* !CF_CFDP_H */

--- a/fsw/src/cf_cfdp_dispatch.c
+++ b/fsw/src/cf_cfdp_dispatch.c
@@ -60,7 +60,7 @@ void CF_CFDP_R_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph,
         else
         {
             ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious;
-            CFE_EVS_SendEvent(CF_CFDP_R_DC_INV_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_DC_INV, CFE_EVS_EventType_ERROR,
                               "CF R%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, fdh->directive_code,
@@ -120,7 +120,7 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph,
         else
         {
             ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious;
-            CFE_EVS_SendEvent(CF_CFDP_S_DC_INV_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_DC_INV, CFE_EVS_EventType_ERROR,
                               "CF S%d(%lu:%lu): received PDU with invalid directive code %d for sub-state %d",
                               (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, fdh->directive_code,
@@ -129,7 +129,7 @@ void CF_CFDP_S_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph,
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CFDP_S_NON_FD_PDU_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_NON_FD_PDU, CFE_EVS_EventType_ERROR,
                           "CF S%d(%lu:%lu): received non-file directive PDU", (txn->state == CF_TxnState_S2),
                           (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
     }

--- a/fsw/src/cf_cfdp_r.c
+++ b/fsw/src/cf_cfdp_r.c
@@ -94,7 +94,7 @@ CFE_Status_t CF_CFDP_R_CheckCrc(CF_Transaction_t *txn, uint32 expected_crc)
     CF_CRC_Finalize(&txn->crc);
     if (txn->crc.result != expected_crc)
     {
-        CFE_EVS_SendEvent(CF_CFDP_R_CRC_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_CRC, CFE_EVS_EventType_ERROR,
                           "CF R%d(%lu:%lu): CRC mismatch for R trans. got 0x%08lx expected 0x%08lx",
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num, (unsigned long)txn->crc.result,
@@ -152,7 +152,7 @@ void CF_CFDP_R2_Complete(CF_Transaction_t *txn, int ok_to_send_nak)
             /* Check limit and handle if needed */
             if (txn->state_data.receive.r2.acknak_count >= CF_AppData.config_table->chan[txn->chan_num].nak_limit)
             {
-                CFE_EVS_SendEvent(CF_CFDP_R_NAK_LIMIT_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_NAK_LIMIT, CFE_EVS_EventType_ERROR,
                                   "CF R%d(%lu:%lu): NAK limited reach", (txn->state == CF_TxnState_R2),
                                   (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
                 send_fin = 1;
@@ -208,7 +208,7 @@ CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *
         fret = CF_WrappedLseek(txn->fd, fd->offset, OS_SEEK_SET);
         if (fret != fd->offset)
         {
-            CFE_EVS_SendEvent(CF_CFDP_R_SEEK_FD_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_SEEK_FD, CFE_EVS_EventType_ERROR,
                               "CF R%d(%lu:%lu): failed to seek offset %ld, got %ld", (txn->state == CF_TxnState_R2),
                               (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                               (long)fd->offset, (long)fret);
@@ -223,7 +223,7 @@ CFE_Status_t CF_CFDP_R_ProcessFd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *
         fret = CF_WrappedWrite(txn->fd, fd->data_ptr, fd->data_len);
         if (fret != fd->data_len)
         {
-            CFE_EVS_SendEvent(CF_CFDP_R_WRITE_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_WRITE, CFE_EVS_EventType_ERROR,
                               "CF R%d(%lu:%lu): OS_write expected %ld, got %ld", (txn->state == CF_TxnState_R2),
                               (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                               (long)fd->data_len, (long)fret);
@@ -260,7 +260,7 @@ CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *txn, CF_Logical_PduBuff
         /* only check size if MD received, otherwise it's still OK */
         if (txn->flags.rx.md_recv && (eof->size != txn->fsize))
         {
-            CFE_EVS_SendEvent(CF_CFDP_R_SIZE_MISMATCH_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_SIZE_MISMATCH, CFE_EVS_EventType_ERROR,
                               "CF R%d(%lu:%lu): EOF file size mismatch: got %lu expected %lu",
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, (unsigned long)eof->size,
@@ -271,7 +271,7 @@ CFE_Status_t CF_CFDP_R_SubstateRecvEof(CF_Transaction_t *txn, CF_Logical_PduBuff
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CFDP_R_PDU_EOF_ERR_EID, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid EOF packet",
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_EOF, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid EOF packet",
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num);
         ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -534,7 +534,7 @@ CFE_Status_t CF_CFDP_R_SubstateSendNak(CF_Transaction_t *txn)
         {
             /* need to send simple NAK packet to request metadata PDU again */
             /* after doing so, transition to recv md state */
-            CFE_EVS_SendEvent(CF_CFDP_R_REQUEST_MD_INF_EID, CFE_EVS_EventType_INFORMATION,
+            CFE_EVS_SendEvent(CF_EID_INF_CFDP_R_REQUEST_MD, CFE_EVS_EventType_INFORMATION,
                               "CF R%d(%lu:%lu): requesting MD", (txn->state == CF_TxnState_R2),
                               (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
             /* scope start/end, and sr[0] start/end == 0 special value to request metadata */
@@ -577,7 +577,7 @@ void CF_CFDP_R_Init(CF_Transaction_t *txn)
             /* the -1 below is to make room for the slash */
             snprintf(txn->history->fnames.dst_filename, sizeof(txn->history->fnames.dst_filename) - 1, "%.*s/%lu.tmp",
                      CF_FILENAME_MAX_PATH - 1, CF_AppData.config_table->tmp_dir, (unsigned long)txn->history->seq_num);
-            CFE_EVS_SendEvent(CF_CFDP_R_TEMP_FILE_INF_EID, CFE_EVS_EventType_INFORMATION,
+            CFE_EVS_SendEvent(CF_EID_INF_CFDP_R_TEMP_FILE, CFE_EVS_EventType_INFORMATION,
                               "CF R%d(%lu:%lu): making temp file %s for transaction without MD",
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, txn->history->fnames.dst_filename);
@@ -590,7 +590,7 @@ void CF_CFDP_R_Init(CF_Transaction_t *txn)
                                OS_READ_WRITE);
     if (ret < 0)
     {
-        CFE_EVS_SendEvent(CF_CFDP_R_CREAT_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_CREAT, CFE_EVS_EventType_ERROR,
                           "CF R%d(%lu:%lu): failed to create file %s for writing, error=%ld",
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num, txn->history->fnames.dst_filename, (long)ret);
@@ -656,7 +656,7 @@ CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *txn)
             fret = CF_WrappedLseek(txn->fd, txn->state_data.receive.r2.rx_crc_calc_bytes, OS_SEEK_SET);
             if (fret != txn->state_data.receive.r2.rx_crc_calc_bytes)
             {
-                CFE_EVS_SendEvent(CF_CFDP_R_SEEK_CRC_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_SEEK_CRC, CFE_EVS_EventType_ERROR,
                                   "CF R%d(%lu:%lu): failed to seek offset %lu, got %ld", (txn->state == CF_TxnState_R2),
                                   (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                                   (unsigned long)txn->state_data.receive.r2.rx_crc_calc_bytes, (long)fret);
@@ -670,7 +670,7 @@ CFE_Status_t CF_CFDP_R2_CalcCrcChunk(CF_Transaction_t *txn)
         fret = CF_WrappedRead(txn->fd, buf, read_size);
         if (fret != read_size)
         {
-            CFE_EVS_SendEvent(CF_CFDP_R_READ_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_READ, CFE_EVS_EventType_ERROR,
                               "CF R%d(%lu:%lu): failed to read file expected %lu, got %ld",
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, (unsigned long)read_size, (long)fret);
@@ -763,7 +763,7 @@ void CF_CFDP_R2_Recv_fin_ack(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CFDP_R_PDU_FINACK_ERR_EID, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid fin-ack",
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_FINACK, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid fin-ack",
                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                           (unsigned long)txn->history->seq_num);
         ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -803,7 +803,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                 /* EOF was received, so check that md and EOF sizes match */
                 if (txn->state_data.receive.r2.eof_size != txn->fsize)
                 {
-                    CFE_EVS_SendEvent(CF_CFDP_R_EOF_MD_SIZE_ERR_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_EOF_MD_SIZE, CFE_EVS_EventType_ERROR,
                                       "CF R%d(%lu:%lu): EOF/md size mismatch md: %lu, EOF: %lu",
                                       (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                                       (unsigned long)txn->history->seq_num, (unsigned long)txn->fsize,
@@ -826,7 +826,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                 CFE_ES_PerfLogExit(CF_PERF_ID_RENAME);
                 if (status != OS_SUCCESS)
                 {
-                    CFE_EVS_SendEvent(CF_CFDP_R_RENAME_ERR_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_RENAME, CFE_EVS_EventType_ERROR,
                                       "CF R%d(%lu:%lu): failed to rename file in R2, error=%ld",
                                       (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                                       (unsigned long)txn->history->seq_num, (long)status);
@@ -841,7 +841,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
                                                OS_READ_WRITE);
                     if (ret < 0)
                     {
-                        CFE_EVS_SendEvent(CF_CFDP_R_OPEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_OPEN, CFE_EVS_EventType_ERROR,
                                           "CF R%d(%lu:%lu): failed to open renamed file in R2, error=%ld",
                                           (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                                           (unsigned long)txn->history->seq_num, (long)ret);
@@ -863,7 +863,7 @@ void CF_CFDP_R2_RecvMd(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         }
         else
         {
-            CFE_EVS_SendEvent(CF_CFDP_R_PDU_MD_ERR_EID, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid md received",
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_PDU_MD, CFE_EVS_EventType_ERROR, "CF R%d(%lu:%lu): invalid md received",
                               (txn->state == CF_TxnState_R2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num);
             ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -943,7 +943,7 @@ void CF_CFDP_R_Cancel(CF_Transaction_t *txn)
  *-----------------------------------------------------------------*/
 void CF_CFDP_R_SendInactivityEvent(CF_Transaction_t *txn)
 {
-    CFE_EVS_SendEvent(CF_CFDP_R_INACT_TIMER_ERR_EID, CFE_EVS_EventType_ERROR,
+    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_INACT_TIMER, CFE_EVS_EventType_ERROR,
                       "CF R%d(%lu:%lu): inactivity timer expired", (txn->state == CF_TxnState_R2),
                       (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
     ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.inactivity_timer;
@@ -1034,7 +1034,7 @@ void CF_CFDP_R_Tick(CF_Transaction_t *txn, int *cont /* unused */)
                     if (txn->state_data.receive.r2.acknak_count >=
                         CF_AppData.config_table->chan[txn->chan_num].ack_limit)
                     {
-                        CFE_EVS_SendEvent(CF_CFDP_R_ACK_LIMIT_ERR_EID, CFE_EVS_EventType_ERROR,
+                        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_R_ACK_LIMIT, CFE_EVS_EventType_ERROR,
                                           "CF R2(%lu:%lu): ACK limit reached, no fin-ack",
                                           (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
                         CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_ACK_LIMIT_NO_FIN);

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -167,7 +167,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *txn, uint32 foffs, uint32 
             status = CF_WrappedLseek(txn->fd, foffs, OS_SEEK_SET);
             if (status != foffs)
             {
-                CFE_EVS_SendEvent(CF_CFDP_S_SEEK_FD_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEEK_FD, CFE_EVS_EventType_ERROR,
                                   "CF S%d(%lu:%lu): error seeking to offset %ld, got %ld",
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, (long)foffs, (long)status);
@@ -181,7 +181,7 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *txn, uint32 foffs, uint32 
             status = CF_WrappedRead(txn->fd, data_ptr, actual_bytes);
             if (status != actual_bytes)
             {
-                CFE_EVS_SendEvent(CF_CFDP_S_READ_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_READ, CFE_EVS_EventType_ERROR,
                                   "CF S%d(%lu:%lu): error reading bytes: expected %ld, got %ld",
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, (long)actual_bytes, (long)status);
@@ -337,7 +337,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
     {
         if (OS_FileOpenCheck(txn->history->fnames.src_filename) == OS_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_CFDP_S_ALREADY_OPEN_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_ALREADY_OPEN, CFE_EVS_EventType_ERROR,
                               "CF S%d(%lu:%lu): file %s already open", (txn->state == CF_TxnState_S2),
                               (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                               txn->history->fnames.src_filename);
@@ -350,7 +350,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
             ret = CF_WrappedOpenCreate(&txn->fd, txn->history->fnames.src_filename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
             if (ret < 0)
             {
-                CFE_EVS_SendEvent(CF_CFDP_S_OPEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_OPEN, CFE_EVS_EventType_ERROR,
                                   "CF S%d(%lu:%lu): failed to open file %s, error=%ld", (txn->state == CF_TxnState_S2),
                                   (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num,
                                   txn->history->fnames.src_filename, (long)ret);
@@ -365,7 +365,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
             status = CF_WrappedLseek(txn->fd, 0, OS_SEEK_END);
             if (status < 0)
             {
-                CFE_EVS_SendEvent(CF_CFDP_S_SEEK_END_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEEK_END, CFE_EVS_EventType_ERROR,
                                   "CF S%d(%lu:%lu): failed to seek end file %s, error=%ld",
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, txn->history->fnames.src_filename,
@@ -382,7 +382,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
             status = CF_WrappedLseek(txn->fd, 0, OS_SEEK_SET);
             if (status != 0)
             {
-                CFE_EVS_SendEvent(CF_CFDP_S_SEEK_BEG_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEEK_BEG, CFE_EVS_EventType_ERROR,
                                   "CF S%d(%lu:%lu): failed to seek begin file %s, got %ld",
                                   (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                                   (unsigned long)txn->history->seq_num, txn->history->fnames.src_filename,
@@ -399,7 +399,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn)
         if (sret == CF_SEND_PDU_ERROR)
         {
             /* failed to send md */
-            CFE_EVS_SendEvent(CF_CFDP_S_SEND_MD_ERR_EID, CFE_EVS_EventType_ERROR, "CF S%d(%lu:%lu): failed to send md",
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_SEND_MD, CFE_EVS_EventType_ERROR, "CF S%d(%lu:%lu): failed to send md",
                               (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num);
             success = false;
@@ -448,7 +448,7 @@ void CF_CFDP_S_SubstateSendFinAck(CF_Transaction_t *txn)
 void CF_CFDP_S2_EarlyFin(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 {
     /* received early fin, so just cancel */
-    CFE_EVS_SendEvent(CF_CFDP_S_EARLY_FIN_ERR_EID, CFE_EVS_EventType_ERROR,
+    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_EARLY_FIN, CFE_EVS_EventType_ERROR,
                       "CF S%d(%lu:%lu): got early FIN -- cancelling", (txn->state == CF_TxnState_S2),
                       (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
     CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_EARLY_FIN);
@@ -520,7 +520,7 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
             nak->segment_list.num_segments;
         if (bad_sr)
         {
-            CFE_EVS_SendEvent(CF_CFDP_S_INVALID_SR_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INVALID_SR, CFE_EVS_EventType_ERROR,
                               "CF S%d(%lu:%lu): received %d invalid NAK segment requests",
                               (txn->state == CF_TxnState_S2), (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num, bad_sr);
@@ -528,7 +528,7 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CFDP_S_PDU_NAK_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_NAK, CFE_EVS_EventType_ERROR,
                           "CF S%d(%lu:%lu): received invalid NAK PDU", (txn->state == CF_TxnState_S2),
                           (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
         ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -571,7 +571,7 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CFDP_S_PDU_EOF_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_PDU_EOF, CFE_EVS_EventType_ERROR,
                           "CF S%d(%lu:%lu): received invalid EOF PDU", (txn->state == CF_TxnState_S2),
                           (unsigned long)txn->history->src_eid, (unsigned long)txn->history->seq_num);
         ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error;
@@ -698,7 +698,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *txn, int *cont /* unused */)
     {
         if (CF_Timer_Expired(&txn->inactivity_timer))
         {
-            CFE_EVS_SendEvent(CF_CFDP_S_INACT_TIMER_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_INACT_TIMER, CFE_EVS_EventType_ERROR,
                               "CF S2(%lu:%lu): inactivity timer expired", (unsigned long)txn->history->src_eid,
                               (unsigned long)txn->history->seq_num);
             CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_INACTIVITY_DETECTED);
@@ -723,7 +723,7 @@ void CF_CFDP_S_Tick(CF_Transaction_t *txn, int *cont /* unused */)
                         if (txn->state_data.send.s2.acknak_count >=
                             CF_AppData.config_table->chan[txn->chan_num].ack_limit)
                         {
-                            CFE_EVS_SendEvent(CF_CFDP_S_ACK_LIMIT_ERR_EID, CFE_EVS_EventType_ERROR,
+                            CFE_EVS_SendEvent(CF_EID_ERR_CFDP_S_ACK_LIMIT, CFE_EVS_EventType_ERROR,
                                               "CF S2(%lu:%lu), ack limit reached, no eof-ack",
                                               (unsigned long)txn->history->src_eid,
                                               (unsigned long)txn->history->seq_num);

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -109,7 +109,7 @@ CF_Logical_PduBuffer_t *CF_CFDP_MsgOutGet(const CF_Transaction_t *txn, bool sile
             chan->cur = txn; /* remember where we were for next time */
             if (!silent && (os_status == OS_SUCCESS))
             {
-                CFE_EVS_SendEvent(CF_CFDP_NO_MSG_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CFDP_NO_MSG, CFE_EVS_EventType_ERROR,
                                   "CF: no output message buffer available");
             }
             success = false;
@@ -268,7 +268,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
                     if (CF_AppData.hk.Payload.channel_hk[chan_num].q_size[CF_QueueIdx_RX] == CF_MAX_SIMULTANEOUS_RX)
                     {
                         CFE_EVS_SendEvent(
-                            CF_CFDP_RX_DROPPED_ERR_EID, CFE_EVS_EventType_ERROR,
+                            CF_EID_ERR_CFDP_RX_DROPPED, CFE_EVS_EventType_ERROR,
                             "CF: dropping packet from %lu transaction number 0x%08lx due max RX transactions reached",
                             (unsigned long)ph->pdu_header.source_eid, (unsigned long)ph->pdu_header.sequence_num);
 
@@ -292,7 +292,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CF_CFDP_INVALID_DST_ERR_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CF_EID_ERR_CFDP_INVALID_DST_EID, CFE_EVS_EventType_ERROR,
                                       "CF: dropping packet for invalid destination eid 0x%lx",
                                       (unsigned long)ph->pdu_header.destination_eid);
                 }

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -72,7 +72,7 @@ CFE_Status_t CF_ResetCmd(const CF_ResetCmd_t *msg)
 
     if (param > 4)
     {
-        CFE_EVS_SendEvent(CF_CMD_RESET_INVALID_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_RESET_INVALID, CFE_EVS_EventType_ERROR,
                           "CF: Received RESET COUNTERS command with invalid parameter %d", param);
         ++CF_AppData.hk.Payload.counters.err;
     }
@@ -143,7 +143,7 @@ CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg)
     if ((tx->cfdp_class != CF_CFDP_CLASS_1 && tx->cfdp_class != CF_CFDP_CLASS_2) || tx->chan_num >= CF_NUM_CHANNELS ||
         (int)tx->keep > 1)
     {
-        CFE_EVS_SendEvent(CF_CMD_BAD_PARAM_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_BAD_PARAM, CFE_EVS_EventType_ERROR,
                           "CF: bad parameter in CF_TxFileCmd(): chan=%u, class=%u keep=%u", (unsigned int)tx->chan_num,
                           (unsigned int)tx->cfdp_class, (unsigned int)tx->keep);
         ++CF_AppData.hk.Payload.counters.err;
@@ -161,13 +161,13 @@ CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg)
     if (CF_CFDP_TxFile(tx->src_filename, tx->dst_filename, tx->cfdp_class, tx->keep, tx->chan_num, tx->priority,
                        tx->dest_id) == CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_CMD_TX_FILE_INF_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_TX_FILE, CFE_EVS_EventType_INFORMATION,
                           "CF: file transfer successfully initiated");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_TX_FILE_ERR_EID, CFE_EVS_EventType_ERROR, "CF: file transfer initiation failed");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_TX_FILE, CFE_EVS_EventType_ERROR, "CF: file transfer initiation failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
 
@@ -192,7 +192,7 @@ CFE_Status_t CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg)
     if ((tx->cfdp_class != CF_CFDP_CLASS_1 && tx->cfdp_class != CF_CFDP_CLASS_2) || tx->chan_num >= CF_NUM_CHANNELS ||
         (int)tx->keep > 1)
     {
-        CFE_EVS_SendEvent(CF_CMD_BAD_PARAM_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_BAD_PARAM, CFE_EVS_EventType_ERROR,
                           "CF: bad parameter in CF_PlaybackDirCmd(): chan=%u, class=%u keep=%u",
                           (unsigned int)tx->chan_num, (unsigned int)tx->cfdp_class, (unsigned int)tx->keep);
         ++CF_AppData.hk.Payload.counters.err;
@@ -210,13 +210,13 @@ CFE_Status_t CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg)
     if (CF_CFDP_PlaybackDir(tx->src_filename, tx->dst_filename, tx->cfdp_class, tx->keep, tx->chan_num, tx->priority,
                             tx->dest_id) == CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_CMD_PLAYBACK_DIR_INF_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_PLAYBACK_DIR, CFE_EVS_EventType_INFORMATION,
                           "CF: directory playback initiation successful");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_PLAYBACK_DIR_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_PLAYBACK_DIR, CFE_EVS_EventType_ERROR,
                           "CF: directory playback initiation failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
@@ -252,7 +252,7 @@ CF_ChanAction_Status_t CF_DoChanAction(const CF_UnionArgs_Payload_t *data, const
     else
     {
         /* bad parameter */
-        CFE_EVS_SendEvent(CF_CMD_CHAN_PARAM_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_CHAN_PARAM, CFE_EVS_EventType_ERROR,
                           "CF: %s: channel parameter out of range. received %d", errstr, data->byte[0]);
         ret = CF_ChanAction_Status_ERROR;
     }
@@ -286,12 +286,12 @@ CFE_Status_t CF_FreezeCmd(const CF_FreezeCmd_t *msg)
 
     if (CF_ChanAction_Status_IS_SUCCESS(CF_DoChanAction(&msg->Payload, "freeze", CF_DoFreezeThaw, &barg)))
     {
-        CFE_EVS_SendEvent(CF_CMD_FREEZE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: freeze successful");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_FREEZE, CFE_EVS_EventType_INFORMATION, "CF: freeze successful");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_FREEZE_ERR_EID, CFE_EVS_EventType_ERROR, "CF: freeze cmd failed");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_FREEZE, CFE_EVS_EventType_ERROR, "CF: freeze cmd failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
 
@@ -310,12 +310,12 @@ CFE_Status_t CF_ThawCmd(const CF_ThawCmd_t *msg)
 
     if (CF_ChanAction_Status_IS_SUCCESS(CF_DoChanAction(&msg->Payload, "thaw", CF_DoFreezeThaw, &barg)))
     {
-        CFE_EVS_SendEvent(CF_CMD_THAW_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: thaw successful");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_THAW, CFE_EVS_EventType_INFORMATION, "CF: thaw successful");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_THAW_ERR_EID, CFE_EVS_EventType_ERROR, "CF: thaw cmd failed");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_THAW, CFE_EVS_EventType_ERROR, "CF: thaw cmd failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
 
@@ -374,7 +374,7 @@ int32 CF_TsnChanAction(const CF_Transaction_Payload_t *data, const char *cmdstr,
         }
         else
         {
-            CFE_EVS_SendEvent(CF_CMD_TRANS_NOT_FOUND_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CMD_TRANS_NOT_FOUND, CFE_EVS_EventType_ERROR,
                               "CF: %s cmd: failed to find transaction for (eid %lu, ts %lu)", cmdstr,
                               (unsigned long)data->eid, (unsigned long)data->ts);
         }
@@ -391,7 +391,7 @@ int32 CF_TsnChanAction(const CF_Transaction_Payload_t *data, const char *cmdstr,
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_TSN_CHAN_INVALID_ERR_EID, CFE_EVS_EventType_ERROR, "CF: %s cmd: invalid channel %d",
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_TSN_CHAN_INVALID, CFE_EVS_EventType_ERROR, "CF: %s cmd: invalid channel %d",
                           cmdstr, data->chan);
     }
 
@@ -439,20 +439,20 @@ void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action)
     if (ret == 1 && args.same)
     {
         /* A single transaction was mached, and it was already set the same way */
-        CFE_EVS_SendEvent(CF_CMD_SUSPRES_SAME_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_SUSPRES_SAME, CFE_EVS_EventType_ERROR,
                           "CF: %s cmd: setting suspend flag to current value of %d", msgstr[action], action);
         ++CF_AppData.hk.Payload.counters.err;
     }
     else if (ret <= 0)
     {
         /* No transaction was matched for the given combination of chan + eid + ts  */
-        CFE_EVS_SendEvent(CF_CMD_SUSPRES_CHAN_ERR_EID, CFE_EVS_EventType_ERROR, "CF: %s cmd: no transaction found",
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_SUSPRES_CHAN, CFE_EVS_EventType_ERROR, "CF: %s cmd: no transaction found",
                           msgstr[action]);
         ++CF_AppData.hk.Payload.counters.err;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_SUSPRES_INF_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_SUSPRES, CFE_EVS_EventType_INFORMATION,
                           "CF: %s cmd: setting suspend flag to %d", msgstr[action], action);
         ++CF_AppData.hk.Payload.counters.cmd;
     }
@@ -503,14 +503,14 @@ CFE_Status_t CF_CancelCmd(const CF_CancelCmd_t *msg)
 {
     if (CF_TsnChanAction(&msg->Payload, "cancel", CF_CmdCancel_Txn, NULL) > 0)
     {
-        CFE_EVS_SendEvent(CF_CMD_CANCEL_INF_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_CANCEL, CFE_EVS_EventType_INFORMATION,
                           "CF: cancel transaction successfully initiated");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
         /* No transaction was matched for the given combination of chan + eid + ts  */
-        CFE_EVS_SendEvent(CF_CMD_CANCEL_CHAN_ERR_EID, CFE_EVS_EventType_ERROR, "CF: cancel cmd: no transaction found");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_CANCEL_CHAN, CFE_EVS_EventType_ERROR, "CF: cancel cmd: no transaction found");
         ++CF_AppData.hk.Payload.counters.err;
     }
 
@@ -538,13 +538,13 @@ CFE_Status_t CF_AbandonCmd(const CF_AbandonCmd_t *msg)
 {
     if (CF_TsnChanAction(&msg->Payload, "abandon", CF_CmdAbandon_Txn, NULL) > 0)
     {
-        CFE_EVS_SendEvent(CF_CMD_ABANDON_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: abandon successful");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_ABANDON, CFE_EVS_EventType_INFORMATION, "CF: abandon successful");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
         /* No transaction was matched for the given combination of chan + eid + ts  */
-        CFE_EVS_SendEvent(CF_CMD_ABANDON_CHAN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ABANDON_CHAN, CFE_EVS_EventType_ERROR,
                           "CF: abandon cmd: no transaction found");
         ++CF_AppData.hk.Payload.counters.err;
     }
@@ -579,12 +579,12 @@ CFE_Status_t CF_EnableDequeueCmd(const CF_EnableDequeueCmd_t *msg)
     if (CF_ChanAction_Status_IS_SUCCESS(
             CF_DoChanAction(&msg->Payload, "enable_dequeue", CF_DoEnableDisableDequeue, &barg)))
     {
-        CFE_EVS_SendEvent(CF_CMD_ENABLE_DEQUEUE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: dequeue enabled");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_ENABLE_DEQUEUE, CFE_EVS_EventType_INFORMATION, "CF: dequeue enabled");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_ENABLE_DEQUEUE_ERR_EID, CFE_EVS_EventType_ERROR, "CF: enable dequeue cmd failed");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_DEQUEUE, CFE_EVS_EventType_ERROR, "CF: enable dequeue cmd failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
 
@@ -604,12 +604,12 @@ CFE_Status_t CF_DisableDequeueCmd(const CF_DisableDequeueCmd_t *msg)
     if (CF_ChanAction_Status_IS_SUCCESS(
             CF_DoChanAction(&msg->Payload, "disable_dequeue", CF_DoEnableDisableDequeue, &barg)))
     {
-        CFE_EVS_SendEvent(CF_CMD_DISABLE_DEQUEUE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: dequeue disabled");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_DISABLE_DEQUEUE, CFE_EVS_EventType_INFORMATION, "CF: dequeue disabled");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_DISABLE_DEQUEUE_ERR_EID, CFE_EVS_EventType_ERROR, "CF: disable dequeue cmd failed");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_DISABLE_DEQUEUE, CFE_EVS_EventType_ERROR, "CF: disable dequeue cmd failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
 
@@ -640,7 +640,7 @@ CF_ChanAction_Status_t CF_DoEnableDisablePolldir(uint8 chan_num, void *arg)
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_POLLDIR_INVALID_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_POLLDIR_INVALID, CFE_EVS_EventType_ERROR,
                           "CF: enable/disable polldir: invalid polldir %d on channel %d", context->data->byte[1],
                           chan_num);
         ret = CF_ChanAction_Status_ERROR;
@@ -662,13 +662,13 @@ CFE_Status_t CF_EnableDirPollingCmd(const CF_EnableDirPollingCmd_t *msg)
     if (CF_ChanAction_Status_IS_SUCCESS(
             CF_DoChanAction(&msg->Payload, "enable_polldir", CF_DoEnableDisablePolldir, &barg)))
     {
-        CFE_EVS_SendEvent(CF_CMD_ENABLE_POLLDIR_INF_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_ENABLE_POLLDIR, CFE_EVS_EventType_INFORMATION,
                           "CF: enabled polling directory");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_ENABLE_POLLDIR_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_POLLDIR, CFE_EVS_EventType_ERROR,
                           "CF: enable polling directory cmd failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
@@ -689,13 +689,13 @@ CFE_Status_t CF_DisableDirPollingCmd(const CF_DisableDirPollingCmd_t *msg)
     if (CF_ChanAction_Status_IS_SUCCESS(
             CF_DoChanAction(&msg->Payload, "disable_polldir", CF_DoEnableDisablePolldir, &barg)))
     {
-        CFE_EVS_SendEvent(CF_CMD_DISABLE_POLLDIR_INF_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_DISABLE_POLLDIR, CFE_EVS_EventType_INFORMATION,
                           "CF: disabled polling directory");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_DISABLE_POLLDIR_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_DISABLE_POLLDIR, CFE_EVS_EventType_ERROR,
                           "CF: disable polling directory cmd failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
@@ -762,7 +762,7 @@ CF_ChanAction_Status_t CF_DoPurgeQueue(uint8 chan_num, void *arg)
             break;
 
         default:
-            CFE_EVS_SendEvent(CF_CMD_PURGE_ARG_ERR_EID, CFE_EVS_EventType_ERROR, "CF: purge queue invalid arg %d",
+            CFE_EVS_SendEvent(CF_EID_ERR_CMD_PURGE_ARG, CFE_EVS_EventType_ERROR, "CF: purge queue invalid arg %d",
                               data->byte[1]);
             ret = CF_ChanAction_Status_ERROR;
             break;
@@ -792,12 +792,12 @@ CFE_Status_t CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg)
     CF_ChanAction_MsgArg_t arg = {&msg->Payload};
     if (CF_ChanAction_Status_IS_SUCCESS(CF_DoChanAction(&msg->Payload, "purge_queue", CF_DoPurgeQueue, &arg)))
     {
-        CFE_EVS_SendEvent(CF_CMD_PURGE_QUEUE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: queue purged");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_PURGE_QUEUE, CFE_EVS_EventType_INFORMATION, "CF: queue purged");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_PURGE_QUEUE_ERR_EID, CFE_EVS_EventType_ERROR, "CF: purge queue cmd failed");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_PURGE_QUEUE, CFE_EVS_EventType_ERROR, "CF: purge queue cmd failed");
         ++CF_AppData.hk.Payload.counters.err;
     }
 
@@ -822,14 +822,14 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
     /* check the commands for validity */
     if (wq->chan >= CF_NUM_CHANNELS)
     {
-        CFE_EVS_SendEvent(CF_CMD_WQ_CHAN_ERR_EID, CFE_EVS_EventType_ERROR, "CF: write queue invalid channel arg");
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_CHAN, CFE_EVS_EventType_ERROR, "CF: write queue invalid channel arg");
         ++CF_AppData.hk.Payload.counters.err;
         success = false;
     }
     /* only invalid combination is up direction, pending queue */
     else if ((wq->type == CF_Type_up) && (wq->queue == CF_Queue_pend))
     {
-        CFE_EVS_SendEvent(CF_CMD_WQ_ARGS_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_ARGS, CFE_EVS_EventType_ERROR,
                           "CF: write queue invalid command parameters");
         ++CF_AppData.hk.Payload.counters.err;
         success = false;
@@ -841,7 +841,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
         ret = CF_WrappedOpenCreate(&fd, wq->filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
         if (ret < 0)
         {
-            CFE_EVS_SendEvent(CF_CMD_WQ_OPEN_ERR_EID, CFE_EVS_EventType_ERROR, "CF: write queue failed to open file %s",
+            CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_OPEN, CFE_EVS_EventType_ERROR, "CF: write queue failed to open file %s",
                               wq->filename);
             ++CF_AppData.hk.Payload.counters.err;
             success = false;
@@ -857,7 +857,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
             ret = CF_WriteTxnQueueDataToFile(fd, chan, CF_QueueIdx_RX);
             if (ret)
             {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_RX_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_RX, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write CF_QueueIdx_RX data");
                 CF_WrappedClose(fd);
                 ++CF_AppData.hk.Payload.counters.err;
@@ -870,7 +870,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
             ret = CF_WriteHistoryQueueDataToFile(fd, chan, CF_Direction_RX);
             if (ret)
             {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEHIST_RX_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEHIST_RX, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write history RX data");
                 CF_WrappedClose(fd);
                 ++CF_AppData.hk.Payload.counters.err;
@@ -892,7 +892,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
                 ret = CF_WriteTxnQueueDataToFile(fd, chan, qs[i]);
                 if (ret)
                 {
-                    CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_TX_ERR_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_TX, CFE_EVS_EventType_ERROR,
                                       "CF: write queue failed to write q index %d", qs[i]);
                     CF_WrappedClose(fd);
                     ++CF_AppData.hk.Payload.counters.err;
@@ -908,7 +908,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
             ret = CF_WriteTxnQueueDataToFile(fd, chan, CF_QueueIdx_PEND);
             if (ret)
             {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_PEND_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEQ_PEND, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write pending queue");
                 CF_WrappedClose(fd);
                 ++CF_AppData.hk.Payload.counters.err;
@@ -922,7 +922,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
             ret = CF_WriteHistoryQueueDataToFile(fd, chan, CF_Direction_TX);
             if (ret)
             {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEHIST_TX_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CMD_WQ_WRITEHIST_TX, CFE_EVS_EventType_ERROR,
                                   "CF: write queue failed to write CF_QueueIdx_TX data");
                 CF_WrappedClose(fd);
                 ++CF_AppData.hk.Payload.counters.err;
@@ -933,7 +933,7 @@ CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
 
     if (success)
     {
-        CFE_EVS_SendEvent(CF_CMD_WQ_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: write queue successful");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_WQ, CFE_EVS_EventType_INFORMATION, "CF: write queue successful");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
 
@@ -1047,12 +1047,12 @@ void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
 
     if (item.size == 0)
     {
-        CFE_EVS_SendEvent(CF_CMD_GETSET_PARAM_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_GETSET_PARAM, CFE_EVS_EventType_ERROR,
                           "CF: invalid configuration parameter id %d received", param_id);
     }
     else if (chan_num >= CF_NUM_CHANNELS)
     {
-        CFE_EVS_SendEvent(CF_CMD_GETSET_CHAN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_GETSET_CHAN, CFE_EVS_EventType_ERROR,
                           "CF: invalid configuration channel id %d received", chan_num);
     }
     else if (is_set)
@@ -1065,7 +1065,7 @@ void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
             }
             else
             {
-                CFE_EVS_SendEvent(CF_CMD_GETSET_VALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_EVS_SendEvent(CF_EID_ERR_CMD_GETSET_VALIDATE, CFE_EVS_EventType_ERROR,
                                   "CF: validation for parameter id %d failed", param_id);
             }
         }
@@ -1078,7 +1078,7 @@ void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
         {
             status = CFE_SUCCESS;
 
-            CFE_EVS_SendEvent(CF_CMD_GETSET1_INF_EID, CFE_EVS_EventType_INFORMATION,
+            CFE_EVS_SendEvent(CF_EID_INF_CMD_GETSET1, CFE_EVS_EventType_INFORMATION,
                               "CF: setting parameter id %d to %lu", param_id, (unsigned long)value);
 
             /* Store value based on its size */
@@ -1116,7 +1116,7 @@ void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value,
             value = *((const uint8 *)item.ptr);
         }
 
-        CFE_EVS_SendEvent(CF_CMD_GETSET2_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: parameter id %d = %lu", param_id,
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_GETSET2, CFE_EVS_EventType_INFORMATION, "CF: parameter id %d = %lu", param_id,
                           (unsigned long)value);
     }
 
@@ -1172,19 +1172,19 @@ CFE_Status_t CF_EnableEngineCmd(const CF_EnableEngineCmd_t *msg)
     {
         if (CF_CFDP_InitEngine() == CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CF_CMD_ENABLE_ENGINE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: enabled CFDP engine");
+            CFE_EVS_SendEvent(CF_EID_INF_CMD_ENABLE_ENGINE, CFE_EVS_EventType_INFORMATION, "CF: enabled CFDP engine");
             ++CF_AppData.hk.Payload.counters.cmd;
         }
         else
         {
-            CFE_EVS_SendEvent(CF_CMD_ENABLE_ENGINE_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENABLE_ENGINE, CFE_EVS_EventType_ERROR,
                               "CF: failed to re-initialize and enable CFDP engine");
             ++CF_AppData.hk.Payload.counters.err;
         }
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_ENG_ALREADY_ENA_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENG_ALREADY_ENA, CFE_EVS_EventType_ERROR,
                           "CF: received enable engine command while engine already enabled");
         ++CF_AppData.hk.Payload.counters.err;
     }
@@ -1203,12 +1203,12 @@ CFE_Status_t CF_DisableEngineCmd(const CF_DisableEngineCmd_t *msg)
     if (CF_AppData.engine.enabled)
     {
         CF_CFDP_DisableEngine();
-        CFE_EVS_SendEvent(CF_CMD_DISABLE_ENGINE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: disabled CFDP engine");
+        CFE_EVS_SendEvent(CF_EID_INF_CMD_DISABLE_ENGINE, CFE_EVS_EventType_INFORMATION, "CF: disabled CFDP engine");
         ++CF_AppData.hk.Payload.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_ENG_ALREADY_DIS_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CMD_ENG_ALREADY_DIS, CFE_EVS_EventType_ERROR,
                           "CF: received disable engine command while engine already disabled");
         ++CF_AppData.hk.Payload.counters.err;
     }

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -184,27 +184,24 @@ CFE_Status_t CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *histor
         {
             case 0:
                 CF_Assert(history->dir < CF_Direction_NUM);
-                /* SAD: No need to check snprintf return; buffer size is sufficient for the formatted output */
                 snprintf(linebuf, sizeof(linebuf), "SEQ (%lu, %lu)\tDIR: %s\tPEER %lu\tSTAT: %d\t",
                          (unsigned long)history->src_eid, (unsigned long)history->seq_num, CF_DSTR[history->dir],
                          (unsigned long)history->peer_eid, (int)history->txn_stat);
                 break;
             case 1:
-                /* SAD: No need to check snprintf return; buffer size is sufficient for the formatted output */
                 snprintf(linebuf, sizeof(linebuf), "SRC: %s\t", history->fnames.src_filename);
                 break;
             case 2:
             default:
-                /* SAD: No need to check snprintf return; buffer size is sufficient for the formatted output */
                 snprintf(linebuf, sizeof(linebuf), "DST: %s\n", history->fnames.dst_filename);
                 break;
         }
 
-        len = OS_strnlen(linebuf, (CF_FILENAME_MAX_LEN * 2) + 128);
+        len = strlen(linebuf);
         ret = CF_WrappedWrite(fd, linebuf, len);
         if (ret != len)
         {
-            CFE_EVS_SendEvent(CF_CMD_WHIST_WRITE_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CF_EID_ERR_CMD_WHIST_WRITE, CFE_EVS_EventType_ERROR,
                               "CF: writing queue file failed, expected %ld got %ld", (long)len, (long)ret);
             return CF_ERROR;
         }
@@ -444,7 +441,7 @@ void CF_WrappedClose(osal_id_t fd)
 
     if (ret != OS_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_CFDP_CLOSE_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CF_EID_ERR_CFDP_CLOSE_ERR, CFE_EVS_EventType_ERROR,
                           "CF: failed to close file 0x%lx, OS_close returned %ld", OS_ObjectIdToInteger(fd), (long)ret);
     }
 }

--- a/fsw/tables/cf_def_config.c
+++ b/fsw/tables/cf_def_config.c
@@ -80,5 +80,6 @@ CF_ConfigTable_t CF_config_table = {
       .move_dir = ""}},
     480,       /* outgoing_file_chunk_size */
     "/cf/tmp", /* temporary file directory */
+    "/cf/fail", /* Stores failed tx file for "polling directory" */
 };
 CFE_TBL_FILEDEF(CF_config_table, CF.config_table, CF config table, cf_def_config.tbl)

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -275,7 +275,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Register_DidNotReturnSuccess(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_INIT_TBL_REG_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_REG);
 }
 
 void Test_CF_TableInit_FailBecause_CFE_TBL_Load_DidNotReturnSuccess(void)
@@ -289,7 +289,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Load_DidNotReturnSuccess(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_INIT_TBL_LOAD_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_LOAD);
 }
 
 void Test_CF_TableInit_FailBecause_CFE_TBL_Manage_DidNotReturnSuccess(void)
@@ -304,7 +304,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_Manage_DidNotReturnSuccess(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_INIT_TBL_MANAGE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_MANAGE);
 }
 
 void Test_CF_TableInit_FailBecause_CFE_TBL_GetAddress_DidNotReturnSuccess(void)
@@ -319,7 +319,7 @@ void Test_CF_TableInit_FailBecause_CFE_TBL_GetAddress_DidNotReturnSuccess(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_INIT_TBL_GETADDR_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_INIT_TBL_GETADDR);
 }
 
 void Test_CF_TableInit_When_CFE_TBL_GetAddress_Returns_CFE_SUCCESS_SuccessAndDoNotSendEvent(void)
@@ -517,7 +517,7 @@ void Test_CF_AppMain_CFE_SB_ReceiveBuffer_Cases(void)
     /* Event from CF_Init and CF_AppMain */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_INIT_INF_EID);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_INIT_MSG_RECV_ERR_EID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_INIT_MSG_RECV);
 
     /* Reset, return CFE_SUCCESS from CFE_SB_ReceiveBuffer and buffer NULL */
     UT_CF_ResetEventCapture();
@@ -529,7 +529,7 @@ void Test_CF_AppMain_CFE_SB_ReceiveBuffer_Cases(void)
     /* Event from CF_Init and CF_AppMain */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_INIT_INF_EID);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_INIT_MSG_RECV_ERR_EID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_INIT_MSG_RECV);
 
     /* Reset, return non-error codes and non-NULL buffer */
     UT_CF_ResetEventCapture();

--- a/unit-test/cf_cfdp_dispatch_tests.c
+++ b/unit-test/cf_cfdp_dispatch_tests.c
@@ -155,7 +155,7 @@ void Test_CF_CFDP_R_DispatchRecv(void)
     ph->fdirective.directive_code = CF_CFDP_FileDirective_INVALID_MAX;
     UtAssert_VOIDCALL(CF_CFDP_R_DispatchRecv(txn, ph, &dispatch, NULL));
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious, 1);
-    UT_CF_AssertEventID(CF_CFDP_R_DC_INV_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_DC_INV);
 
     /* file data with error */
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
@@ -207,7 +207,7 @@ void Test_CF_CFDP_S_DispatchRecv(void)
     ph->fdirective.directive_code = CF_CFDP_FileDirective_INVALID_MAX;
     UtAssert_VOIDCALL(CF_CFDP_S_DispatchRecv(txn, ph, &dispatch));
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious, 1);
-    UT_CF_AssertEventID(CF_CFDP_S_DC_INV_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_DC_INV);
 
     /* file data PDU, not expected in this type of txn */
     UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -360,7 +360,7 @@ void Test_CF_CFDP_R_Init(void)
     txn->state = CF_TxnState_R2;
     UtAssert_VOIDCALL(CF_CFDP_R_Init(txn));
     UtAssert_STUB_COUNT(CF_CFDP_ArmAckTimer, 1);
-    UT_CF_AssertEventID(CF_CFDP_R_TEMP_FILE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CFDP_R_TEMP_FILE);
 
     /* nominal, R2 state, with md_recv (no tempfile) */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
@@ -375,7 +375,7 @@ void Test_CF_CFDP_R_Init(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, -1);
     txn->state = CF_TxnState_R1;
     UtAssert_VOIDCALL(CF_CFDP_R_Init(txn));
-    UT_CF_AssertEventID(CF_CFDP_R_CREAT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CREAT);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 1);
 
@@ -384,7 +384,7 @@ void Test_CF_CFDP_R_Init(void)
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, -1);
     txn->state = CF_TxnState_R2;
     UtAssert_VOIDCALL(CF_CFDP_R_Init(txn));
-    UT_CF_AssertEventID(CF_CFDP_R_CREAT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CREAT);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 2);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 }
@@ -463,7 +463,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     txn->state      = CF_TxnState_R1;
     txn->crc.result = 0xdeadbeef;
     UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x1badc0de), 1);
-    UT_CF_AssertEventID(CF_CFDP_R_CRC_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 1);
 
     /* CRC mismatch, class 2 */
@@ -471,7 +471,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     txn->state      = CF_TxnState_R2;
     txn->crc.result = 0xdeadbeef;
     UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x2badc0de), 1);
-    UT_CF_AssertEventID(CF_CFDP_R_CRC_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_CRC);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 2);
 
     /* CRC match */
@@ -511,7 +511,7 @@ void Test_CF_CFDP_R2_Complete(void)
     UtAssert_VOIDCALL(CF_CFDP_R2_Complete(txn, 1));
     UtAssert_BOOL_TRUE(txn->flags.rx.send_fin);
     UtAssert_BOOL_TRUE(txn->flags.rx.complete);
-    UT_CF_AssertEventID(CF_CFDP_R_NAK_LIMIT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_NAK_LIMIT);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.nak_limit, 1);
 
     /* test with md_recv - with no more setup this only sets filedata state */
@@ -578,7 +578,7 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_WrappedWrite), -1);
     UtAssert_INT32_EQ(CF_CFDP_R_ProcessFd(txn, ph), -1);
     UtAssert_UINT32_EQ(txn->state_data.receive.cached_pos, 300);
-    UT_CF_AssertEventID(CF_CFDP_R_WRITE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_WRITE);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* call again, but with a failed lseek */
@@ -590,7 +590,7 @@ void Test_CF_CFDP_R_ProcessFd(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_WrappedLseek), -1);
     UtAssert_INT32_EQ(CF_CFDP_R_ProcessFd(txn, ph), -1);
     UtAssert_UINT32_EQ(txn->state_data.receive.cached_pos, 300);
-    UT_CF_AssertEventID(CF_CFDP_R_SEEK_FD_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_SEEK_FD);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
 
     /* these stats should have been updated during the course of this test */
@@ -626,13 +626,13 @@ void Test_CF_CFDP_R_SubstateRecvEof(void)
     eof->size             = 100;
     txn->fsize            = 300;
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateRecvEof(txn, ph), CF_REC_PDU_FSIZE_MISMATCH_ERROR);
-    UT_CF_AssertEventID(CF_CFDP_R_SIZE_MISMATCH_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_SIZE_MISMATCH);
 
     /* with failure of CF_CFDP_RecvEof() */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_RecvEof), -1);
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateRecvEof(txn, ph), CF_REC_PDU_BAD_EOF_ERROR);
-    UT_CF_AssertEventID(CF_CFDP_R_PDU_EOF_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_EOF);
 
     /* these counters should have been updated during the test */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[UT_CFDP_CHANNEL].counters.fault.file_size_mismatch, 1);
@@ -853,14 +853,14 @@ void Test_CF_CFDP_R_SubstateSendNak(void)
     /* with md_recv flag false, this should request one by sending a blank NAK */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, &txn, NULL);
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateSendNak(txn), 0);
-    UT_CF_AssertEventID(CF_CFDP_R_REQUEST_MD_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CFDP_R_REQUEST_MD);
     UtAssert_STUB_COUNT(CF_CFDP_SendNak, 1);
 
     /* same, but with failure of CF_CFDP_SendNak */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_TX, &ph, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendNak), 1, CF_SEND_PDU_NO_BUF_AVAIL_ERROR);
     UtAssert_INT32_EQ(CF_CFDP_R_SubstateSendNak(txn), -1);
-    UT_CF_AssertEventID(CF_CFDP_R_REQUEST_MD_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CFDP_R_REQUEST_MD);
     UtAssert_STUB_COUNT(CF_CFDP_SendNak, 2);
 
     /* with md_recv flag true, this should call gap compute to assemble the NAK */
@@ -962,7 +962,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk(void)
     txn->fsize                           = 50;
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedRead), 1, -1);
     UtAssert_INT32_EQ(CF_CFDP_R2_CalcCrcChunk(txn), -1);
-    UT_CF_AssertEventID(CF_CFDP_R_READ_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_READ);
     UtAssert_BOOL_FALSE(txn->flags.com.crc_calc);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_read, 1);
@@ -975,7 +975,7 @@ void Test_CF_CFDP_R2_CalcCrcChunk(void)
     txn->fsize                                   = 50;
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedLseek), 1, -1);
     UtAssert_INT32_EQ(CF_CFDP_R2_CalcCrcChunk(txn), -1);
-    UT_CF_AssertEventID(CF_CFDP_R_SEEK_CRC_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_SEEK_CRC);
     UtAssert_BOOL_FALSE(txn->flags.com.crc_calc);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
@@ -1030,7 +1030,7 @@ void Test_CF_CFDP_R2_Recv_fin_ack(void)
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvAck), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_R2_Recv_fin_ack(txn, ph));
-    UT_CF_AssertEventID(CF_CFDP_R_PDU_FINACK_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_FINACK);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 }
 
@@ -1069,28 +1069,28 @@ void Test_CF_CFDP_R2_RecvMd(void)
     txn->state_data.receive.r2.eof_size = 120;
     txn->flags.rx.eof_recv              = true;
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(txn, ph));
-    UT_CF_AssertEventID(CF_CFDP_R_EOF_MD_SIZE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_EOF_MD_SIZE);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILE_SIZE_ERROR);
 
     /* OS_mv failure */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(OS_mv), 1, CF_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(txn, ph));
-    UT_CF_AssertEventID(CF_CFDP_R_RENAME_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_RENAME);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* reopen failure */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, CF_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(txn, ph));
-    UT_CF_AssertEventID(CF_CFDP_R_OPEN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_OPEN);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* CF_CFDP_RecvMd failure */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvMd), 1, CF_PDU_METADATA_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_R2_RecvMd(txn, ph));
-    UT_CF_AssertEventID(CF_CFDP_R_PDU_MD_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_PDU_MD);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 }
 
@@ -1105,7 +1105,7 @@ void Test_CF_CFDP_R_SendInactivityEvent(void)
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
     UtAssert_VOIDCALL(CF_CFDP_R_SendInactivityEvent(txn));
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.inactivity_timer, 1);
-    UT_CF_AssertEventID(CF_CFDP_R_INACT_TIMER_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_R_INACT_TIMER);
 }
 
 /*******************************************************************************

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -245,7 +245,7 @@ void Test_CF_CFDP_S_Tick(void)
     txn->state = CF_TxnState_S2;
     UtAssert_VOIDCALL(CF_CFDP_S_Tick(txn, &cont));
     UtAssert_STUB_COUNT(CF_Timer_Tick, 1);
-    UT_CF_AssertEventID(CF_CFDP_S_INACT_TIMER_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_INACT_TIMER);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.inactivity_timer, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 1);
 
@@ -283,7 +283,7 @@ void Test_CF_CFDP_S_Tick(void)
     txn->state_data.send.sub_state        = CF_TxSubState_WAIT_FOR_EOF_ACK;
     txn->state_data.send.s2.acknak_count  = 9;
     UtAssert_VOIDCALL(CF_CFDP_S_Tick(txn, &cont));
-    UT_CF_AssertEventID(CF_CFDP_S_ACK_LIMIT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_ACK_LIMIT);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.ack_limit, 1);
     UtAssert_STUB_COUNT(CF_CFDP_ResetTransaction, 2);
 
@@ -460,7 +460,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, true), -1);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_read, 1);
-    UT_CF_AssertEventID(CF_CFDP_S_READ_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_READ);
 
     /* require lseek */
     offset = 25;
@@ -481,7 +481,7 @@ void Test_CF_CFDP_S_SendFileData(void)
     UtAssert_INT32_EQ(CF_CFDP_S_SendFileData(txn, offset, read_size, true), -1);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.sent.file_data_bytes, cumulative_read);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
-    UT_CF_AssertEventID(CF_CFDP_S_SEEK_FD_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_FD);
 }
 
 void Test_CF_CFDP_S_SubstateSendFileData(void)
@@ -628,7 +628,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     /* with no setup, OS_FileOpenCheck returns SUCCESS (true) */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
-    UT_CF_AssertEventID(CF_CFDP_S_ALREADY_OPEN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_ALREADY_OPEN);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 1);
 
     /* file already open */
@@ -645,7 +645,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedOpenCreate), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
-    UT_CF_AssertEventID(CF_CFDP_S_OPEN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_OPEN);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_open, 2);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
@@ -653,7 +653,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedLseek), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
-    UT_CF_AssertEventID(CF_CFDP_S_SEEK_END_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_END);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 1);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
@@ -661,7 +661,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_WrappedLseek), 2, -1);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
-    UT_CF_AssertEventID(CF_CFDP_S_SEEK_BEG_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEEK_BEG);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.file_seek, 2);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
@@ -669,7 +669,7 @@ void Test_CF_CFDP_S_SubstateSendMetadata(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_TX, NULL, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_SendMd), 1, CF_SEND_PDU_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_S_SubstateSendMetadata(txn));
-    UT_CF_AssertEventID(CF_CFDP_S_SEND_MD_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_SEND_MD);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_FILESTORE_REJECTION);
 
     /* CF_CFDP_SendMd fails w/ NO_MSG (no event here) */
@@ -742,7 +742,7 @@ void Test_CF_CFDP_S2_Nak(void)
     /* no segments */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
-    UT_CF_AssertEventID(CF_CFDP_S_PDU_NAK_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_NAK);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 
     /* nominal, re-send md request (0,0) */
@@ -774,7 +774,7 @@ void Test_CF_CFDP_S2_Nak(void)
     txn->fsize                     = 300;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.nak_segment_requests, 6);
-    UT_CF_AssertEventID(CF_CFDP_S_INVALID_SR_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_INVALID_SR);
 
     /* bad decode */
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
@@ -783,7 +783,7 @@ void Test_CF_CFDP_S2_Nak(void)
     nak->segment_list.num_segments = 1;
     UtAssert_VOIDCALL(CF_CFDP_S2_Nak(txn, ph));
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 2);
-    UT_CF_AssertEventID(CF_CFDP_S_PDU_NAK_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_NAK);
 }
 
 void Test_CF_CFDP_S2_Nak_Arm(void)
@@ -817,7 +817,7 @@ void Test_CF_CFDP_S2_WaitForEofAck(void)
     UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_RecvAck), 1, -1);
     UtAssert_VOIDCALL(CF_CFDP_S2_WaitForEofAck(txn, ph));
-    UT_CF_AssertEventID(CF_CFDP_S_PDU_EOF_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_S_PDU_EOF);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.error, 1);
 
     /* with error status */

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -316,7 +316,7 @@ void Test_CF_CFDP_ReceiveMessage(void)
     config->local_eid              = 123;
     ph->pdu_header.destination_eid = ~config->local_eid;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(chan));
-    UT_CF_AssertEventID(CF_CFDP_INVALID_DST_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_INVALID_DST_EID);
 
     /* recv correct destination_eid but CF_MAX_SIMULTANEOUS_RX hit */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, &chan, NULL, &txn, &config);
@@ -324,7 +324,7 @@ void Test_CF_CFDP_ReceiveMessage(void)
     config->local_eid                                                      = 123;
     ph->pdu_header.destination_eid                                         = config->local_eid;
     UtAssert_VOIDCALL(CF_CFDP_ReceiveMessage(chan));
-    UT_CF_AssertEventID(CF_CFDP_RX_DROPPED_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_RX_DROPPED);
 }
 
 void Test_CF_CFDP_Send(void)
@@ -393,7 +393,7 @@ void Test_CF_CFDP_MsgOutGet(void)
     /* no msg available from SB */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, NULL);
     UtAssert_NULL(CF_CFDP_MsgOutGet(txn, false));
-    UT_CF_AssertEventID(CF_CFDP_NO_MSG_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_NO_MSG);
 
     /* same, but the silent flag should suppress the event */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, NULL);

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -270,19 +270,19 @@ void Test_CF_CFDP_RecvPh(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, NULL, NULL);
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvPh(UT_CFDP_CHANNEL, ph), CF_SHORT_PDU_ERROR);
-    UT_CF_AssertEventID(CF_PDU_SHORT_HEADER_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_SHORT_HEADER);
 
     /* decode error, large file bit set */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, NULL, NULL);
     ph->pdu_header.large_flag = true;
     UtAssert_INT32_EQ(CF_CFDP_RecvPh(UT_CFDP_CHANNEL, ph), CF_ERROR);
-    UT_CF_AssertEventID(CF_PDU_LARGE_FILE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_LARGE_FILE);
 
     /* decode error, insufficient storage for EID or seq num */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, NULL, NULL);
     UT_SetDeferredRetcode(UT_KEY(CF_CFDP_DecodeHeader), 1, CF_ERROR);
     UtAssert_INT32_EQ(CF_CFDP_RecvPh(UT_CFDP_CHANNEL, ph), CF_ERROR);
-    UT_CF_AssertEventID(CF_PDU_TRUNCATION_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_TRUNCATION);
 }
 
 void Test_CF_CFDP_RecvMd(void)
@@ -316,21 +316,21 @@ void Test_CF_CFDP_RecvMd(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvMd(txn, ph), CF_PDU_METADATA_ERROR);
-    UT_CF_AssertEventID(CF_PDU_MD_SHORT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_MD_SHORT);
 
     /* decode errors: LV dest filename too long */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     md                       = &ph->int_header.md;
     md->dest_filename.length = CF_FILENAME_MAX_LEN + 1;
     UtAssert_INT32_EQ(CF_CFDP_RecvMd(txn, ph), CF_PDU_METADATA_ERROR);
-    UT_CF_AssertEventID(CF_PDU_INVALID_DST_LEN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_INVALID_DST_LEN);
 
     /* decode errors: LV source filename too long */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     md                         = &ph->int_header.md;
     md->source_filename.length = CF_FILENAME_MAX_LEN + 1;
     UtAssert_INT32_EQ(CF_CFDP_RecvMd(txn, ph), CF_PDU_METADATA_ERROR);
-    UT_CF_AssertEventID(CF_PDU_INVALID_SRC_LEN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_INVALID_SRC_LEN);
 }
 
 void Test_CF_CFDP_RecvFd(void)
@@ -357,7 +357,7 @@ void Test_CF_CFDP_RecvFd(void)
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvFd(txn, ph), CF_SHORT_PDU_ERROR);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_PROTOCOL_ERROR);
-    UT_CF_AssertEventID(CF_PDU_FD_SHORT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_FD_SHORT);
 
     /* decode errors: CRC part */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
@@ -371,7 +371,7 @@ void Test_CF_CFDP_RecvFd(void)
     ph->pdu_header.segment_meta_flag = 1;
     UtAssert_INT32_EQ(CF_CFDP_RecvFd(txn, ph), CF_ERROR);
     UtAssert_INT32_EQ(txn->history->txn_stat, CF_TxnStatus_PROTOCOL_ERROR);
-    UT_CF_AssertEventID(CF_PDU_FD_UNSUPPORTED_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_FD_UNSUPPORTED);
 }
 
 void Test_CF_CFDP_RecvEof(void)
@@ -391,7 +391,7 @@ void Test_CF_CFDP_RecvEof(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvEof(txn, ph), CF_SHORT_PDU_ERROR);
-    UT_CF_AssertEventID(CF_PDU_EOF_SHORT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_EOF_SHORT);
 }
 
 void Test_CF_CFDP_RecvAck(void)
@@ -410,7 +410,7 @@ void Test_CF_CFDP_RecvAck(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvAck(txn, ph), CF_SHORT_PDU_ERROR);
-    UT_CF_AssertEventID(CF_PDU_ACK_SHORT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_ACK_SHORT);
 }
 
 void Test_CF_CFDP_RecvFin(void)
@@ -430,7 +430,7 @@ void Test_CF_CFDP_RecvFin(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvFin(txn, ph), CF_SHORT_PDU_ERROR);
-    UT_CF_AssertEventID(CF_PDU_FIN_SHORT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_FIN_SHORT);
 }
 
 void Test_CF_CFDP_RecvNak(void)
@@ -450,7 +450,7 @@ void Test_CF_CFDP_RecvNak(void)
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, NULL, &txn, NULL);
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_INT32_EQ(CF_CFDP_RecvNak(txn, ph), CF_SHORT_PDU_ERROR);
-    UT_CF_AssertEventID(CF_PDU_NAK_SHORT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_PDU_NAK_SHORT);
 }
 
 void Test_CF_CFDP_RecvDrop(void)
@@ -517,13 +517,13 @@ void Test_CF_CFDP_RecvIdle(void)
     CF_CODEC_SET_DONE(ph->pdec);
     UtAssert_VOIDCALL(CF_CFDP_RecvIdle(txn, ph));
     UtAssert_INT32_EQ(txn->state, CF_TxnState_IDLE);
-    UT_CF_AssertEventID(CF_CFDP_IDLE_MD_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_IDLE_MD);
 
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_RX, &ph, NULL, &history, &txn, NULL);
     ph->fdirective.directive_code = CF_CFDP_FileDirective_INVALID_MIN;
     UtAssert_VOIDCALL(CF_CFDP_RecvIdle(txn, ph));
     UtAssert_INT32_EQ(txn->state, CF_TxnState_IDLE);
-    UT_CF_AssertEventID(CF_CFDP_FD_UNHANDLED_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_FD_UNHANDLED);
 }
 
 void Test_CF_CFDP_CopyStringFromLV(void)
@@ -869,7 +869,7 @@ void Test_CF_CFDP_InitEngine(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemGetIdByName), OS_ERROR);
     UtAssert_INT32_EQ(CF_CFDP_InitEngine(), OS_ERROR);
     UtAssert_BOOL_FALSE(CF_AppData.engine.enabled);
-    UT_CF_AssertEventID(CF_INIT_SEM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_INIT_SEM);
 
     /* Max retries of OS_CountSemGetIdByName - sem was never created at all  */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, NULL, &config);
@@ -877,7 +877,7 @@ void Test_CF_CFDP_InitEngine(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemGetIdByName), OS_ERR_NAME_NOT_FOUND);
     UtAssert_INT32_EQ(CF_CFDP_InitEngine(), OS_ERR_NAME_NOT_FOUND);
     UtAssert_BOOL_FALSE(CF_AppData.engine.enabled);
-    UT_CF_AssertEventID(CF_INIT_SEM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_INIT_SEM);
 
     /* Retry of OS_CountSemGetIdByName, when sem was created late, and thus
      * got return OS_ERR_NAME_NOT_FOUND followed by OS_SUCCESS */
@@ -928,7 +928,7 @@ void Test_CF_CFDP_TxFile(void)
     UtAssert_STRINGBUF_EQ(dest, -1, history->fnames.dst_filename, sizeof(history->fnames.dst_filename));
     UtAssert_STRINGBUF_EQ(src, -1, history->fnames.src_filename, sizeof(history->fnames.src_filename));
     UtAssert_UINT32_EQ(chan->num_cmd_tx, 1);
-    UT_CF_AssertEventID(CF_CFDP_S_START_SEND_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CFDP_S_START_SEND);
 
     /* same but for class 2 (for branch coverage) */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, &chan, &history, &txn, NULL);
@@ -939,13 +939,13 @@ void Test_CF_CFDP_TxFile(void)
     UtAssert_STRINGBUF_EQ(dest, -1, history->fnames.dst_filename, sizeof(history->fnames.dst_filename));
     UtAssert_STRINGBUF_EQ(src, -1, history->fnames.src_filename, sizeof(history->fnames.src_filename));
     UtAssert_UINT32_EQ(chan->num_cmd_tx, 2);
-    UT_CF_AssertEventID(CF_CFDP_S_START_SEND_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CFDP_S_START_SEND);
 
     /* max TX */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_TX, NULL, &chan, &history, &txn, NULL);
     chan->num_cmd_tx = CF_MAX_COMMANDED_PLAYBACK_FILES_PER_CHAN;
     UtAssert_INT32_EQ(CF_CFDP_TxFile(src, dest, CF_CFDP_CLASS_1, 1, UT_CFDP_CHANNEL, 0, 1), -1);
-    UT_CF_AssertEventID(CF_CFDP_MAX_CMD_TX_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_MAX_CMD_TX);
 }
 
 void Test_CF_CFDP_PlaybackDir(void)
@@ -975,7 +975,7 @@ void Test_CF_CFDP_PlaybackDir(void)
     memset(pb, 0, sizeof(*pb));
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryOpen), 1, OS_ERROR);
     UtAssert_INT32_EQ(CF_CFDP_PlaybackDir(src, dest, CF_CFDP_CLASS_1, 1, UT_CFDP_CHANNEL, 0, 1), -1);
-    UT_CF_AssertEventID(CF_CFDP_OPENDIR_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_OPENDIR);
 
     /* no non-busy entries */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, &chan, NULL, NULL, NULL);
@@ -985,7 +985,7 @@ void Test_CF_CFDP_PlaybackDir(void)
         pb->busy = 1;
     }
     UtAssert_INT32_EQ(CF_CFDP_PlaybackDir(src, dest, CF_CFDP_CLASS_1, 1, UT_CFDP_CHANNEL, 0, 1), -1);
-    UT_CF_AssertEventID(CF_CFDP_DIR_SLOT_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_DIR_SLOT);
 }
 
 static int32 Ut_Hook_CycleTx_SetRanOne(void *UserObj, int32 StubRetcode, uint32 CallCount,
@@ -1175,7 +1175,7 @@ void Test_CF_CFDP_ProcessPollingDirectories(void)
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryOpen), 1, OS_ERROR);
     UtAssert_VOIDCALL(CF_CFDP_ProcessPollingDirectories(chan));
     UtAssert_BOOL_TRUE(poll->timer_set);
-    UT_CF_AssertEventID(CF_CFDP_OPENDIR_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CFDP_OPENDIR);
 
     /* Test case where the impl calls through to CF_CFDP_ProcessPlaybackDirectory()
      *
@@ -1264,7 +1264,7 @@ void Test_CF_CFDP_ProcessPlaybackDirectory(void)
     UtAssert_BOOL_FALSE(pb.diropen);
     UtAssert_STRINGBUF_EQ(history->fnames.src_filename, sizeof(history->fnames.src_filename), "/ut", -1);
     UtAssert_STRINGBUF_EQ(history->fnames.dst_filename, sizeof(history->fnames.dst_filename), "/ut", -1);
-    UT_CF_AssertEventID(CF_CFDP_S_START_SEND_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CFDP_S_START_SEND);
 }
 
 static int32 Ut_Hook_TickTransactions_SetEarlyExit(void *UserObj, int32 StubRetcode, uint32 CallCount,

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -166,7 +166,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsEqTo_5_SendEventAndRejectCommand(vo
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_RESET_INVALID_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 }
@@ -189,7 +189,7 @@ void Test_CF_CmdReset_tests_WhenCommandByteIsGreaterThan_5_SendEventAndRejectCom
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_RESET_INVALID_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_RESET_INVALID);
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 }
@@ -458,7 +458,7 @@ void Test_CF_CmdTxFile(void)
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_TX_FILE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_TX_FILE);
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
@@ -466,21 +466,21 @@ void Test_CF_CmdTxFile(void)
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_TX_FILE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_TX_FILE);
 
     /* out of range arguments: bad class */
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 2);
 
     /* out of range arguments: bad channel */
@@ -488,7 +488,7 @@ void Test_CF_CmdTxFile(void)
     memset(msg, 0, sizeof(*msg));
     msg->chan_num = CF_NUM_CHANNELS;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 3);
 
     /* out of range arguments: bad keep */
@@ -496,7 +496,7 @@ void Test_CF_CmdTxFile(void)
     memset(msg, 0, sizeof(*msg));
     msg->keep = 15;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 4);
 
     /* CF_CFDP_TxFile fails*/
@@ -504,7 +504,7 @@ void Test_CF_CmdTxFile(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_TxFile), -1);
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_TX_FILE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_TX_FILE);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 5);
 }
 
@@ -539,14 +539,14 @@ void Test_CF_CmdPlaybackDir(void)
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 2);
 
     /* out of range arguments: bad channel */
@@ -554,7 +554,7 @@ void Test_CF_CmdPlaybackDir(void)
     memset(msg, 0, sizeof(*msg));
     msg->chan_num = CF_NUM_CHANNELS;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 3);
 
     /* out of range arguments: bad keep */
@@ -562,7 +562,7 @@ void Test_CF_CmdPlaybackDir(void)
     memset(msg, 0, sizeof(*msg));
     msg->keep = 15;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_BAD_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 4);
 
     /* CF_CFDP_PlaybackDir fails*/
@@ -570,7 +570,7 @@ void Test_CF_CmdPlaybackDir(void)
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_PlaybackDir), -1);
     memset(msg, 0, sizeof(*msg));
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
-    UT_CF_AssertEventID(CF_CMD_PLAYBACK_DIR_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_PLAYBACK_DIR);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 5);
 }
 
@@ -750,7 +750,7 @@ void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendE
     /* Assert */
     UtAssert_STUB_COUNT(Chan_action_fn_t, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
     UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
@@ -792,7 +792,7 @@ void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
     /* Assert */
     UtAssert_STUB_COUNT(Chan_action_fn_t, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_CHAN_PARAM);
 
     UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
@@ -861,7 +861,7 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndAcceptCommand(void)
                   "CF_AppData.hk.Payload.counters.cmd is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.cmd, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_FREEZE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_FREEZE);
 }
 
 void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
@@ -884,7 +884,7 @@ void Test_CF_CmdFreeze_Set_frozen_To_1_AndRejectCommand(void)
     /* Assert */
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
-    UT_CF_AssertEventID(CF_CMD_FREEZE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_FREEZE);
 }
 
 /*******************************************************************************
@@ -922,7 +922,7 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndAcceptCommand(void)
                   "CF_AppData.hk.Payload.counters.cmd is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.cmd, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_THAW_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_THAW);
 }
 
 void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
@@ -945,7 +945,7 @@ void Test_CF_CmdThaw_Set_frozen_To_0_AndRejectCommand(void)
     /* Assert */
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
-    UT_CF_AssertEventID(CF_CMD_THAW_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_THAW);
 }
 
 /*******************************************************************************
@@ -1068,7 +1068,7 @@ void Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotF
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_TRANS_NOT_FOUND_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_TRANS_NOT_FOUND);
 
     UtAssert_STUB_COUNT(Dummy_CF_TsnChanAction_fn_t, 0);
 }
@@ -1183,7 +1183,7 @@ void Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_TSN_CHAN_INVALID_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_TSN_CHAN_INVALID);
 }
 
 /*******************************************************************************
@@ -1284,7 +1284,7 @@ void Test_CF_DoSuspRes(void)
     UT_SetDeferredRetcode(UT_KEY(CF_TraverseAllTransactions), 1, 1);
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_SUSPRES_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_SUSPRES);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 1);
 
     /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
@@ -1295,7 +1295,7 @@ void Test_CF_DoSuspRes(void)
     UT_SetHandlerFunction(UT_KEY(CF_TraverseAllTransactions), UT_AltHandler_CF_TraverseAllTransactions_SetSuspResArg,
                           &utargs);
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 0));
-    UT_CF_AssertEventID(CF_CMD_SUSPRES_SAME_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_SUSPRES_SAME);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 2);
 
     /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
@@ -1305,7 +1305,7 @@ void Test_CF_DoSuspRes(void)
     UT_SetDeferredRetcode(UT_KEY(CF_TraverseAllTransactions), 1, 10);
     UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_SUSPRES_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_SUSPRES);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 2);
 }
 
@@ -1331,8 +1331,8 @@ void Test_CF_CmdSuspend_Call_CF_DoSuspRes_WithGiven_msg_And_action_1(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_TSN_CHAN_INVALID_ERR_EID);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_CMD_SUSPRES_CHAN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_ERR_CMD_TSN_CHAN_INVALID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_CMD_SUSPRES_CHAN);
 
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
@@ -1359,8 +1359,8 @@ void Test_CF_CmdResume_Call_CF_DoSuspRes_WithGiven_msg_And_action_0(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_TSN_CHAN_INVALID_ERR_EID);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_CMD_SUSPRES_CHAN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_ERR_CMD_TSN_CHAN_INVALID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_EID_ERR_CMD_SUSPRES_CHAN);
 
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
@@ -1412,7 +1412,7 @@ void Test_CF_CmdCancel_Success(void)
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_CANCEL_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_CANCEL);
 }
 
 void Test_CF_CmdCancel_Failure(void)
@@ -1430,7 +1430,7 @@ void Test_CF_CmdCancel_Failure(void)
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
-    UT_CF_AssertEventID(CF_CMD_CANCEL_CHAN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_CANCEL_CHAN);
 }
 
 /*******************************************************************************
@@ -1482,7 +1482,7 @@ void Test_CF_CmdAbandon_Success(void)
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_ABANDON_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_ABANDON);
 }
 
 void Test_CF_CmdAbandon_Failure(void)
@@ -1500,7 +1500,7 @@ void Test_CF_CmdAbandon_Failure(void)
     /* Assert */
     UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
-    UT_CF_AssertEventID(CF_CMD_ABANDON_CHAN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ABANDON_CHAN);
 }
 
 /*******************************************************************************
@@ -1574,7 +1574,7 @@ void Test_CF_CmdEnableDequeue_Success(void)
         "THE BEHAVIOR BUT IT IS NOT",
         CF_AppData.hk.Payload.counters.cmd, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_ENABLE_DEQUEUE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_DEQUEUE);
 }
 
 void Test_CF_CmdEnableDequeue_Failure(void)
@@ -1603,7 +1603,7 @@ void Test_CF_CmdEnableDequeue_Failure(void)
     /* Assert */
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
-    UT_CF_AssertEventID(CF_CMD_ENABLE_DEQUEUE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_DEQUEUE);
 }
 
 /*******************************************************************************
@@ -1646,7 +1646,7 @@ void Test_CF_CmdDisableDequeue_Success(void)
                   "CF_AppData.hk.Payload.counters.cmd is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.cmd, initial_hk_cmd_counter);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_DISABLE_DEQUEUE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_DEQUEUE);
 }
 
 void Test_CF_CmdDisableDequeue_Failure(void)
@@ -1675,7 +1675,7 @@ void Test_CF_CmdDisableDequeue_Failure(void)
     /* Assert */
     /* Assert for CF_DoFreezeThaw */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
-    UT_CF_AssertEventID(CF_CMD_DISABLE_DEQUEUE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_DEQUEUE);
 }
 
 /*******************************************************************************
@@ -1781,7 +1781,7 @@ void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_An
     local_result = CF_DoEnableDisablePolldir(arg_chan_num, arg_context);
 
     /* Assert */
-    UT_CF_AssertEventID(CF_CMD_POLLDIR_INVALID_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_POLLDIR_INVALID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
@@ -1810,7 +1810,7 @@ void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
     local_result = CF_DoEnableDisablePolldir(arg_chan_num, arg_context);
 
     /* Assert */
-    UT_CF_AssertEventID(CF_CMD_POLLDIR_INVALID_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_POLLDIR_INVALID);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
 }
@@ -1858,7 +1858,7 @@ void Test_CF_CmdEnablePolldir_SuccessWhenActionSuccess(void)
     UtAssert_True(CF_AppData.hk.Payload.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.Payload.counters.cmd is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.cmd, initial_hk_cmd_counter);
-    UT_CF_AssertEventID(CF_CMD_ENABLE_POLLDIR_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_POLLDIR);
 }
 
 void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
@@ -1889,7 +1889,7 @@ void Test_CF_CmdEnablePolldir_FailWhenActionFail(void)
     UtAssert_True(CF_AppData.hk.Payload.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.Payload.counters.err is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.err, initial_hk_err_counter);
-    UT_CF_AssertEventID(CF_CMD_ENABLE_POLLDIR_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_POLLDIR);
 }
 
 /*******************************************************************************
@@ -1934,7 +1934,7 @@ void Test_CF_CmdDisablePolldir_SuccessWhenActionSuccess(void)
     UtAssert_True(CF_AppData.hk.Payload.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.hk.Payload.counters.cmd is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.cmd, initial_hk_cmd_counter);
-    UT_CF_AssertEventID(CF_CMD_DISABLE_POLLDIR_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_POLLDIR);
 }
 
 void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
@@ -1966,7 +1966,7 @@ void Test_CF_CmdDisablePolldir_FailWhenActionFail(void)
     UtAssert_True(CF_AppData.hk.Payload.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.Payload.counters.err is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.err, initial_hk_err_counter);
-    UT_CF_AssertEventID(CF_CMD_DISABLE_POLLDIR_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_DISABLE_POLLDIR);
 }
 
 /*******************************************************************************
@@ -2176,7 +2176,7 @@ void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     /* Assert */
     UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_PURGE_ARG_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_ARG);
     UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
 }
 
@@ -2201,7 +2201,7 @@ void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
     /* Assert */
     UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_PURGE_ARG_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_ARG);
     UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
 }
 
@@ -2239,7 +2239,7 @@ void Test_CF_CmdPurgeQueue_FailWhenActionFail(void)
     UtAssert_True(CF_AppData.hk.Payload.counters.err == (uint16)(initial_hk_err_counter + 1),
                   "CF_AppData.hk.Payload.counters.err is %d and should be 1 more than %d",
                   CF_AppData.hk.Payload.counters.err, initial_hk_err_counter);
-    UT_CF_AssertEventID(CF_CMD_PURGE_QUEUE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_PURGE_QUEUE);
 }
 
 void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)
@@ -2264,7 +2264,7 @@ void Test_CF_CmdPurgeQueue_SuccessWhenActionSuccess(void)
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_PURGE_QUEUE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_PURGE_QUEUE);
 }
 
 /*******************************************************************************
@@ -2292,7 +2292,7 @@ void Test_CF_CmdWriteQueue_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_CHAN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 }
@@ -2316,7 +2316,7 @@ void Test_CF_CmdWriteQueue_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRej
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_CHAN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_CHAN);
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2345,7 +2345,7 @@ void Test_CF_CmdWriteQueue_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_ARGS_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_ARGS);
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2386,7 +2386,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     UtAssert_STUB_COUNT(CF_WrappedOpenCreate, 1);
     UtAssert_INT32_EQ(context_CF_WrappedOpenCreate.access, OS_WRITE_ONLY);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_OPEN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2427,7 +2427,7 @@ void Test_CF_CmdWriteQueue_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     UtAssert_STUB_COUNT(CF_WrappedOpenCreate, 1);
     UtAssert_INT32_EQ(context_CF_WrappedOpenCreate.access, OS_WRITE_ONLY);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_OPEN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_OPEN);
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2475,7 +2475,7 @@ void Test_CF_CmdWriteQueue_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     /* Assert */
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_WRITEQ_RX_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2526,7 +2526,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     /* Assert */
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_WRITEQ_RX_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2577,7 +2577,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     /* Assert */
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_WRITEHIST_RX_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_RX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2628,7 +2628,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     /* Assert */
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_WRITEQ_TX_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2681,7 +2681,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryDataToFile_FailsOnSecondCallAnd_w
     /* Assert */
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_WRITEQ_TX_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2732,7 +2732,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     /* Assert */
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_WRITEQ_PEND_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEQ_PEND);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2783,7 +2783,7 @@ void Test_CF_CmdWriteQueue_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     /* Assert */
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_WRITEHIST_TX_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WQ_WRITEHIST_TX);
     UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
@@ -2832,7 +2832,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 4);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -2877,7 +2877,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -2922,7 +2922,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 3);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -2967,7 +2967,7 @@ void Test_CF_CmdWriteQueue_Success_type_AllAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3016,7 +3016,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3061,7 +3061,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3106,7 +3106,7 @@ void Test_CF_CmdWriteQueue_Success_type_UpAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3153,7 +3153,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 3);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3198,7 +3198,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3243,7 +3243,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3288,7 +3288,7 @@ void Test_CF_CmdWriteQueue_Success_type_DownAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CF_WriteTxnQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_WQ);
     UtAssert_STUB_COUNT(CF_WrappedClose, 0);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3439,7 +3439,7 @@ void Test_CF_CmdGetSetParam(void)
     {
         UT_CF_ResetEventCapture();
         UtAssert_VOIDCALL(CF_GetSetParamCmd(1, param_id, 1 + param_id, UT_CFDP_CHANNEL));
-        UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
+        UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET1);
         UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, ++expected_count);
     }
 
@@ -3460,27 +3460,27 @@ void Test_CF_CmdGetSetParam(void)
     {
         UT_CF_ResetEventCapture();
         UtAssert_VOIDCALL(CF_GetSetParamCmd(0, param_id, 1, UT_CFDP_CHANNEL));
-        UT_CF_AssertEventID(CF_CMD_GETSET2_INF_EID);
+        UT_CF_AssertEventID(CF_EID_INF_CMD_GETSET2);
         UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, ++expected_count);
     }
 
     /* Bad param ID */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_GetSetParamCmd(0, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
-    UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_PARAM);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
 
     /* Bad channel ID */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_GetSetParamCmd(0, 0, 0, CF_NUM_CHANNELS + 1));
-    UT_CF_AssertEventID(CF_CMD_GETSET_CHAN_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_CHAN);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 2);
 
     /* Validation fail */
     UT_CF_ResetEventCapture();
     UtAssert_VOIDCALL(CF_GetSetParamCmd(1, CF_GetSet_ValueID_outgoing_file_chunk_size,
                                         100 + sizeof(CF_CFDP_PduFileDataContent_t), UT_CFDP_CHANNEL));
-    UT_CF_AssertEventID(CF_CMD_GETSET_VALIDATE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_GETSET_VALIDATE);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 3);
 }
 
@@ -3511,7 +3511,7 @@ void Test_CF_CmdSetParam_Call_CF_CmdGetSetParam_With_cmd_key_And_cmd_value(void)
     /* Assert */
     UtAssert_UINT32_EQ(CF_AppData.config_table->ticks_per_second, utbuf.Payload.value);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_GETSET1_INF_EID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET1);
     /* Assert for incremented counter() */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 1);
 }
@@ -3542,7 +3542,7 @@ void Test_CF_CmdGetParam_Call_CF_CmdGetSetParam_With_cmd_data_byte_0_AndConstant
     /* Assert */
     /* Note actual value not tested, just flow */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_GETSET2_INF_EID);
+    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_EID_INF_CMD_GETSET2);
     /* Assert for incremented counter() */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, 1);
 }
@@ -3576,7 +3576,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
     /* Assert */
     UtAssert_STUB_COUNT(CF_CFDP_InitEngine, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_ENABLE_ENGINE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -3604,7 +3604,7 @@ void Test_CF_CmdEnableEngine_WithEngineNotEnableFailsInitSendEventAndIncrementEr
     /* Assert */
     UtAssert_STUB_COUNT(CF_CFDP_InitEngine, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_ENABLE_ENGINE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ENABLE_ENGINE);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 }
@@ -3629,7 +3629,7 @@ void Test_CF_CmdEnableEngine_WithEngineEnableFailsSendEventAndIncrementErrCounte
     /* Assert */
     UtAssert_STUB_COUNT(CF_CFDP_InitEngine, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_ENG_ALREADY_ENA_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_ENA);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 }
@@ -3658,7 +3658,7 @@ void Test_CF_CmdDisableEngine_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
     /* Assert */
     UtAssert_STUB_COUNT(CF_CFDP_DisableEngine, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_DISABLE_ENGINE_INF_EID);
+    UT_CF_AssertEventID(CF_EID_INF_CMD_DISABLE_ENGINE);
 
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
@@ -3682,7 +3682,7 @@ void Test_CF_CmdDisableEngine_WhenEngineDisabledAndIncrementErrCounterThenFail(v
     /* Assert */
     UtAssert_STUB_COUNT(CF_CFDP_DisableEngine, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_ENG_ALREADY_DIS_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_ENG_ALREADY_DIS);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
     UtAssert_True(CF_AppData.hk.Payload.counters.err == (uint16)(initial_hk_err_counter + 1),

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -549,7 +549,7 @@ void Test_CF_WriteHistoryEntryToFile(void)
     UT_CF_ResetEventCapture();
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, -1);
     UtAssert_INT32_EQ(CF_WriteHistoryEntryToFile(arg_fd, &history), -1);
-    UT_CF_AssertEventID(CF_CMD_WHIST_WRITE_ERR_EID);
+    UT_CF_AssertEventID(CF_EID_ERR_CMD_WHIST_WRITE);
 }
 
 /*******************************************************************************

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -41,7 +41,7 @@ void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *, UT_EntryKey_t, const U
  * Generated stub function for CF_FindTransactionBySequenceNumber()
  * ----------------------------------------------------
  */
-CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *      chan,
+CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t       *chan,
                                                      CF_TransactionSeq_t transaction_sequence_number,
                                                      CF_EntityId_t       src_eid)
 {


### PR DESCRIPTION
Fix #441, Update to handle error during tx.
1. For polling, the file gets moved or deleted to pervent infinite loop
2. For others, the file does not get deleted.

**Checklist (Please check before submitting)**

* [ x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [ x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
Fixes #441, cf was deleting file during error.  This update how the cf handle error during tx. 

**Testing performed**
Steps taken to test the contribution:
Tested against DACINCI's build

1. Set the polling directory to class 2 (ACK)
2. make SIMULATION=native TARGET=pclinux prep
3. make install
4. Create a 100KB.txt file. 
5. Tested with polling directory and tested with tx file command. 

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
Two updates: 
1. If an error occurs in a polling directory - it will attempt to move the file to a "fail directory". If it cannot, it will delete the file to prevent an infinite cycle of trying to transmit. 
2. If it was a tx file command and not in a polling directory, it would not delete the file. 

**System(s) tested on**
docker - ubunutu 22.04

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of the license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
Anh Van, GSFC
