### PR TITLE
Fix #442, xact priority sorted incorrectly

### DIFF
--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -328,19 +328,20 @@ CF_CListTraverse_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context)
  *-----------------------------------------------------------------*/
 void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue)
 {
-    int           insert_back = 0;
+    int          insert_front = 0;
     CF_Channel_t *chan        = &CF_AppData.engine.channels[txn->chan_num];
 
     CF_Assert(txn->chan_num < CF_NUM_CHANNELS);
     CF_Assert(txn->state != CF_TxnState_IDLE);
 
     /* look for proper position on PEND queue for this transaction.
-     * This is a simple priority sort. */
+     * This is a simple priority sort. A priority of 0 denotes the
+     * highest priority, and a priority of 255 denotes the lowest. */
 
     if (!chan->qs[queue])
     {
         /* list is empty, so just insert */
-        insert_back = 1;
+        insert_front = 1;
     }
     else
     {
@@ -352,13 +353,13 @@ void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue)
         }
         else
         {
-            insert_back = 1;
+            insert_front = 1;
         }
     }
 
-    if (insert_back)
+    if (insert_front)
     {
-        CF_CList_InsertBack_Ex(chan, queue, &txn->cl_node);
+        CF_CList_InsertFront_Ex(chan, queue, &txn->cl_node);
     }
     txn->flags.com.q_index = queue;
 }

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -158,6 +158,12 @@ static inline void CF_CList_InsertBack_Ex(CF_Channel_t *chan, CF_QueueIdx_t queu
     ++CF_AppData.hk.Payload.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
 }
 
+static inline void CF_CList_InsertFront_Ex(CF_Channel_t *chan, CF_QueueIdx_t queueidx, CF_CListNode_t *node)
+{
+    CF_CList_InsertFront(&chan->qs[queueidx], node);
+    ++CF_AppData.hk.Payload.channel_hk[chan - CF_AppData.engine.channels].q_size[queueidx];
+}
+
 /************************************************************************/
 /** @brief Find an unused transaction on a channel.
  *

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -679,39 +679,39 @@ void Test_CF_PrioSearch_When_t_PrioIsLessThanContextPrio_Set_context_t_To_t_AndR
 **
 *******************************************************************************/
 
-void Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_index_To_q(void)
+void Test_CF_InsertSortPrio_Call_CF_CList_InsertFront_Ex_ListIsEmpty_AndSet_q_index_To_q(void)
 {
     /* Arrange */
     CF_Transaction_t  txn;
     CF_Transaction_t *arg_t = &txn;
     CF_QueueIdx_t     arg_q = Any_cf_queue_index_t();
     CF_Channel_t *    chan;
-    CF_CListNode_t ** expected_insert_back_head;
-    CF_CListNode_t *  expected_insert_back_node;
+    CF_CListNode_t ** expected_insert_front_head;
+    CF_CListNode_t *  expected_insert_front_node;
 
-    CF_CList_InsertBack_context_t context_clist_insert_back;
+    CF_CList_InsertFront_context_t context_clist_insert_front;
 
     /* txn settings to bypass CF_Assert */
     txn.chan_num = Any_uint8_LessThan(CF_NUM_CHANNELS);
     txn.state    = Any_uint8_Except(CF_TxnState_IDLE);
 
-    UT_SetDataBuffer(UT_KEY(CF_CList_InsertBack), &context_clist_insert_back, sizeof(context_clist_insert_back), false);
+    UT_SetDataBuffer(UT_KEY(CF_CList_InsertFront), &context_clist_insert_front, sizeof(context_clist_insert_front), false);
 
     /* setting (&CF_AppData.engine.channels[arg_t->chan_num])->qs[arg_q] to NULL
      * makes the list empty */
     chan            = &CF_AppData.engine.channels[arg_t->chan_num];
     chan->qs[arg_q] = NULL;
 
-    expected_insert_back_head = &chan->qs[arg_q];
-    expected_insert_back_node = &arg_t->cl_node;
+    expected_insert_front_head = &chan->qs[arg_q];
+    expected_insert_front_node = &arg_t->cl_node;
 
     /* Act */
     CF_InsertSortPrio(arg_t, arg_q);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);
