### PR TITLE
Fix #469, rename CF_ResetCmd to CF_ResetCountersCmd in EDS

### DIFF
--- a/eds/cf.xml
+++ b/eds/cf.xml
@@ -439,7 +439,7 @@
         </ConstraintSet>
       </ContainerDataType>
 
-      <ContainerDataType name="ResetCmd" baseType="CMD" shortDescription="Resets HK TLM parent and child task counters">
+      <ContainerDataType name="ResetCountersCmd" baseType="CMD" shortDescription="Resets HK TLM parent and child task counters">
         <LongDescription>
               \cfcmd Reset counters
 

--- a/fsw/src/cf_eds_dispatch.c
+++ b/fsw/src/cf_eds_dispatch.c
@@ -25,7 +25,7 @@ static const EdsDispatchTable_CF_Application_CFE_SB_Telecommand_t CF_TC_DISPATCH
             .NoopCmd_indication              = CF_NoopCmd,
             .PlaybackDirCmd_indication       = CF_PlaybackDirCmd,
             .PurgeQueueCmd_indication        = CF_PurgeQueueCmd,
-            .ResetCmd_indication             = CF_ResetCmd,
+            .ResetCountersCmd_indication     = CF_ResetCountersCmd,
             .ResumeCmd_indication            = CF_ResumeCmd,
             .SetParamCmd_indication          = CF_SetParamCmd,
             .SuspendCmd_indication           = CF_SuspendCmd,


### PR DESCRIPTION
This change had been made to the FSW but a corresponding change needs to be made to the EDS file.

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Renames the command to `CF_ResetCountersCmd` to match FSW (changed previously).

Fixes #469

**Testing performed**
Build and run

**Expected behavior changes**
Builds successfully

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
