### PR TITLE
Fix #444, Adds JSC 2.1 Static Analysis comments and exposes CF_strnlen

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -301,22 +301,6 @@ CF_Logical_PduBuffer_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *txn, 
 
 /*----------------------------------------------------------------
  *
- * Internal helper routine only, not part of API.
- *
- *-----------------------------------------------------------------*/
-static inline size_t CF_strnlen(const char *str, size_t maxlen)
-{
-    const char *end = memchr(str, 0, maxlen);
-    if (end != NULL)
-    {
-        /* actual length of string is difference */
-        maxlen = end - str;
-    }
-    return maxlen;
-}
-
-/*----------------------------------------------------------------
- *
  * Application-scope internal function
  * See description in cf_cfdp.h for argument/return detail
  *
@@ -344,10 +328,10 @@ CFE_Status_t CF_CFDP_SendMd(CF_Transaction_t *txn)
         /* at this point, need to append filenames into md packet */
         /* this does not actually copy here - that is done during encode */
         md->source_filename.length =
-            CF_strnlen(txn->history->fnames.src_filename, sizeof(txn->history->fnames.src_filename));
+            OS_strnlen(txn->history->fnames.src_filename, sizeof(txn->history->fnames.src_filename));
         md->source_filename.data_ptr = txn->history->fnames.src_filename;
         md->dest_filename.length =
-            CF_strnlen(txn->history->fnames.dst_filename, sizeof(txn->history->fnames.dst_filename));
+            OS_strnlen(txn->history->fnames.dst_filename, sizeof(txn->history->fnames.dst_filename));
         md->dest_filename.data_ptr = txn->history->fnames.dst_filename;
 
         CF_CFDP_EncodeMd(ph->penc, md);

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -184,20 +184,23 @@ CFE_Status_t CF_WriteHistoryEntryToFile(osal_id_t fd, const CF_History_t *histor
         {
             case 0:
                 CF_Assert(history->dir < CF_Direction_NUM);
+                /* SAD: No need to check snprintf return; buffer size is sufficient for the formatted output */
                 snprintf(linebuf, sizeof(linebuf), "SEQ (%lu, %lu)\tDIR: %s\tPEER %lu\tSTAT: %d\t",
                          (unsigned long)history->src_eid, (unsigned long)history->seq_num, CF_DSTR[history->dir],
                          (unsigned long)history->peer_eid, (int)history->txn_stat);
                 break;
             case 1:
+                /* SAD: No need to check snprintf return; buffer size is sufficient for the formatted output */
                 snprintf(linebuf, sizeof(linebuf), "SRC: %s\t", history->fnames.src_filename);
                 break;
             case 2:
             default:
+                /* SAD: No need to check snprintf return; buffer size is sufficient for the formatted output */
                 snprintf(linebuf, sizeof(linebuf), "DST: %s\n", history->fnames.dst_filename);
                 break;
         }
 
-        len = strlen(linebuf);
+        len = OS_strnlen(linebuf, (CF_FILENAME_MAX_LEN * 2) + 128);
         ret = CF_WrappedWrite(fd, linebuf, len);
         if (ret != len)
         {

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -41,7 +41,7 @@ void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *, UT_EntryKey_t, const U
  * Generated stub function for CF_FindTransactionBySequenceNumber()
  * ----------------------------------------------------
  */
-CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t       *chan,
+CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t *      chan,
                                                      CF_TransactionSeq_t transaction_sequence_number,
                                                      CF_EntityId_t       src_eid)
 {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #444, Adds comments in the fsw to document where static analysis warnings have been flagged and why it's ok to leave the code in its current state.

**Testing performed**
None, only comments are added.

**Expected behavior changes**
N/A

**System(s) tested on**
N/A

**Additional context**
Depends on https://github.com/nasa/osal/pull/1465

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
