### PR TITLE
Fix #440, Replaces inaccurate CF_CFDP_ReceiveMessage comment

### DIFF
--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -247,8 +247,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
                                             ph->int_header.fin.cc, ph->pdu_header.destination_eid,
                                             ph->pdu_header.sequence_num) != CF_SEND_PDU_NO_BUF_AVAIL_ERROR)
                         {
-                            /* couldn't get output buffer -- don't care about a send error (oh well, can't send) but we
-                             * do care that there was no message because chan->cur will be set to this transaction */
+                            /* CF_CFDP_SendAck does not return CF_SEND_PDU_ERROR */
                             chan->cur = NULL; /* do not remember temp transaction for next time */
                         }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #440, Replaces inaccurate comment regarding not getting output buffer within CF_CFDP_ReceiveMessage().

**Testing performed**
Manual inspection

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - OS:Ubuntu 20.04

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