-    UtAssert_ADDRESS_EQ(context_clist_insert_back.head, expected_insert_back_head);
-    UtAssert_ADDRESS_EQ(context_clist_insert_back.node, expected_insert_back_node);
+    UtAssert_STUB_COUNT(CF_CList_InsertFront, 1);
+    UtAssert_ADDRESS_EQ(context_clist_insert_front.head, expected_insert_front_head);
+    UtAssert_ADDRESS_EQ(context_clist_insert_front.node, expected_insert_front_node);
     UtAssert_True(arg_t->flags.com.q_index == arg_q,
                   "arg_t->flags.com.q_index set to %d and should be %d (CF_QueueIdx_t queue)", arg_t->flags.com.q_index,
                   arg_q);
@@ -776,7 +776,7 @@ void Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q(voi
                   arg_t->flags.com.q_index, arg_q);
 }
 
-void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
+void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertFront_Ex(void)
 {
     /* Arrange */
     CF_Transaction_t  txn;
@@ -786,11 +786,11 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     CF_Channel_t *    chan;
     CF_CListNode_t *  expected_end;
     CF_CListFn_t      expected_fn;
-    CF_CListNode_t ** expected_insert_back_head;
-    CF_CListNode_t *  expected_insert_back_node;
+    CF_CListNode_t ** expected_insert_front_head;
+    CF_CListNode_t *  expected_insert_front_node;
 
     CF_CList_Traverse_R_context_t context_cf_clist_traverse_r;
-    CF_CList_InsertBack_context_t context_clist_insert_back;
+    CF_CList_InsertFront_context_t context_clist_insert_front;
 
     UT_SetDataBuffer(UT_KEY(CF_CList_Traverse_R), &context_cf_clist_traverse_r, sizeof(context_cf_clist_traverse_r),
                      false);
@@ -810,11 +810,11 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     /* set expected values */
     expected_end              = chan->qs[arg_q];
     expected_fn               = CF_PrioSearch;
-    expected_insert_back_head = &chan->qs[arg_q];
-    expected_insert_back_node = &arg_t->cl_node;
+    expected_insert_front_head = &chan->qs[arg_q];
+    expected_insert_front_node = &arg_t->cl_node;
 
-    /* Arrange for CF_CList_InsertBack_Ex */
-    UT_SetDataBuffer(UT_KEY(CF_CList_InsertBack), &context_clist_insert_back, sizeof(context_clist_insert_back), false);
+    /* Arrange for CF_CList_InsertFront_Ex */
+    UT_SetDataBuffer(UT_KEY(CF_CList_InsertFront), &context_clist_insert_front, sizeof(context_clist_insert_front), false);
 
     /* Act */
     CF_InsertSortPrio(arg_t, arg_q);
@@ -824,9 +824,9 @@ void Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex(void)
     UtAssert_ADDRESS_EQ(context_cf_clist_traverse_r.end, expected_end);
     UtAssert_True(context_cf_clist_traverse_r.fn == expected_fn, "context_cf_clist_traverse_r.fn ==  expected_fn");
     UtAssert_STUB_COUNT(CF_CList_InsertAfter, 0);
-    UtAssert_STUB_COUNT(CF_CList_InsertBack, 1);
-    UtAssert_ADDRESS_EQ(context_clist_insert_back.head, expected_insert_back_head);
-    UtAssert_ADDRESS_EQ(context_clist_insert_back.node, expected_insert_back_node);
+    UtAssert_STUB_COUNT(CF_CList_InsertFront, 1);
+    UtAssert_ADDRESS_EQ(context_clist_insert_front.head, expected_insert_front_head);
+    UtAssert_ADDRESS_EQ(context_clist_insert_front.node, expected_insert_front_node);
     UtAssert_True(arg_t->flags.com.q_index == arg_q, "txn->flags.com.q_index is %u and should be %u (q)",
                   arg_t->flags.com.q_index, arg_q);
 }
