### PR TITLE
Fix #455, Convert suitable `0`/`1` variables to `bool` type

### DIFF
--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -44,7 +44,7 @@ typedef struct CF_CFDP_Tick_args
 {
     CF_Channel_t *chan;                    /**< \brief channel structure */
     void (*fn)(CF_Transaction_t *, int *); /**< \brief function pointer */
-    int early_exit;                        /**< \brief early exit result */
+    bool early_exit;                        /**< \brief early exit result */
     int cont;                              /**< \brief if 1, then re-traverse the list */
 } CF_CFDP_Tick_args_t;
 
@@ -91,7 +91,7 @@ void CF_CFDP_DecodeStart(CF_DecoderState_t *pdec, const void *msgbuf, CF_Logical
  * @param txn  Pointer to the transaction object
  * @param keep_history Whether the transaction info should be preserved in history
  */
-void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, int keep_history);
+void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, bool keep_history);
 
 /************************************************************************/
 /** @brief Helper function to store transaction status code only

--- a/fsw/src/cf_cfdp_r.h
+++ b/fsw/src/cf_cfdp_r.h
@@ -149,7 +149,7 @@ void CF_CFDP_R2_Reset(CF_Transaction_t *txn);
  *       txn must not be NULL.
  *
  *
- * @retval CFE_SUCCESS on CRC match, otherwise error.
+ * @retval CFE_SUCCESS on CRC match, otherwise CF_ERROR.
  *
  *
  * @param txn            Pointer to the transaction object

--- a/fsw/src/cf_cfdp_s.c
+++ b/fsw/src/cf_cfdp_s.c
@@ -48,7 +48,7 @@
  *-----------------------------------------------------------------*/
 static inline void CF_CFDP_S_Reset(CF_Transaction_t *txn)
 {
-    CF_CFDP_ResetTransaction(txn, 1);
+    CF_CFDP_ResetTransaction(txn, true);
 }
 
 /*----------------------------------------------------------------
@@ -62,7 +62,7 @@ CFE_Status_t CF_CFDP_S_SendEof(CF_Transaction_t *txn)
     if (!txn->flags.com.crc_calc)
     {
         CF_CRC_Finalize(&txn->crc);
-        txn->flags.com.crc_calc = 1;
+        txn->flags.com.crc_calc = true;
     }
     return CF_CFDP_SendEof(txn);
 }
@@ -93,7 +93,7 @@ void CF_CFDP_S1_SubstateSendEof(CF_Transaction_t *txn)
 void CF_CFDP_S2_SubstateSendEof(CF_Transaction_t *txn)
 {
     txn->state_data.send.sub_state = CF_TxSubState_WAIT_FOR_EOF_ACK;
-    txn->flags.com.ack_timer_armed = 1; /* will cause tick to see ack_timer as expired, and act */
+    txn->flags.com.ack_timer_armed = true; /* will cause tick to see ack_timer as expired, and act */
 
     /* no longer need to send file data PDU except in the case of NAK response */
 
