### PR TITLE
Fix #463, size check

### DIFF
--- a/fsw/src/cf_dispatch.c
+++ b/fsw/src/cf_dispatch.c
@@ -84,7 +84,7 @@ void CF_ProcessGroundCommand(const CFE_SB_Buffer_t *BufPtr)
         [CF_DISABLE_DEQUEUE_CC]     = sizeof(CF_DisableDequeueCmd_t),
         [CF_ENABLE_DIR_POLLING_CC]  = sizeof(CF_EnableDirPollingCmd_t),
         [CF_DISABLE_DIR_POLLING_CC] = sizeof(CF_DisableDirPollingCmd_t),
-        [CF_PURGE_QUEUE_CC]         = sizeof(CF_UnionArgs_Payload_t),
+        [CF_PURGE_QUEUE_CC]         = sizeof(CF_PurgeQueueCmd_t),
         [CF_ENABLE_ENGINE_CC]       = sizeof(CF_EnableEngineCmd_t),
         [CF_DISABLE_ENGINE_CC]      = sizeof(CF_DisableEngineCmd_t),
     };


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [ x I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Correct the size for CF_PURGE_QUEUE_CC.  It should be the size of the whole command struct, not just the payload.  Not sure how this got mismatched, it was the only one.

Fixes #463

**Testing performed**
Build and run CF, send command

**Expected behavior changes**
No longer rejects command

**System(s) tested on**
Linux

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