@@ -1229,13 +1229,13 @@ void add_CF_PrioSearch_tests(void)
 
 void add_CF_InsertSortPrio_tests(void)
 {
-    UtTest_Add(Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_index_To_q, cf_utils_tests_Setup,
+    UtTest_Add(Test_CF_InsertSortPrio_Call_CF_CList_InsertFront_Ex_ListIsEmpty_AndSet_q_index_To_q, cf_utils_tests_Setup,
                cf_utils_tests_Teardown,
-               "Test_CF_InsertSortPrio_Call_CF_CList_InsertBack_Ex_ListIsEmpty_AndSet_q_index_To_q");
+               "Test_CF_InsertSortPrio_Call_CF_CList_InsertFront_Ex_ListIsEmpty_AndSet_q_index_To_q");
     UtTest_Add(Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q, cf_utils_tests_Setup,
                cf_utils_tests_Teardown, "Test_CF_InsertSortPrio_Call_CF_CList_InsertAfter_Ex_AndSet_q_index_To_q");
-    UtTest_Add(Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex, cf_utils_tests_Setup,
-               cf_utils_tests_Teardown, "Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertBack_Ex");
+    UtTest_Add(Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertFront_Ex, cf_utils_tests_Setup,
+               cf_utils_tests_Teardown, "Test_CF_InsertSortPrio_When_p_t_Is_NULL_Call_CF_CList_InsertFront_Ex");
 }
 
 void add_CF_TraverseAllTransactions_Impl_tests(void)

--- a/unit-test/stubs/cf_clist_handlers.c
+++ b/unit-test/stubs/cf_clist_handlers.c
@@ -78,6 +78,23 @@ void UT_DefaultHandler_CF_CList_InsertBack(void *UserObj, UT_EntryKey_t FuncKey,
  * arguments to a test-provided context capture buffer.
  *
  *-----------------------------------------------------------------*/
+void UT_DefaultHandler_CF_CList_InsertFront(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    CF_CList_InsertBack_context_t *ctxt = UT_CF_GetContextBuffer(FuncKey, CF_CList_InsertBack_context_t);
+
+    if (ctxt)
+    {
+        ctxt->head = UT_Hook_GetArgValueByName(Context, "head", CF_CListNode_t **);
+        ctxt->node = UT_Hook_GetArgValueByName(Context, "node", CF_CListNode_t *);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * For compatibility with other tests, this has a mechanism to save its
+ * arguments to a test-provided context capture buffer.
+ *
+ *-----------------------------------------------------------------*/
 void UT_DefaultHandler_CF_CList_CF_CList_Pop(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     CF_CList_Pop_context_t *ctxt = UT_CF_GetContextBuffer(FuncKey, CF_CList_Pop_context_t);

--- a/unit-test/stubs/cf_clist_stubs.c
+++ b/unit-test/stubs/cf_clist_stubs.c
@@ -29,6 +29,7 @@
 void UT_DefaultHandler_CF_CList_InitNode(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CList_InsertAfter(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CList_InsertBack(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CF_CList_InsertFront(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CList_Remove(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CList_Traverse(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CList_Traverse_R(void *, UT_EntryKey_t, const UT_StubContext_t *);
@@ -82,7 +83,7 @@ void CF_CList_InsertFront(CF_CListNode_t **head, CF_CListNode_t *node)
     UT_GenStub_AddParam(CF_CList_InsertFront, CF_CListNode_t **, head);
     UT_GenStub_AddParam(CF_CList_InsertFront, CF_CListNode_t *, node);
 
-    UT_GenStub_Execute(CF_CList_InsertFront, Basic, NULL);
+    UT_GenStub_Execute(CF_CList_InsertFront, Basic, UT_DefaultHandler_CF_CList_InsertFront);
 }
 
 /*

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -170,6 +170,12 @@ typedef struct
 typedef struct
 {
     CF_CListNode_t **head;
+    CF_CListNode_t * node;
+} CF_CList_InsertFront_context_t;
+
+typedef struct
+{
+    CF_CListNode_t **head;
     CF_CListNode_t * start;
     CF_CListNode_t * after;
 } CF_CList_InsertAfter_context_t;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Pulled in fix from @ctolbert555
Marked as draft because I still need to test the update against the open source

Fixed priority sort functionality

Previously, if the priority to be inserted was the lowest number (highest prio) it would have no matches and be inserted into the back of the queue, which is incorrect, as the sort is meant to sort from lowest number to highest. Now, if it is the lowest number it will be inserted into the front of the queue.
Fixes #442 

**Testing performed**
TBD

**Expected behavior changes**
TBD

**System(s) tested on**
TBD


**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
