### PR TITLE
Fix #441, cf delete files during error when tx

### DIFF
--- a/config/default_cf_tblstruct.h
+++ b/config/default_cf_tblstruct.h
@@ -51,6 +51,7 @@ typedef struct CF_ConfigTable
     uint16 outgoing_file_chunk_size;    /**< \brief maximum size of outgoing file data chunk in a PDU.
                                          *   Limited by CF_MAX_PDU_SIZE minus the PDU header(s) */
     char tmp_dir[CF_FILENAME_MAX_PATH]; /**< \brief directory to put temp files */
+    char fail_dir[CF_FILENAME_MAX_PATH]; /**< \brief fail directory */
 } CF_ConfigTable_t;
 
 #endif

--- a/docs/dox_src/cfs_cf.dox
+++ b/docs/dox_src/cfs_cf.dox
@@ -398,16 +398,24 @@
   When files are found in a polling directory that is enabled, the files are
   automatically queued by CF for output. The polling rate is configurable and
   each channel has a configurable number of polling directories.  Each polling
-  directory has an enable, a class setting, a priority setting, a preserve
-  setting and a destination directory. When enabled, CF will periodically check
-  the polling directories for files. When a file is found, CF will place the
-  file information on the pending queue if it is closed and not already on the
-  queue and not currently active. All polling directories are checked at the
-  same frequency which is defined by the table parameter
-  NumWakeupsPerPollDirChk. Setting this parameter to one will cause CF to check
-  the polling directories at the fastest possible rate, every time it receives a
-  'wake-up' command. Checking polling directories is a processor-intensive
-  effort, it is best to keep the polling rate as low as possible.
+  directory has an enable, a class setting, a priority setting, a destination 
+  directory. When enabled, CF will periodically check the polling directories 
+  for files. When a file is found, CF will place the file information on the 
+  pending queue if it is closed and not already on the queue and not currently 
+  active. All polling directories are checked at the same frequency which is 
+  defined by the table parameter NumWakeupsPerPollDirChk. Setting this parameter 
+  to one will cause CF to check the polling directories at the fastest possible 
+  rate, every time it receives a 'wake-up' command. Checking polling directories 
+  is a processor-intensive effort, it is best to keep the polling rate as low as 
+  possible.
+
+  <H2> Failed Transmit and directory use </H2>
+   
+  Currently, the fail directory is used only to store class 2 TX files that failed 
+  during transmission from a polling directory. When a file fails during transmission 
+  from a polling directory, it is deleted from the polling directory to prevent an 
+  infinite loop and moved to the fail directory. However, if a file fails during a 
+  class 2 TX outside of a polling directory, the file will not be deleted.
 
   <H2> Efficiency </H2>
 
@@ -645,7 +653,8 @@ CF_UnionArgs_Payload_t;
   and an event will be generated.
 
   If the command is not successful, the command error counter will increment and
-  an error event will be generated indicating the reason for failure.
+  an error event will be generated indicating the reason for failure. File will 
+  not be deleted if the 'transmit' failed (unless in an polling directories). 
 
   \verbatim
   typedef struct CF_TxFileCmd

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -1588,9 +1588,7 @@ void CF_CFDP_CycleEngine(void)
  *-----------------------------------------------------------------*/
 void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, int keep_history)
 {
-    char *        filename;
-    char          destination[OS_MAX_PATH_LEN];
-    osal_status_t status = OS_ERROR;
+
     CF_Channel_t *chan   = &CF_AppData.engine.channels[txn->chan_num];
     CF_Assert(txn->chan_num < CF_NUM_CHANNELS);
 
@@ -1608,31 +1606,10 @@ void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, int keep_history)
     if (OS_ObjectIdDefined(txn->fd))
     {
         CF_WrappedClose(txn->fd);
+
         if (!txn->keep)
         {
-            if (CF_CFDP_IsSender(txn))
-            {
-                /* If move directory is defined attempt move */
-                if (CF_AppData.config_table->chan[txn->chan_num].move_dir[0] != 0)
-                {
-                    filename = strrchr(txn->history->fnames.src_filename, '/');
-                    if (filename != NULL)
-                    {
-                        snprintf(destination, sizeof(destination), "%s%s",
-                                 CF_AppData.config_table->chan[txn->chan_num].move_dir, filename);
-                        status = OS_mv(txn->history->fnames.src_filename, destination);
-                    }
-                }
-
-                if (status != OS_SUCCESS)
-                {
-                    OS_remove(txn->history->fnames.src_filename);
-                }
-            }
-            else
-            {
-                OS_remove(txn->history->fnames.dst_filename);
-            }
+            CF_CFDP_HandleNotKeepFile(txn);
         }
     }
 