@@ -250,7 +250,7 @@ CFE_Status_t CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *txn)
 {
     const CF_Chunk_t *chunk;
     CFE_Status_t      sret;
-    CFE_Status_t      ret = 0;
+    CFE_Status_t      ret = CFE_SUCCESS;
 
     if (txn->flags.tx.md_need_send)
     {
@@ -263,7 +263,7 @@ CFE_Status_t CF_CFDP_S_CheckAndRespondNak(CF_Transaction_t *txn)
         {
             if (sret == CFE_SUCCESS)
             {
-                txn->flags.tx.md_need_send = 0;
+                txn->flags.tx.md_need_send = false;
             }
             /* unless CF_SEND_PDU_ERROR, return 1 to keep caller from sending file data */
             ret = 1; /* 1 means nak processed, so don't send filedata */
@@ -494,7 +494,7 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
             if (sr->offset_start == 0 && sr->offset_end == 0)
             {
                 /* need to re-send metadata PDU */
-                txn->flags.tx.md_need_send = 1;
+                txn->flags.tx.md_need_send = true;
             }
             else
             {
@@ -566,7 +566,7 @@ void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         else
         {
             txn->state_data.send.sub_state = CF_TxSubState_WAIT_FOR_FIN;
-            txn->flags.com.ack_timer_armed = 0; /* just wait for FIN now, nothing to re-send */
+            txn->flags.com.ack_timer_armed = false; /* just wait for FIN now, nothing to re-send */
         }
     }
     else

--- a/fsw/src/cf_cfdp_types.h
+++ b/fsw/src/cf_cfdp_types.h
@@ -455,7 +455,7 @@ typedef struct CF_Engine
     CF_Chunk_t        chunk_mem[CF_NUM_CHUNKS_ALL_CHANNELS];
 
     uint32 outgoing_counter;
-    uint8  enabled;
+    bool  enabled;
 } CF_Engine_t;
 
 #endif

--- a/fsw/src/cf_clist.c
+++ b/fsw/src/cf_clist.c
@@ -189,7 +189,7 @@ void CF_CList_Traverse(CF_CListNode_t *start, CF_CListFn_t fn, void *context)
 {
     CF_CListNode_t *node = start;
     CF_CListNode_t *node_next;
-    int             last = 0;
+    bool            last = false;
 
     if (node)
     {
@@ -199,7 +199,7 @@ void CF_CList_Traverse(CF_CListNode_t *start, CF_CListFn_t fn, void *context)
             node_next = node->next;
             if (node_next == start)
             {
-                last = 1;
+                last = true;
             }
             if (!CF_CListTraverse_Status_IS_CONTINUE(fn(node, context)))
             {
@@ -230,7 +230,7 @@ void CF_CList_Traverse_R(CF_CListNode_t *end, CF_CListFn_t fn, void *context)
     {
         CF_CListNode_t *node = end->prev;
         CF_CListNode_t *node_next;
-        int             last = 0;
+        bool             last = false;
 
         if (node)
         {
@@ -242,7 +242,7 @@ void CF_CList_Traverse_R(CF_CListNode_t *end, CF_CListFn_t fn, void *context)
                 node_next = node->prev;
                 if (node_next == end)
                 {
-                    last = 1;
+                    last = true;
                 }
 
                 if (!CF_CListTraverse_Status_IS_CONTINUE(fn(node, context)))

--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -554,13 +554,13 @@ CF_ChanAction_Status_t CF_ValidateMaxOutgoingCmd(uint32 val, uint8 chan_num);
  * @par Assumptions, External Events, and Notes:
  *       None
  *
- * @param is_set    Whether to get (0) or set (1)
+ * @param is_set    Whether to get (false) or set (true)
  * @param param_id  Parameter ID
  * @param value     Value to get/set
  * @param chan_num  Channel number to operate on
  *
  */
-void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num);
+void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num);
 
 /************************************************************************/
 /** @brief Ground command to set a configuration parameter.

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -331,7 +331,7 @@ CF_CListTraverse_Status_t CF_PrioSearch(CF_CListNode_t *node, void *context)
  *-----------------------------------------------------------------*/
 void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue)
 {
-    int           insert_back = 0;
+    bool           insert_back = false;
     CF_Channel_t *chan        = &CF_AppData.engine.channels[txn->chan_num];
 
     CF_Assert(txn->chan_num < CF_NUM_CHANNELS);
@@ -343,7 +343,7 @@ void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue)
     if (!chan->qs[queue])
     {
         /* list is empty, so just insert */
-        insert_back = 1;
+        insert_back = true;
     }
     else
     {
@@ -355,7 +355,7 @@ void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue)
         }
         else
         {
-            insert_back = 1;
+            insert_back = true;
         }
     }
 

--- a/unit-test/cf_app_tests.c
+++ b/unit-test/cf_app_tests.c
@@ -69,7 +69,7 @@ void UT_UpdatedDefaultHandler_CFE_SB_ReceiveBuffer(void *UserObj, UT_EntryKey_t 
 void Test_CF_CheckTables_DoNotReleaseAddressBecauseEngineIsEnabled(void)
 {
     /* Arrange */
-    CF_AppData.engine.enabled = 1;
+    CF_AppData.engine.enabled = true;
 
     /* Act */
     CF_CheckTables();

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -462,7 +462,7 @@ void Test_CF_CFDP_R_CheckCrc(void)
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
     txn->state      = CF_TxnState_R1;
     txn->crc.result = 0xdeadbeef;
-    UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x1badc0de), 1);
+    UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x1badc0de), CF_ERROR);
     UT_CF_AssertEventID(CF_CFDP_R_CRC_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 1);
 
@@ -470,14 +470,14 @@ void Test_CF_CFDP_R_CheckCrc(void)
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
     txn->state      = CF_TxnState_R2;
     txn->crc.result = 0xdeadbeef;
