### PR TITLE
Fix #462, Setting status after memset

### DIFF
--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -192,10 +192,10 @@ CFE_Status_t CF_AppInit(void)
     const CFE_SB_MsgId_Atom_t MID_VALUES[] = {CF_CMD_MID, CF_SEND_HK_MID, CF_WAKE_UP_MID};
     uint32                    i;
 
-    CF_AppData.RunStatus = CFE_ES_RunStatus_APP_RUN;
-
     /* Zero-out global data structure */
     memset(&CF_AppData, 0, sizeof(CF_AppData));
+
+    CF_AppData.RunStatus = CFE_ES_RunStatus_APP_RUN;
 
     CFE_MSG_Init(CFE_MSG_PTR(CF_AppData.hk.TelemetryHeader), CFE_SB_ValueToMsgId(CF_HK_TLM_MID), sizeof(CF_AppData.hk));
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #462 - Setting RunStatus after the memset call

**Expected behavior changes**
Value of CF_AppData.RunStatus will stay defined in CF_AppInit()

**System(s) tested on**
OS: RHEL 8.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Tvisha Andharia - GSFC 582 intern
