### PR TITLE
Fix #460, add fail_dir member to EDS

### DIFF
--- a/eds/cf.xml
+++ b/eds/cf.xml
@@ -174,7 +174,7 @@
          <Entry type="ChannelConfigTable" name="chan" shortDescription="Channel configuration" />
          <Entry type="BASE_TYPES/uint16" name="outgoing_file_chunk_size" shortDescription="maximum size of outgoing file data PDUs - must be smaller than file data character array" />
          <Entry type="BASE_TYPES/PathName" name="tmp_dir" shortDescription="directory to put temp files" />
-
+         <Entry type="BASE_TYPES/PathName" name="fail_dir" shortDescription="fail directory" />
        </EntryList>
      </ContainerDataType>
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The CF_ConfigTable has a field that was recently added to source but not to EDS.  This updates the EDS XML to match.

Fixes #460

**Testing performed**
Build with EDS, tables build successfully

**Expected behavior changes**
Build with EDS, tables build successfully

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