-    UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x2badc0de), 1);
+    UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0x2badc0de), CF_ERROR);
     UT_CF_AssertEventID(CF_CFDP_R_CRC_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.fault.crc_mismatch, 2);
 
     /* CRC match */
     UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_RX, NULL, NULL, NULL, &txn, NULL);
     txn->crc.result = 0xc0ffee;
-    UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0xc0ffee), 0);
+    UtAssert_INT32_EQ(CF_CFDP_R_CheckCrc(txn, 0xc0ffee), CFE_SUCCESS);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -379,7 +379,7 @@ void Test_CF_CFDP_MsgOutGet(void)
 
     /* transaction is suspended */
     UT_CFDP_SetupBasicTestState(UT_CF_Setup_NONE, NULL, NULL, NULL, &txn, NULL);
-    txn->flags.com.suspended = 1;
+    txn->flags.com.suspended = true;
     UtAssert_NULL(CF_CFDP_MsgOutGet(txn, false));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -1455,7 +1455,7 @@ void Test_CF_Abandon_TxnCmd_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetTransaction.txn, arg_t);
-    UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == 0,
+    UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == false,
                   "CF_CFDP_CancelTransaction was called with int %d and should be 0 (constant in call)",
                   context_CF_CFDP_ResetTransaction.keep_history);
 }
@@ -2022,7 +2022,7 @@ void Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT
 
     /* Assert */
     UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetTransaction.txn, &txn);