@@ -1827,5 +1804,102 @@ void CF_CFDP_DisableEngine(void)
         memset(&CF_AppData.hk.Payload.channel_hk[i].q_size, 0, sizeof(CF_AppData.hk.Payload.channel_hk[i].q_size));
 
         CFE_SB_DeletePipe(chan->pipe);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in cf_cfdp.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+bool CF_CFDP_IsPollingDir(const char * src_file, uint8 chan_num)
+{
+    bool return_code = false;
+    char src_dir[CF_FILENAME_MAX_LEN] = "\0";
+    CF_ChannelConfig_t *cc;
+    CF_PollDir_t *      pd;
+    int                 i;
+
+    char * last_slash = strrchr(src_file, '/');
+    if(last_slash != NULL)
+    {
+        strncpy(src_dir, src_file, last_slash - src_file);
+    }
+
+    cc = &CF_AppData.config_table->chan[chan_num];
+    for (i = 0; i < CF_MAX_POLLING_DIR_PER_CHAN; ++i)
+    {
+        pd = &cc->polldir[i];
+        if(strcmp(src_dir, pd->src_dir) == 0)
+        {
+            return_code = true;
+            break;
+        }
+    }
+
+    return return_code;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in cf_cfdp.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CF_CFDP_HandleNotKeepFile(CF_Transaction_t *txn)
+{
+    /* Sender */
+    if (CF_CFDP_IsSender(txn))
+    {
+        if(!CF_TxnStatus_IsError(txn->history->txn_stat))
+        {
+            /* If move directory is defined attempt move */
+            CF_CFDP_MoveFile(txn->history->fnames.src_filename, CF_AppData.config_table->chan[txn->chan_num].move_dir);
+        }
+        else
+        {
+            /* file inside an polling directory */
+            if(CF_CFDP_IsPollingDir(txn->history->fnames.src_filename, txn->chan_num))
+            {
+                /* If fail directory is defined attempt move */
+                CF_CFDP_MoveFile(txn->history->fnames.src_filename, CF_AppData.config_table->fail_dir);
+            }
+        }
+    }
+    /* Not Sender */
+    else
+    {
+        OS_remove(txn->history->fnames.dst_filename);
+    }
+}
+
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in cf_cfdp.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CF_CFDP_MoveFile(const char *src, const char *dest_dir)
+{
+    osal_status_t status = OS_ERROR;
+    char *        filename;
+    char          destination[OS_MAX_PATH_LEN];
+
+    if(dest_dir[0] != 0)
+    {
+        filename = strrchr(src, '/');
+        if (filename != NULL)
+        {
+            snprintf(destination, sizeof(destination), "%s%s",
+                    dest_dir, filename);
+            status = OS_mv(src, destination);
+        }  
+    }
+
+    if (status != OS_SUCCESS)
+    {
+        OS_remove(src);
     }
 }

--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -703,4 +703,34 @@ void CF_CFDP_ProcessPollingDirectories(CF_Channel_t *chan);
  */
 CF_CListTraverse_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context);
 
+/************************************************************************/
+/** @brief Check if source file came from polling directory
+ *
+ *
+ * @par Assumptions, External Events, and Notes:
+ *
+ * @retval true/false
+ */
+bool CF_CFDP_IsPollingDir(const char * src_file, uint8 chan_num);
+
+/************************************************************************/
+/** @brief Remove/Move file after transaction
+ * 
+ * This helper is used to handle "not keep" file option after a transaction.  
+ *
+ * @par Assumptions, External Events, and Notes:
+ *
+ */
+void CF_CFDP_HandleNotKeepFile(CF_Transaction_t *txn);
+
+/************************************************************************/
+/** @brief Move File 
+ * 
+ * This helper is used to move a file.  
+ *
+ * @par Assumptions, External Events, and Notes:
+ *
+ */
+void CF_CFDP_MoveFile(const char *src, const char *dest_dir);
+
 #endif /* !CF_CFDP_H */

--- a/fsw/tables/cf_def_config.c
+++ b/fsw/tables/cf_def_config.c
@@ -80,5 +80,6 @@ CF_ConfigTable_t CF_config_table = {
       .move_dir = ""}},
     480,       /* outgoing_file_chunk_size */
     "/cf/tmp", /* temporary file directory */
+    "/cf/fail", /* Stores failed tx file for "polling directory" */
 };
 CFE_TBL_FILEDEF(CF_config_table, CF.config_table, CF config table, cf_def_config.tbl)

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -245,6 +245,18 @@ void CF_CFDP_EncodeStart(CF_EncoderState_t *penc, void *msgbuf, CF_Logical_PduBu
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_HandleNotKeepFile()
+ * ----------------------------------------------------
+ */
+void CF_CFDP_HandleNotKeepFile(CF_Transaction_t *txn)
+{
+    UT_GenStub_AddParam(CF_CFDP_HandleNotKeepFile, CF_Transaction_t *, txn);
+
+    UT_GenStub_Execute(CF_CFDP_HandleNotKeepFile, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_CFDP_InitEngine()
  * ----------------------------------------------------
  */
@@ -271,6 +283,36 @@ void CF_CFDP_InitTxnTxFile(CF_Transaction_t *txn, CF_CFDP_Class_t cfdp_class, ui
     UT_GenStub_AddParam(CF_CFDP_InitTxnTxFile, uint8, priority);
 
     UT_GenStub_Execute(CF_CFDP_InitTxnTxFile, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_IsPollingDir()
+ * ----------------------------------------------------
+ */
+bool CF_CFDP_IsPollingDir(const char *src_file, uint8 chan_num)
+{
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_IsPollingDir, bool);
+
+    UT_GenStub_AddParam(CF_CFDP_IsPollingDir, const char *, src_file);
+    UT_GenStub_AddParam(CF_CFDP_IsPollingDir, uint8, chan_num);
+
+    UT_GenStub_Execute(CF_CFDP_IsPollingDir, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_CFDP_IsPollingDir, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_MoveFile()
+ * ----------------------------------------------------
+ */
+void CF_CFDP_MoveFile(const char *src, const char *dest_dir)
+{
+    UT_GenStub_AddParam(CF_CFDP_MoveFile, const char *, src);
+    UT_GenStub_AddParam(CF_CFDP_MoveFile, const char *, dest_dir);
+
+    UT_GenStub_Execute(CF_CFDP_MoveFile, Basic, NULL);
 }
 
 /*


### PR DESCRIPTION
Fix #441, Update to handle an error during tx. For polling, the file gets moved or deleted to prevent an infinite loop. For others, the file does not get deleted. Update Unit Test.

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]
Fix #441, cf delete file during error when tx. 

**Testing performed**
Steps taken to test the contribution:
1. Tx class 2 cmd and make fail. ( ack limit reached, no eof-ack)
2. Check file has not been deleted. 

3. Put in polling directory and see and make fail (ack limit reached, no eof-ack)
4. Check file has been moved to fail directory
5. File is no longer in polling directory

6. Put in polling directory, no failing directory, and make fail ( ack limit reached, no eof-ack)
7. The file is deleted from the polling directory. 

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
1. When an error occurs during the TX.
a. if the file is not in a polling directory, do nothing
b. if the file is in a polling directory, attempt to move to the "fail" directory and delete it from the polling directory. 

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]
Tested on a docker container with ubuntu22.04 running against COSMOS

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
Anh Van, GSFC