-    UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == 0,
+    UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == false,
                   "CF_CFDP_ResetTransaction received keep_history %u and should be 0 (constant)",
                   context_CF_CFDP_ResetTransaction.keep_history);
     UtAssert_True(local_result == CF_CLIST_CONT, "CF_PurgeHistory returned %d and should be %d (CF_CLIST_CONT)",
@@ -3421,7 +3421,7 @@ void Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Retu
 void Test_CF_GetSetParamCmd(void)
 {
     /* Test cases for:
-     * void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num);
+     * void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num);
      */
 
     /* Arrange */
@@ -3438,7 +3438,8 @@ void Test_CF_GetSetParamCmd(void)
     for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
     {
         UT_CF_ResetEventCapture();
-        UtAssert_VOIDCALL(CF_GetSetParamCmd(1, param_id, 1 + param_id, UT_CFDP_CHANNEL));
+        UtAssert_VOIDCALL(
+            CF_GetSetParamCmd(true, param_id, 1 + param_id, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
         UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, ++expected_count);
     }
@@ -3459,26 +3460,28 @@ void Test_CF_GetSetParamCmd(void)
     for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
     {
         UT_CF_ResetEventCapture();
-        UtAssert_VOIDCALL(CF_GetSetParamCmd(0, param_id, 1, UT_CFDP_CHANNEL));
+        UtAssert_VOIDCALL(
+            CF_GetSetParamCmd(false, param_id, 1, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_CMD_GETSET2_INF_EID);
         UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, ++expected_count);
     }
 
     /* Bad param ID */
     UT_CF_ResetEventCapture();
-    UtAssert_VOIDCALL(CF_GetSetParamCmd(0, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
+    UtAssert_VOIDCALL(
+        CF_GetSetParamCmd(false, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
     UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
 
     /* Bad channel ID */
     UT_CF_ResetEventCapture();
-    UtAssert_VOIDCALL(CF_GetSetParamCmd(0, 0, 0, CF_NUM_CHANNELS + 1));
+    UtAssert_VOIDCALL(CF_GetSetParamCmd(false, 0, 0, CF_NUM_CHANNELS + 1));
     UT_CF_AssertEventID(CF_CMD_GETSET_CHAN_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 2);
 
     /* Validation fail */
     UT_CF_ResetEventCapture();
-    UtAssert_VOIDCALL(CF_GetSetParamCmd(1, CF_GetSet_ValueID_outgoing_file_chunk_size,
+    UtAssert_VOIDCALL(CF_GetSetParamCmd(true, CF_GetSet_ValueID_outgoing_file_chunk_size,
                                         100 + sizeof(CF_CFDP_PduFileDataContent_t), UT_CFDP_CHANNEL));
     UT_CF_AssertEventID(CF_CMD_GETSET_VALIDATE_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 3);
@@ -3562,7 +3565,7 @@ void Test_CF_EnableEngineCmd_WithEngineNotEnableInitSuccessAndIncrementCmdCounte
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    CF_AppData.engine.enabled = 0; /* 0 is not enabled */
+    CF_AppData.engine.enabled = false;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
 
@@ -3590,7 +3593,7 @@ void Test_CF_EnableEngineCmd_WithEngineNotEnableFailsInitSendEventAndIncrementEr
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    CF_AppData.engine.enabled = 0; /* 0 is not enabled */
+    CF_AppData.engine.enabled = false;
 
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
 
@@ -3617,7 +3620,7 @@ void Test_CF_EnableEngineCmd_WithEngineEnableFailsSendEventAndIncrementCmdCounte
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    CF_AppData.engine.enabled = 1; /* 1 is enabled */
+    CF_AppData.engine.enabled = true;
 
     CF_AppData.hk.Payload.counters.cmd = initial_hk_cmd_counter;
 
@@ -3648,7 +3651,7 @@ void Test_CF_DisableEngineCmd_SuccessWhenEngineEnabledAndIncrementCmdCounter(voi
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    CF_AppData.engine.enabled = 1; /* 1 is enabled */
+    CF_AppData.engine.enabled = true;
 
     CF_AppData.hk.Payload.counters.cmd = initial_hk_cmd_counter;
 
@@ -3672,7 +3675,7 @@ void Test_CF_DisableEngineCmd_WhenEngineDisabledAndIncrementCmdCounter(void)
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    CF_AppData.engine.enabled = 0; /* 0 is not enabled */
+    CF_AppData.engine.enabled = false;
 
     CF_AppData.hk.Payload.counters.cmd = initial_hk_counter;
 

--- a/unit-test/stubs/cf_cfdp_handlers.c
+++ b/unit-test/stubs/cf_cfdp_handlers.c
@@ -124,7 +124,7 @@ void UT_DefaultHandler_CF_CFDP_ResetTransaction(void *UserObj, UT_EntryKey_t Fun
     if (ctxt)
     {
         ctxt->txn          = UT_Hook_GetArgValueByName(Context, "txn", CF_Transaction_t *);
-        ctxt->keep_history = UT_Hook_GetArgValueByName(Context, "keep_history", int);
+        ctxt->keep_history = UT_Hook_GetArgValueByName(Context, "keep_history", bool);
     }
 }
 

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -513,10 +513,10 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
  * Generated stub function for CF_CFDP_ResetTransaction()
  * ----------------------------------------------------
  */
-void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, int keep_history)
+void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, bool keep_history)
 {
     UT_GenStub_AddParam(CF_CFDP_ResetTransaction, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_CFDP_ResetTransaction, int, keep_history);
+    UT_GenStub_AddParam(CF_CFDP_ResetTransaction, bool, keep_history);
 
     UT_GenStub_Execute(CF_CFDP_ResetTransaction, Basic, UT_DefaultHandler_CF_CFDP_ResetTransaction);
 }

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -382,9 +382,9 @@ CFE_Status_t CF_GetParamCmd(const CF_GetParamCmd_t *msg)
  * Generated stub function for CF_GetSetParamCmd()
  * ----------------------------------------------------
  */
-void CF_GetSetParamCmd(uint8 is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num)
+void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, uint8 chan_num)
 {
-    UT_GenStub_AddParam(CF_GetSetParamCmd, uint8, is_set);
+    UT_GenStub_AddParam(CF_GetSetParamCmd, bool, is_set);
     UT_GenStub_AddParam(CF_GetSetParamCmd, CF_GetSet_ValueID_t, param_id);
     UT_GenStub_AddParam(CF_GetSetParamCmd, uint32, value);
     UT_GenStub_AddParam(CF_GetSetParamCmd, uint8, chan_num);

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -103,7 +103,7 @@ typedef struct
 typedef struct
 {
     CF_Transaction_t *txn;
-    int               keep_history;
+    bool               keep_history;
 } CF_CFDP_ResetTransaction_context_t;
 
 typedef struct


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #455 
  - Continuation of recent efforts to improve type/return values in the CFDP app
  - This targets obvious candidates of `int` variables being used to represent boolean truth values (on/off, true/false) to use the actual `bool` type - improving the clarity of the code.
  - Note: no changes have been made here to the external facing `inc` folder

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Effectively no change to behavior (these `int` variables were already being used as boolean truth values).

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt