### PR TITLE
Fix #435, simplify state machines and add holdover

### DIFF
--- a/config/default_cf_extern_typedefs.h
+++ b/config/default_cf_extern_typedefs.h
@@ -78,7 +78,7 @@ typedef enum
     CF_QueueIdx_HIST      = 4,
     CF_QueueIdx_HIST_FREE = 5,
     CF_QueueIdx_FREE      = 6,
-    CF_QueueIdx_NUM       = 7,
+    CF_QueueIdx_NUM       = 7
 } CF_QueueIdx_t;
 
 /**

--- a/config/default_cf_internal_cfg.h
+++ b/config/default_cf_internal_cfg.h
@@ -16,24 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ************************************************************************/
-/************************************************************************
- * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
- * System (cFS) Health & Safety (CF) Application version 2.4.1”
- *
- * Copyright (c) 2021 United States Government as represented by the
- * Administrator of the National Aeronautics and Space Administration.
- * All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License. You may obtain
- * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- ************************************************************************/
 
 /**
  * @file

--- a/config/default_cf_tbldefs.h
+++ b/config/default_cf_tbldefs.h
@@ -78,7 +78,6 @@ typedef struct CF_ChannelConfig
     char  move_dir[OS_MAX_PATH_LEN]; /**< \brief Move directory if not empty */
 } CF_ChannelConfig_t;
 
-
 /*
  * Previously, the entire definition of the CF table was in this file, now it is split.
  * For backward compatibility with existing CF table definitions, include the other part here.

--- a/config/default_cf_tblstruct.h
+++ b/config/default_cf_tblstruct.h
@@ -48,9 +48,9 @@ typedef struct CF_ConfigTable
 
     CF_ChannelConfig_t chan[CF_NUM_CHANNELS]; /**< \brief Channel configuration */
 
-    uint16 outgoing_file_chunk_size;    /**< \brief maximum size of outgoing file data chunk in a PDU.
-                                         *   Limited by CF_MAX_PDU_SIZE minus the PDU header(s) */
-    char tmp_dir[CF_FILENAME_MAX_PATH]; /**< \brief directory to put temp files */
+    uint16 outgoing_file_chunk_size;     /**< \brief maximum size of outgoing file data chunk in a PDU.
+                                          *   Limited by CF_MAX_PDU_SIZE minus the PDU header(s) */
+    char tmp_dir[CF_FILENAME_MAX_PATH];  /**< \brief directory to put temp files */
     char fail_dir[CF_FILENAME_MAX_PATH]; /**< \brief fail directory */
 } CF_ConfigTable_t;
 

--- a/fsw/inc/cf_events.h
+++ b/fsw/inc/cf_events.h
@@ -490,6 +490,19 @@
  */
 #define CF_CFDP_CLOSE_ERR_EID (68)
 
+/**
+ * \brief CF No chunklist available
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Engine has aborted a transaction due to lack of an
+ *  available resource to track the chunks associated
+ *  with the file.
+ */
+#define CF_CFDP_NO_CHUNKLIST_AVAIL_EID 88
+
 /**************************************************************************
  * CF_CFDP_R event IDs - Engine receive
  */
@@ -709,6 +722,19 @@
  *  Expiration of the RX inactivity timer
  */
 #define CF_CFDP_R_INACT_TIMER_ERR_EID (88)
+
+/**
+ * \brief CF No chunklist available
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Engine has aborted a transaction due to lack of an
+ *  available resource to track the chunks associated
+ *  with the file.
+ */
+#define CF_CFDP_NO_CHUNKLIST_AVAIL_EID 88
 
 /**************************************************************************
  * CF_CFDP_S event IDs - Engine send

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -144,10 +144,9 @@ static inline CF_CFDP_Class_t CF_CFDP_GetClass(const CF_Transaction_t *txn)
  *-----------------------------------------------------------------*/
 static inline bool CF_CFDP_IsSender(CF_Transaction_t *txn)
 {
-    CF_Assert(txn->flags.com.q_index != CF_QueueIdx_FREE);
-    /* the state could actually be CF_TxnState_IDLE, which is still not a sender. This would
-     * be an unused transaction in the RX (CF_CFDP_ReceiveMessage) path. */
-    return !!((txn->state == CF_TxnState_S1) || (txn->state == CF_TxnState_S2));
+    CF_Assert(txn->history);
+
+    return (txn->history->dir == CF_Direction_TX);
 }
 
 /*----------------------------------------------------------------
@@ -155,9 +154,29 @@ static inline bool CF_CFDP_IsSender(CF_Transaction_t *txn)
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
-static inline void CF_CFDP_ArmInactTimer(CF_Transaction_t *txn)
+void CF_CFDP_ArmInactTimer(CF_Transaction_t *txn)
 {
-    CF_Timer_InitRelSec(&txn->inactivity_timer, CF_AppData.config_table->chan[txn->chan_num].inactivity_timer_s);
+    CF_Timer_Seconds_t Sec;
+
+    /* select timeout based on the state */
+    if (CF_CFDP_GetTxnStatus(txn) == CF_CFDP_AckTxnStatus_ACTIVE)
+    {
+        /* in an active transaction, we expect traffic so use the normal inactivity timer */
+        Sec = CF_AppData.config_table->chan[txn->chan_num].inactivity_timer_s;
+    }
+    else
+    {
+        /* in an inactive transaction, we do NOT expect traffic, and this timer is now used
+         * just in case any late straggler PDUs dp get delivered.  In this case the
+         * time should be longer than the retransmit time (ack timer) but less than the full
+         * inactivity timer (because again, we are not expecting traffic, so waiting the full
+         * timeout would hold resources longer than needed).  Using double the ack timer should
+         * ensure that if the remote retransmitted anything, we will see it, and avoids adding
+         * another config option just for this. */
+        Sec = CF_AppData.config_table->chan[txn->chan_num].ack_timer_s * 2;
+    }
+
+    CF_Timer_InitRelSec(&txn->inactivity_timer, Sec);
 }
 
 /*----------------------------------------------------------------
@@ -168,12 +187,13 @@ static inline void CF_CFDP_ArmInactTimer(CF_Transaction_t *txn)
  *-----------------------------------------------------------------*/
 void CF_CFDP_DispatchRecv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 {
-    static const CF_CFDP_TxnRecvDispatchTable_t state_fns = {.rx = {[CF_TxnState_IDLE] = CF_CFDP_RecvIdle,
+    static const CF_CFDP_TxnRecvDispatchTable_t state_fns = {.rx = {[CF_TxnState_INIT] = CF_CFDP_RecvInit,
                                                                     [CF_TxnState_R1]   = CF_CFDP_R1_Recv,
                                                                     [CF_TxnState_S1]   = CF_CFDP_S1_Recv,
                                                                     [CF_TxnState_R2]   = CF_CFDP_R2_Recv,
                                                                     [CF_TxnState_S2]   = CF_CFDP_S2_Recv,
-                                                                    [CF_TxnState_DROP] = CF_CFDP_RecvDrop}};
+                                                                    [CF_TxnState_DROP] = CF_CFDP_RecvDrop,
+                                                                    [CF_TxnState_HOLD] = CF_CFDP_RecvHold}};
 
     CF_CFDP_RxStateDispatch(txn, ph, &state_fns);
     CF_CFDP_ArmInactTimer(txn); /* whenever a packet was received by the other size, always arm its inactivity timer */
@@ -200,11 +220,22 @@ static void CF_CFDP_DispatchTx(CF_Transaction_t *txn)
 static CF_ChunkWrapper_t *CF_CFDP_FindUnusedChunks(CF_Channel_t *chan, CF_Direction_t dir)
 {
     CF_ChunkWrapper_t *ret;
+    CF_CListNode_t **  chunklist_head;
 
-    CF_Assert(dir < CF_Direction_NUM);
-    CF_Assert(chan->cs[dir]);
+    chunklist_head = CF_GetChunkListHead(chan, dir);
 
-    ret = container_of(CF_CList_Pop(&chan->cs[dir]), CF_ChunkWrapper_t, cl_node);
+    /* this should never be null */
+    CF_Assert(chunklist_head);
+
+    if (*chunklist_head == NULL)
+    {
+        ret = NULL;
+    }
+    else
+    {
+        ret = container_of(CF_CList_Pop(chunklist_head), CF_ChunkWrapper_t, cl_node);
+    }
+
     return ret;
 }
 
@@ -251,7 +282,7 @@ CF_Logical_PduBuffer_t *CF_CFDP_ConstructPduHeader(const CF_Transaction_t *txn, 
         hdr = &ph->pdu_header;
 
         hdr->version   = 1;
-        hdr->pdu_type  = (directive_code == 0); /* set to '1' for file data PDU, '0' for a directive PDU */
+        hdr->pdu_type  = (directive_code == 0);     /* set to '1' for file data PDU, '0' for a directive PDU */
         hdr->direction = (towards_sender != false); /* set to '1' for toward sender, '0' for toward receiver */
         hdr->txm_mode  = (CF_CFDP_GetClass(txn) == CF_CFDP_CLASS_1); /* set to '1' for class 1 data, '0' for class 2 */
 
@@ -844,7 +875,41 @@ void CF_CFDP_RecvDrop(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CF_CFDP_RecvIdle(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
+void CF_CFDP_RecvHold(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
+{
+    /* anything received in this state is considered spurious */
+    ++CF_AppData.hk.Payload.channel_hk[txn->chan_num].counters.recv.spurious;
+
+    /*
+     * Normally we do not expect PDUs for a transaction in holdover, because
+     * from the local point of view it is completed and done.  But the reason
+     * for the holdover is because the remote side might not have gotten all
+     * the acks and could still be [re-]sending us PDUs for anything it does
+     * not know we got already.
+     *
+     * If an R2 sent FIN, it's possible that the peer missed the
+     * FIN-ACK and is sending another FIN. In that case we need to send
+     * another ACK.
+     */
+
+    /* currently the only thing we will re-ack is the FIN. */
+    if (ph->fdirective.directive_code == CF_CFDP_FileDirective_FIN)
+    {
+        if (!CF_CFDP_RecvFin(txn, ph))
+        {
+            CF_CFDP_SendAck(txn, CF_CFDP_AckTxnStatus_TERMINATED, CF_CFDP_FileDirective_FIN, ph->int_header.fin.cc,
+                            ph->pdu_header.destination_eid, ph->pdu_header.sequence_num);
+        }
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in cf_cfdp.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CF_CFDP_RecvInit(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 {
     CF_Logical_PduFileDirectiveHeader_t *fdh;
     int                                  status;
@@ -857,11 +922,18 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
     txn->history->peer_eid = ph->pdu_header.source_eid;
     txn->history->src_eid  = ph->pdu_header.source_eid;
 
-    txn->chunks = CF_CFDP_FindUnusedChunks(&CF_AppData.engine.channels[txn->chan_num], CF_Direction_RX);
-
-    /* this is an idle transaction, so see if there's a received packet that can
-     * be bound to the transaction */
-    if (ph->pdu_header.pdu_type)
+    /* all RX transactions will need a chunk list to track file segments */
+    if (txn->chunks == NULL)
+    {
+        txn->chunks = CF_CFDP_FindUnusedChunks(CF_GetChannelFromTxn(txn), CF_Direction_RX);
+    }
+    if (txn->chunks == NULL)
+    {
+        CFE_EVS_SendEvent(CF_CFDP_NO_CHUNKLIST_AVAIL_EID, CFE_EVS_EventType_ERROR,
+                          "CF: cannot get chunklist -- abandoning transaction %u\n",
+                          (unsigned int)ph->pdu_header.sequence_num);
+    }
+    else if (ph->pdu_header.pdu_type)
     {
         /* file data PDU */
         /* being idle and receiving a file data PDU means that no active transaction knew
@@ -915,10 +987,10 @@ void CF_CFDP_RecvIdle(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
         }
     }
 
-    if (txn->state == CF_TxnState_IDLE)
+    if (txn->state == CF_TxnState_INIT)
     {
         /* state was not changed, so free the transaction */
-        CF_CFDP_ResetTransaction(txn, false);
+        CF_CFDP_FinishTransaction(txn, false);
     }
 }
 
@@ -932,8 +1004,9 @@ CFE_Status_t CF_CFDP_InitEngine(void)
 {
     /* initialize all transaction nodes */
     CF_History_t *     history;
-    CF_Transaction_t * txn              = CF_AppData.engine.transactions;
-    CF_ChunkWrapper_t *cw               = CF_AppData.engine.chunks;
+    CF_Transaction_t * txn = CF_AppData.engine.transactions;
+    CF_ChunkWrapper_t *cw  = CF_AppData.engine.chunks;
+    CF_CListNode_t **  list_head;
     CFE_Status_t       ret              = CFE_SUCCESS;
     int                chunk_mem_offset = 0;
     int                i;
@@ -1003,16 +1076,18 @@ CFE_Status_t CF_CFDP_InitEngine(void)
 
         for (j = 0; j < CF_NUM_TRANSACTIONS_PER_CHANNEL; ++j, ++txn)
         {
-            txn->chan_num = i;
-            CF_FreeTransaction(txn);
+            /* Initially put this on the free list for this channel */
+            CF_FreeTransaction(txn, i);
 
             for (k = 0; k < CF_Direction_NUM; ++k, ++cw)
             {
+                list_head = CF_GetChunkListHead(&CF_AppData.engine.channels[i], k);
+
                 CF_Assert((chunk_mem_offset + CF_DIR_MAX_CHUNKS[k][i]) <= CF_NUM_CHUNKS_ALL_CHANNELS);
                 CF_ChunkListInit(&cw->chunks, CF_DIR_MAX_CHUNKS[k][i], &CF_AppData.engine.chunk_mem[chunk_mem_offset]);
                 chunk_mem_offset += CF_DIR_MAX_CHUNKS[k][i];
                 CF_CList_InitNode(&cw->cl_node);
-                CF_CList_InsertBack(&CF_AppData.engine.channels[i].cs[k], &cw->cl_node);
+                CF_CList_InsertBack(list_head, &cw->cl_node);
             }
         }
 
@@ -1078,8 +1153,9 @@ void CF_CFDP_CycleTx(CF_Channel_t *chan)
 {
     CF_Transaction_t *     txn;
     CF_CFDP_CycleTx_args_t args;
+    uint8                  chan_num = (chan - CF_AppData.engine.channels);
 
-    if (CF_AppData.config_table->chan[(chan - CF_AppData.engine.channels)].dequeue_enabled)
+    if (CF_AppData.config_table->chan[chan_num].dequeue_enabled)
     {
         args = (CF_CFDP_CycleTx_args_t) {chan, 0};
 
@@ -1102,6 +1178,20 @@ void CF_CFDP_CycleTx(CF_Channel_t *chan)
                 }
 
                 txn = container_of(chan->qs[CF_QueueIdx_PEND], CF_Transaction_t, cl_node);
+
+                /* to be processed this needs a chunklist, get one now */
+                if (txn->chunks == NULL)
+                {
+                    txn->chunks = CF_CFDP_FindUnusedChunks(chan, CF_Direction_TX);
+                }
+                if (txn->chunks == NULL)
+                {
+                    /* leave it pending, come back later */
+                    /* it needs to wait until a chunklist is freed */
+                    break;
+                }
+
+                CF_CFDP_ArmInactTimer(txn);
                 CF_MoveTransaction(txn, CF_QueueIdx_TXA);
             }
         }
@@ -1193,7 +1283,8 @@ void CF_CFDP_TickTransactions(CF_Channel_t *chan)
 
                 break;
             }
-        } while (args.cont);
+        }
+        while (args.cont);
 
         if (!reset)
         {
@@ -1241,15 +1332,10 @@ static void CF_CFDP_TxFile_Initiate(CF_Transaction_t *txn, CF_CFDP_Class_t cfdp_
     ++CF_AppData.engine.seq_num;
 
     /* Capture info for history */
-    txn->history->dir      = CF_Direction_TX;
     txn->history->seq_num  = CF_AppData.engine.seq_num;
     txn->history->src_eid  = CF_AppData.config_table->local_eid;
     txn->history->peer_eid = dest_id;
 
-    CF_CFDP_ArmInactTimer(txn);
-
-    /* NOTE: whether or not class 1 or 2, get a free chunks. It's cheap, and simplifies cleanup path */
-    txn->chunks = CF_CFDP_FindUnusedChunks(&CF_AppData.engine.channels[chan], CF_Direction_TX);
     CF_InsertSortPrio(txn, CF_QueueIdx_PEND);
 }
 
@@ -1268,7 +1354,16 @@ CFE_Status_t CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, 
 
     CFE_Status_t ret = CFE_SUCCESS;
 
-    if (chan->num_cmd_tx == CF_MAX_COMMANDED_PLAYBACK_FILES_PER_CHAN)
+    if (chan->num_cmd_tx < CF_MAX_COMMANDED_PLAYBACK_FILES_PER_CHAN)
+    {
+        txn = CF_FindUnusedTransaction(&CF_AppData.engine.channels[chan_num], CF_Direction_TX);
+    }
+    else
+    {
+        txn = NULL;
+    }
+
+    if (txn == NULL)
     {
         CFE_EVS_SendEvent(CF_CFDP_MAX_CMD_TX_ERR_EID, CFE_EVS_EventType_ERROR,
                           "CF: max number of commanded files reached");
@@ -1276,11 +1371,6 @@ CFE_Status_t CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, 
     }
     else
     {
-        txn = CF_FindUnusedTransaction(&CF_AppData.engine.channels[chan_num]);
-        CF_Assert(txn); /* should always have a free transaction at this point */
-
-        CF_Assert(txn->state == CF_TxnState_IDLE);
-
         /* NOTE: the caller of this function ensures the provided src and dst filenames are NULL terminated */
         strncpy(txn->history->fnames.src_filename, src_filename, sizeof(txn->history->fnames.src_filename) - 1);
         txn->history->fnames.src_filename[sizeof(txn->history->fnames.src_filename) - 1] = 0;
@@ -1293,6 +1383,39 @@ CFE_Status_t CF_CFDP_TxFile(const char *src_filename, const char *dst_filename, 
     }
 
     return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in cf_cfdp.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CF_Transaction_t *CF_CFDP_StartRxTransaction(uint8 chan_num)
+{
+    CF_Channel_t *    chan = &CF_AppData.engine.channels[chan_num];
+    CF_Transaction_t *txn;
+
+    if (CF_AppData.hk.Payload.channel_hk[chan_num].q_size[CF_QueueIdx_RX] < CF_MAX_SIMULTANEOUS_RX)
+    {
+        txn = CF_FindUnusedTransaction(chan, CF_Direction_RX);
+    }
+    else
+    {
+        txn = NULL;
+    }
+
+    if (txn != NULL)
+    {
+        /* set default FIN status */
+        txn->state_data.receive.r2.dc = CF_CFDP_FinDeliveryCode_INCOMPLETE;
+        txn->state_data.receive.r2.fs = CF_CFDP_FinFileStatus_DISCARDED;
+
+        txn->flags.com.q_index = CF_QueueIdx_RX;
+        CF_CList_InsertBack_Ex(chan, txn->flags.com.q_index, &txn->cl_node);
+    }
+
+    return txn;
 }
 
 /*----------------------------------------------------------------
@@ -1382,42 +1505,51 @@ void CF_CFDP_ProcessPlaybackDirectory(CF_Channel_t *chan, CF_Playback_t *pb)
 
     while (pb->diropen && (pb->num_ts < CF_NUM_TRANSACTIONS_PER_PLAYBACK))
     {
-        CFE_ES_PerfLogEntry(CF_PERF_ID_DIRREAD);
-        status = OS_DirectoryRead(pb->dir_id, &dirent);
-        CFE_ES_PerfLogExit(CF_PERF_ID_DIRREAD);
-
-        if (status == CFE_SUCCESS)
+        if (pb->pending_file[0] == 0)
         {
+            CFE_ES_PerfLogEntry(CF_PERF_ID_DIRREAD);
+            status = OS_DirectoryRead(pb->dir_id, &dirent);
+            CFE_ES_PerfLogExit(CF_PERF_ID_DIRREAD);
+
+            if (status != OS_SUCCESS)
+            {
+                /* PFTO: can we figure out the difference between "end of dir" and an error? */
+                OS_DirectoryClose(pb->dir_id);
+                pb->diropen = false;
+                break;
+            }
+
             if (!strcmp(dirent.FileName, ".") || !strcmp(dirent.FileName, ".."))
             {
                 continue;
             }
 
-            txn = CF_FindUnusedTransaction(chan);
-            CF_Assert(pt); /* should be impossible not to have one because there are limits on the number of uses of
-                                them */
+            strncpy(pb->pending_file, OS_DIRENTRY_NAME(dirent), sizeof(pb->pending_file) - 1);
+            pb->pending_file[sizeof(pb->pending_file) - 1] = 0;
+        }
+        else
+        {
+            txn = CF_FindUnusedTransaction(chan, CF_Direction_TX);
+            if (txn == NULL)
+            {
+                /* while not expected this can certainly happen, because
+                 * rx transactions consume in these as well. */
+                /* should not need to do anything special, will come back next tick */
+                break;
+            }
 
-            /* the -1 below is to make room for the slash */
             snprintf(txn->history->fnames.src_filename, sizeof(txn->history->fnames.src_filename), "%.*s/%.*s",
-                     CF_FILENAME_MAX_PATH - 1, pb->fnames.src_filename, CF_FILENAME_MAX_NAME - 1, dirent.FileName);
+                     CF_FILENAME_MAX_PATH - 1, pb->fnames.src_filename, CF_FILENAME_MAX_NAME - 1, pb->pending_file);
             snprintf(txn->history->fnames.dst_filename, sizeof(txn->history->fnames.dst_filename), "%.*s/%.*s",
-                     CF_FILENAME_MAX_PATH - 1, pb->fnames.dst_filename, CF_FILENAME_MAX_NAME - 1, dirent.FileName);
-
-            /* in case snprintf didn't have room for NULL terminator */
-            txn->history->fnames.src_filename[CF_FILENAME_MAX_LEN - 1] = 0;
-            txn->history->fnames.dst_filename[CF_FILENAME_MAX_LEN - 1] = 0;
+                     CF_FILENAME_MAX_PATH - 1, pb->fnames.dst_filename, CF_FILENAME_MAX_NAME - 1, pb->pending_file);
 
             CF_CFDP_TxFile_Initiate(txn, pb->cfdp_class, pb->keep, (chan - CF_AppData.engine.channels), pb->priority,
                                     pb->dest_id);
 
             txn->pb = pb;
             ++pb->num_ts;
-        }
-        else
-        {
-            /* PFTO: can we figure out the difference between "end of dir" and an error? */
-            OS_DirectoryClose(pb->dir_id);
-            pb->diropen = false;
+
+            pb->pending_file[0] = 0; /* continue reading dir */
         }
     }
 
@@ -1586,11 +1718,9 @@ void CF_CFDP_CycleEngine(void)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, bool keep_history)
+void CF_CFDP_FinishTransaction(CF_Transaction_t *txn, bool keep_history)
 {
-
-    CF_Channel_t *chan   = &CF_AppData.engine.channels[txn->chan_num];
-    CF_Assert(txn->chan_num < CF_NUM_CHANNELS);
+    CF_Channel_t *chan;
 
     if (txn->flags.com.q_index == CF_QueueIdx_FREE)
     {
@@ -1599,9 +1729,23 @@ void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, bool keep_history)
         return;
     }
 
-    CF_CFDP_SendEotPkt(txn);
+    chan = CF_GetChannelFromTxn(txn);
 
-    CF_DequeueTransaction(txn);
+    /* this should always be */
+    CF_Assert(chan != NULL);
+
+    /* If this was on the TXA queue (transmit side) then we need to move it out
+     * so the tick processor will stop trying to actively transmit something -
+     * it should move on to the next transaction.
+     *
+     * RX transactions can stay on the RX queue, that does not hurt anything
+     * because they are only triggered when a PDU comes in matching that seq_num
+     * (RX queue is not separated into A/W parts) */
+    if (txn->flags.com.q_index == CF_QueueIdx_TXA)
+    {
+        CF_DequeueTransaction(txn);
+        CF_InsertSortPrio(txn, CF_QueueIdx_TXW);
+    }
 
     if (OS_ObjectIdDefined(txn->fd))
     {
@@ -1611,43 +1755,99 @@ void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, bool keep_history)
         {
             CF_CFDP_HandleNotKeepFile(txn);
         }
+
+        txn->fd = OS_OBJECT_ID_UNDEFINED;
     }
 
-    /* extra bookkeeping for tx direction only */
-    if (txn->history->dir == CF_Direction_TX)
+    if (txn->history != NULL)
     {
-        if (txn->flags.tx.cmd_tx)
+        CF_CFDP_SendEotPkt(txn);
+
+        /* extra bookkeeping for tx direction only */
+        if (txn->history->dir == CF_Direction_TX && txn->flags.tx.cmd_tx)
         {
             CF_Assert(chan->num_cmd_tx); /* sanity check */
+
             --chan->num_cmd_tx;
         }
 
-        if (txn->pb)
-        {
-            /* a playback's transaction is now done, decrement the playback counter */
-            CF_Assert(txn->pb->num_ts);
-            --txn->pb->num_ts;
-        }
+        txn->flags.com.keep_history = keep_history;
     }
 
-    /* bookkeeping for all transactions */
-    /* move transaction history to history queue */
-    if (keep_history)
+    if (txn->pb)
     {
-        CF_CList_InsertBack_Ex(chan, CF_QueueIdx_HIST, &txn->history->cl_node);
-    }
-    else
-    {
-        CF_CList_InsertBack_Ex(chan, CF_QueueIdx_HIST_FREE, &txn->history->cl_node);
+        /* a playback's transaction is now done, decrement the playback counter */
+        CF_Assert(txn->pb->num_ts);
+        --txn->pb->num_ts;
     }
 
-    CF_CList_InsertBack(&chan->cs[!!CF_CFDP_IsSender(txn)], &txn->chunks->cl_node);
-
+    /* no need to come back to this txn */
     if (chan->cur == txn)
     {
-        chan->cur = NULL; /* this transaction couldn't get a message previously, so clear it here to avoid problems */
+        chan->cur = NULL;
     }
-    CF_FreeTransaction(txn);
+
+    /* Put this transaction into the holdover state, inactivity timer will recycle it */
+    txn->state = CF_TxnState_HOLD;
+    CF_CFDP_ArmInactTimer(txn);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in cf_cfdp.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CF_CFDP_RecycleTransaction(CF_Transaction_t *txn)
+{
+    CF_Channel_t *   chan;
+    CF_CListNode_t **chunklist_head;
+    CF_QueueIdx_t    hist_destq;
+
+    /* File should have been closed by the state machine, but if
+     * it still hanging open at this point, close it now so its not leaked.
+     * This is not normal/expected so log it if this happens. */
+    if (OS_ObjectIdDefined(txn->fd))
+    {
+        CFE_ES_WriteToSysLog("%s(): Closing dangling file handle: %lu\n", __func__, OS_ObjectIdToInteger(txn->fd));
+        OS_close(txn->fd);
+        txn->fd = OS_OBJECT_ID_UNDEFINED;
+    }
+
+    CF_DequeueTransaction(txn); /* this makes it "float" (not in any queue) */
+
+    chan = CF_GetChannelFromTxn(txn);
+
+    /* this should always be */
+    if (chan != NULL && txn->history != NULL)
+    {
+        if (txn->chunks != NULL)
+        {
+            chunklist_head = CF_GetChunkListHead(chan, txn->history->dir);
+            if (chunklist_head != NULL)
+            {
+                CF_CList_InsertBack(chunklist_head, &txn->chunks->cl_node);
+                txn->chunks = NULL;
+            }
+        }
+
+        if (txn->flags.com.keep_history)
+        {
+            /* move transaction history to history queue */
+            hist_destq = CF_QueueIdx_HIST;
+        }
+        else
+        {
+            hist_destq = CF_QueueIdx_HIST_FREE;
+        }
+        CF_CList_InsertBack_Ex(chan, hist_destq, &txn->history->cl_node);
+        txn->history = NULL;
+    }
+
+    /* this wipes it and puts it back onto the list to be found by
+     * CF_FindUnusedTransaction().  Need to preserve the chan_num
+     * and keep it associated with this channel, though. */
+    CF_FreeTransaction(txn, txn->chan_num);
 }
 
 /*----------------------------------------------------------------
@@ -1733,12 +1933,19 @@ int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t 
  *-----------------------------------------------------------------*/
 void CF_CFDP_CancelTransaction(CF_Transaction_t *txn)
 {
-    void (*fns[2])(CF_Transaction_t * txn) = {CF_CFDP_R_Cancel, CF_CFDP_S_Cancel};
+    void (*fns[CF_Direction_NUM])(CF_Transaction_t *) = {
+        [CF_Direction_RX] = CF_CFDP_R_Cancel, [CF_Direction_TX] = CF_CFDP_S_Cancel};
+
     if (!txn->flags.com.canceled)
     {
         txn->flags.com.canceled = true;
         CF_CFDP_SetTxnStatus(txn, CF_TxnStatus_CANCEL_REQUEST_RECEIVED);
-        fns[!!CF_CFDP_IsSender(txn)](txn);
+
+        /* this should always be true, just confirming before indexing into array */
+        if (txn->history->dir < CF_Direction_NUM)
+        {
+            fns[txn->history->dir](txn);
+        }
     }
 }
 
@@ -1813,16 +2020,16 @@ void CF_CFDP_DisableEngine(void)
  * See description in cf_cfdp.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-bool CF_CFDP_IsPollingDir(const char * src_file, uint8 chan_num)
+bool CF_CFDP_IsPollingDir(const char *src_file, uint8 chan_num)
 {
-    bool return_code = false;
-    char src_dir[CF_FILENAME_MAX_LEN] = "\0";
+    bool                return_code                  = false;
+    char                src_dir[CF_FILENAME_MAX_LEN] = "\0";
     CF_ChannelConfig_t *cc;
     CF_PollDir_t *      pd;
     int                 i;
 
-    char * last_slash = strrchr(src_file, '/');
-    if(last_slash != NULL)
+    char *last_slash = strrchr(src_file, '/');
+    if (last_slash != NULL)
     {
         strncpy(src_dir, src_file, last_slash - src_file);
     }
@@ -1831,7 +2038,7 @@ bool CF_CFDP_IsPollingDir(const char * src_file, uint8 chan_num)
     for (i = 0; i < CF_MAX_POLLING_DIR_PER_CHAN; ++i)
     {
         pd = &cc->polldir[i];
-        if(strcmp(src_dir, pd->src_dir) == 0)
+        if (strcmp(src_dir, pd->src_dir) == 0)
         {
             return_code = true;
             break;
@@ -1852,7 +2059,7 @@ void CF_CFDP_HandleNotKeepFile(CF_Transaction_t *txn)
     /* Sender */
     if (CF_CFDP_IsSender(txn))
     {
-        if(!CF_TxnStatus_IsError(txn->history->txn_stat))
+        if (!CF_TxnStatus_IsError(txn->history->txn_stat))
         {
             /* If move directory is defined attempt move */
             CF_CFDP_MoveFile(txn->history->fnames.src_filename, CF_AppData.config_table->chan[txn->chan_num].move_dir);
@@ -1860,7 +2067,7 @@ void CF_CFDP_HandleNotKeepFile(CF_Transaction_t *txn)
         else
         {
             /* file inside an polling directory */
-            if(CF_CFDP_IsPollingDir(txn->history->fnames.src_filename, txn->chan_num))
+            if (CF_CFDP_IsPollingDir(txn->history->fnames.src_filename, txn->chan_num))
             {
                 /* If fail directory is defined attempt move */
                 CF_CFDP_MoveFile(txn->history->fnames.src_filename, CF_AppData.config_table->fail_dir);

--- a/fsw/src/cf_cfdp_r.h
+++ b/fsw/src/cf_cfdp_r.h
@@ -65,6 +65,21 @@ void CF_CFDP_R1_Recv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
 void CF_CFDP_R2_Recv(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
+/** @brief Perform acknowledgement timer tick (time-based) processing for R transactions.
+ *
+ * @par Description
+ *       This is invoked as part of overall timer tick processing if the transaction
+ *       has some sort of acknowledgement pending from the remote.
+ *
+ * @par Assumptions, External Events, and Notes:
+ *       txn must not be NULL
+ *
+ * @param txn  Pointer to the transaction object
+ *
+ */
+void CF_CFDP_R_AckTimerTick(CF_Transaction_t *txn);
+
+/************************************************************************/
 /** @brief Perform tick (time-based) processing for R transactions.
  *
  * @par Description

--- a/fsw/src/cf_cfdp_s.h
+++ b/fsw/src/cf_cfdp_s.h
@@ -74,6 +74,21 @@ void CF_CFDP_S1_Tx(CF_Transaction_t *txn);
 void CF_CFDP_S2_Tx(CF_Transaction_t *txn);
 
 /************************************************************************/
+/** @brief Perform acknowledgement timer tick (time-based) processing for S transactions.
+ *
+ * @par Description
+ *       This is invoked as part of overall timer tick processing if the transaction
+ *       has some sort of acknowledgement pending from the remote.
+ *
+ * @par Assumptions, External Events, and Notes:
+ *       txn must not be NULL
+ *
+ * @param txn  Pointer to the transaction object
+ *
+ */
+void CF_CFDP_S_AckTimerTick(CF_Transaction_t *txn);
+
+/************************************************************************/
 /** @brief Perform tick (time-based) processing for S transactions.
  *
  * @par Description
@@ -249,7 +264,7 @@ void CF_CFDP_S_SubstateSendMetadata(CF_Transaction_t *txn);
  *
  * @param txn     Pointer to the transaction object
  */
-void CF_CFDP_S_SubstateSendFinAck(CF_Transaction_t *txn);
+CFE_Status_t CF_CFDP_S_SendFinAck(CF_Transaction_t *txn);
 
 /************************************************************************/
 /** @brief A FIN was received before file complete, so abandon the transaction.
@@ -301,11 +316,10 @@ void CF_CFDP_S2_Nak(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
 void CF_CFDP_S2_Nak_Arm(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
 
 /************************************************************************/
-/** @brief S2 received ACK PDU in wait for EOF-ACK state.
+/** @brief S2 received ACK PDU.
  *
  * @par Description
- *       This function will trigger a state transition to CF_TxSubState_WAIT_FOR_FIN,
- *       which waits for a FIN PDU.
+ *       Handles reception of an ACK PDU
  *
  * @par Assumptions, External Events, and Notes:
  *       txn must not be NULL. ph must not be NULL.
@@ -313,6 +327,6 @@ void CF_CFDP_S2_Nak_Arm(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
  * @param txn  Pointer to the transaction object
  * @param ph Pointer to the PDU information
  */
-void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
+void CF_CFDP_S2_EofAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph);
 
 #endif /* !CF_CFDP_S_H */

--- a/fsw/src/cf_clist.c
+++ b/fsw/src/cf_clist.c
@@ -214,7 +214,8 @@ void CF_CList_Traverse(CF_CListNode_t *start, CF_CListFn_t fn, void *context)
                 start = node_next;
             }
             node = node_next;
-        } while (!last);
+        }
+        while (!last);
     }
 }
 
@@ -230,7 +231,7 @@ void CF_CList_Traverse_R(CF_CListNode_t *end, CF_CListFn_t fn, void *context)
     {
         CF_CListNode_t *node = end->prev;
         CF_CListNode_t *node_next;
-        bool             last = false;
+        bool            last = false;
 
         if (node)
         {
@@ -259,7 +260,8 @@ void CF_CList_Traverse_R(CF_CListNode_t *end, CF_CListFn_t fn, void *context)
                     end = node_next;
                 }
                 node = node_next;
-            } while (!last);
+            }
+            while (!last);
         }
     }
 }

--- a/fsw/src/cf_logical_pdu.h
+++ b/fsw/src/cf_logical_pdu.h
@@ -107,9 +107,10 @@ typedef struct CF_Logical_PduHeader
     uint8 crc_flag;   /**< \brief CRC not present (0) or CRC present (1) */
     uint8 large_flag; /**< \brief Small/32-bit size (0) or Large/64-bit size (1) */
 
-    uint8 segment_meta_flag; /**< \brief Segment Metatdata not present (0) or Present (1) */
-    uint8 eid_length;        /**< \brief Length of encoded entity IDs, in octets (NOT size of logical value) */
-    uint8 txn_seq_length;    /**< \brief Length of encoded sequence number, in octets (NOT size of logical value) */
+    uint8 segmentation_control; /**< \brief Record boundaries not preserved (0) or preserved (1) */
+    uint8 eid_length;           /**< \brief Length of encoded entity IDs, in octets (NOT size of logical value) */
+    uint8 segment_meta_flag;    /**< \brief Segment Metatdata not present (0) or Present (1) */
+    uint8 txn_seq_length;       /**< \brief Length of encoded sequence number, in octets (NOT size of logical value) */
 
     uint16 header_encoded_length; /**< \brief Length of the encoded PDU header, in octets (NOT sizeof struct) */
     uint16 data_encoded_length;   /**< \brief Length of the encoded PDU data, in octets */

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -165,11 +165,12 @@ static inline void CF_CList_InsertBack_Ex(CF_Channel_t *chan, CF_QueueIdx_t queu
  *       chan must not be NULL.
  *
  * @param chan Pointer to the CF channel
+ * @param direction Intended direction of data flow (TX or RX)
  *
  * @returns Pointer to a free transaction
  * @retval  NULL if no free transactions available.
  */
-CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *chan);
+CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *chan, CF_Direction_t direction);
 
 /************************************************************************/
 /** @brief Returns a history structure back to its unused state.
@@ -193,8 +194,9 @@ void CF_ResetHistory(CF_Channel_t *chan, CF_History_t *history);
  *       txn must not be NULL.
  *
  * @param txn Pointer to the transaction object
+ * @param chan The channel number which this transaction is associated with
  */
-void CF_FreeTransaction(CF_Transaction_t *txn);
+void CF_FreeTransaction(CF_Transaction_t *txn, uint8 chan);
 
 /************************************************************************/
 /** @brief Finds an active transaction by sequence number.
@@ -517,5 +519,44 @@ CF_TxnStatus_t CF_TxnStatus_From_ConditionCode(CF_CFDP_ConditionCode_t cc);
  * @retval false if no error has occurred during the transaction yet
  */
 bool CF_TxnStatus_IsError(CF_TxnStatus_t txn_stat);
+
+/************************************************************************/
+/** @brief Gets the associated channel struct from a transaction
+ *
+ * @par Assumptions, External Events, and Notes:
+ *       txn must not be null, and the chan_num must be set
+ *
+ * @param txn   Transaction
+ *
+ * @returns Pointer to CF_Channel_t struct associated with the transaction
+ * @retval NULL if checks failed
+ */
+CF_Channel_t *CF_GetChannelFromTxn(CF_Transaction_t *txn);
+
+/************************************************************************/
+/** @brief Gets the head of the chunk list for the given channel + direction
+ *
+ * The chunk list contains structs that are available for tracking the chunks
+ * associated with files in transit.  An entry needs to be pulled from this
+ * list for every transaction, and returned to this list when the transaction
+ * completes.
+ *
+ * @param chan       Pointer to channel struct
+ * @param direction  Whether this is TX or RX
+ *
+ * @returns Pointer to list head
+ */
+CF_CListNode_t **CF_GetChunkListHead(CF_Channel_t *chan, uint8 direction);
+
+/************************************************************************/
+/** @brief Gets the status of this transaction
+ *
+ * Determines if the transaction is ACTIVE or TERMINATED.
+ * (By definition if it has a txn object then it is not UNRECOGNIZED)
+ *
+ * @param txn   Transaction
+ * @returns CF_CFDP_AckTxnStatus_t value corresponding to transaction
+ */
+CF_CFDP_AckTxnStatus_t CF_CFDP_GetTxnStatus(CF_Transaction_t *txn);
 
 #endif /* !CF_UTILS_H */

--- a/fsw/tables/cf_def_config.c
+++ b/fsw/tables/cf_def_config.c
@@ -78,8 +78,8 @@ CF_ConfigTable_t CF_config_table = {
       "", /* throttle sem, empty string means no throttle */
       1,  /* dequeue enable flag (1 = enabled) */
       .move_dir = ""}},
-    480,       /* outgoing_file_chunk_size */
-    "/cf/tmp", /* temporary file directory */
+    480,        /* outgoing_file_chunk_size */
+    "/cf/tmp",  /* temporary file directory */
     "/cf/fail", /* Stores failed tx file for "polling directory" */
 };
 CFE_TBL_FILEDEF(CF_config_table, CF.config_table, CF config table, cf_def_config.tbl)

--- a/unit-test/cf_clist_tests.c
+++ b/unit-test/cf_clist_tests.c
@@ -76,6 +76,8 @@ void Test_CF_CList_InsertFront(void)
 
     /* Already tested, so OK to use to initialize */
     CF_CList_InitNode(&node[0]);
+    CF_CList_InitNode(&node[1]);
+    CF_CList_InitNode(&node[2]);
 
     /* Insert to empty list */
     UtAssert_VOIDCALL(CF_CList_InsertFront(&head, &node[0]));
@@ -109,6 +111,8 @@ void Test_CF_CList_InsertBack(void)
 
     /* Already tested, so OK to use to initialize */
     CF_CList_InitNode(&node[0]);
+    CF_CList_InitNode(&node[1]);
+    CF_CList_InitNode(&node[2]);
 
     /* Insert to empty list */
     UtAssert_VOIDCALL(CF_CList_InsertBack(&head, &node[0]));
@@ -142,6 +146,8 @@ void Test_CF_CList_Pop(void)
 
     /* Already tested, so OK to use to initialize */
     CF_CList_InitNode(&node[0]);
+    CF_CList_InitNode(&node[1]);
+    CF_CList_InitNode(&node[2]);
     CF_CList_InsertBack(&head, &node[0]);
     CF_CList_InsertBack(&head, &node[1]);
     CF_CList_InsertBack(&head, &node[2]);
@@ -177,6 +183,8 @@ void Test_CF_CList_Remove(void)
 
     /* Already tested, so OK to use to initialize */
     CF_CList_InitNode(&node[0]);
+    CF_CList_InitNode(&node[1]);
+    CF_CList_InitNode(&node[2]);
     CF_CList_InsertBack(&head, &node[0]);
     CF_CList_InsertBack(&head, &node[1]);
     CF_CList_InsertBack(&head, &node[2]);
@@ -207,6 +215,9 @@ void Test_CF_CList_InsertAfter(void)
 
     /* Already tested, so OK to use to initialize */
     CF_CList_InitNode(&node[0]);
+    CF_CList_InitNode(&node[1]);
+    CF_CList_InitNode(&node[2]);
+    CF_CList_InitNode(&node[3]);
 
     /* Insert to a single node list */
     UtAssert_VOIDCALL(CF_CList_InsertAfter(&head, &node[0], &node[1]));

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -1442,22 +1442,15 @@ void Test_CF_CancelCmd_Failure(void)
 void Test_CF_Abandon_TxnCmd_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void)
 {
     /* Arrange */
-    CF_Transaction_t                   txn;
-    CF_Transaction_t *                 arg_t       = &txn;
-    void *                             arg_ignored = NULL;
-    CF_CFDP_ResetTransaction_context_t context_CF_CFDP_ResetTransaction;
-
-    UT_SetDataBuffer(UT_KEY(CF_CFDP_ResetTransaction), &context_CF_CFDP_ResetTransaction,
-                     sizeof(context_CF_CFDP_ResetTransaction), false);
+    CF_Transaction_t  txn;
+    CF_Transaction_t *arg_t       = &txn;
+    void *            arg_ignored = NULL;
 
     /* Act */
     CF_Abandon_TxnCmd(arg_t, arg_ignored);
 
     /* Assert */
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetTransaction.txn, arg_t);
-    UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == false,
-                  "CF_CFDP_CancelTransaction was called with int %d and should be 0 (constant in call)",
-                  context_CF_CFDP_ResetTransaction.keep_history);
+    UtAssert_STUB_COUNT(CF_CFDP_FinishTransaction, 1);
 }
 
 /*******************************************************************************
@@ -2007,26 +2000,16 @@ void Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT(void)
 void Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT(void)
 {
     /* Arrange */
-    CF_Transaction_t                   txn;
-    CF_CListNode_t *                   arg_n = &txn.cl_node;
-    int                                ignored;
-    void *                             arg_ignored = &ignored;
-    CF_CListTraverse_Status_t          local_result;
-    CF_CFDP_ResetTransaction_context_t context_CF_CFDP_ResetTransaction;
-
-    UT_SetDataBuffer(UT_KEY(CF_CFDP_ResetTransaction), &context_CF_CFDP_ResetTransaction,
-                     sizeof(context_CF_CFDP_ResetTransaction), false);
+    CF_Transaction_t txn;
+    CF_CListNode_t * arg_n = &txn.cl_node;
+    int              ignored;
+    void *           arg_ignored = &ignored;
 
     /* Act */
-    local_result = CF_PurgeTransaction(arg_n, arg_ignored);
+    UtAssert_INT32_EQ(CF_PurgeTransaction(arg_n, arg_ignored), CF_CLIST_CONT);
 
     /* Assert */
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetTransaction.txn, &txn);
-    UtAssert_True(context_CF_CFDP_ResetTransaction.keep_history == false,
-                  "CF_CFDP_ResetTransaction received keep_history %u and should be 0 (constant)",
-                  context_CF_CFDP_ResetTransaction.keep_history);
-    UtAssert_True(local_result == CF_CLIST_CONT, "CF_PurgeHistory returned %d and should be %d (CF_CLIST_CONT)",
-                  local_result, CF_CLIST_CONT);
+    UtAssert_STUB_COUNT(CF_CFDP_FinishTransaction, 1);
 }
 
 /*******************************************************************************
@@ -3438,8 +3421,7 @@ void Test_CF_GetSetParamCmd(void)
     for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
     {
         UT_CF_ResetEventCapture();
-        UtAssert_VOIDCALL(
-            CF_GetSetParamCmd(true, param_id, 1 + param_id, UT_CFDP_CHANNEL));
+        UtAssert_VOIDCALL(CF_GetSetParamCmd(true, param_id, 1 + param_id, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
         UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, ++expected_count);
     }
@@ -3460,16 +3442,14 @@ void Test_CF_GetSetParamCmd(void)
     for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
     {
         UT_CF_ResetEventCapture();
-        UtAssert_VOIDCALL(
-            CF_GetSetParamCmd(false, param_id, 1, UT_CFDP_CHANNEL));
+        UtAssert_VOIDCALL(CF_GetSetParamCmd(false, param_id, 1, UT_CFDP_CHANNEL));
         UT_CF_AssertEventID(CF_CMD_GETSET2_INF_EID);
         UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.cmd, ++expected_count);
     }
 
     /* Bad param ID */
     UT_CF_ResetEventCapture();
-    UtAssert_VOIDCALL(
-        CF_GetSetParamCmd(false, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
+    UtAssert_VOIDCALL(CF_GetSetParamCmd(false, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
     UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.hk.Payload.counters.err, 1);
 
@@ -3865,8 +3845,8 @@ void add_CF_ResumeCmd_tests(void)
 
 void add_CF_Cancel_TxnCmd_tests(void)
 {
-    UtTest_Add(Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t, cf_cmd_tests_Setup, cf_cmd_tests_Teardown,
-               "Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t");
+    UtTest_Add(Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t, cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown, "Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t");
 }
 
 void add_CF_CancelCmd_tests(void)

--- a/unit-test/cf_codec_tests.c
+++ b/unit-test/cf_codec_tests.c
@@ -58,7 +58,7 @@ void Test_CF_CFDP_GetValueEncodedSize(void)
     /*
      * This next case uses UINT64_C macro to force promotion so the +1 is done as 64-bit,
      * otherwise the UINT32_MAX is a 32-bit value and +1 results in 0.  Not all systems have
-	 * UINT64_C so these will be skipped in that case.
+     * UINT64_C so these will be skipped in that case.
      */
     UtAssert_UINT32_EQ(CF_CFDP_GetValueEncodedSize(UINT32_MAX + UINT64_C(1)), 5);
 #endif

--- a/unit-test/cf_eds_dispatch_tests.c
+++ b/unit-test/cf_eds_dispatch_tests.c
@@ -25,7 +25,6 @@
 #include "cf_msgids.h"
 #include "cf_events.h"
 
-
 /* UT includes */
 #include "uttest.h"
 #include "utassert.h"

--- a/unit-test/stubs/cf_app_stubs.c
+++ b/unit-test/stubs/cf_app_stubs.c
@@ -28,6 +28,20 @@
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_AppInit()
+ * ----------------------------------------------------
+ */
+CFE_Status_t CF_AppInit(void)
+{
+    UT_GenStub_SetupReturnBuffer(CF_AppInit, CFE_Status_t);
+
+    UT_GenStub_Execute(CF_AppInit, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_AppInit, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_AppMain()
  * ----------------------------------------------------
  */
@@ -46,20 +60,6 @@ void CF_CheckTables(void)
 {
 
     UT_GenStub_Execute(CF_CheckTables, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_AppInit()
- * ----------------------------------------------------
- */
-CFE_Status_t CF_AppInit(void)
-{
-    UT_GenStub_SetupReturnBuffer(CF_AppInit, CFE_Status_t);
-
-    UT_GenStub_Execute(CF_AppInit, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_AppInit, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_cfdp_s_stubs.c
+++ b/unit-test/stubs/cf_cfdp_s_stubs.c
@@ -78,6 +78,19 @@ void CF_CFDP_S2_EarlyFin(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_S2_EofAck()
+ * ----------------------------------------------------
+ */
+void CF_CFDP_S2_EofAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
+{
+    UT_GenStub_AddParam(CF_CFDP_S2_EofAck, CF_Transaction_t *, txn);
+    UT_GenStub_AddParam(CF_CFDP_S2_EofAck, CF_Logical_PduBuffer_t *, ph);
+
+    UT_GenStub_Execute(CF_CFDP_S2_EofAck, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_CFDP_S2_Fin()
  * ----------------------------------------------------
  */
@@ -166,19 +179,6 @@ void CF_CFDP_S2_Tx(CF_Transaction_t *txn)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CFDP_S2_WaitForEofAck()
- * ----------------------------------------------------
- */
-void CF_CFDP_S2_WaitForEofAck(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
-{
-    UT_GenStub_AddParam(CF_CFDP_S2_WaitForEofAck, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_CFDP_S2_WaitForEofAck, CF_Logical_PduBuffer_t *, ph);
-
-    UT_GenStub_Execute(CF_CFDP_S2_WaitForEofAck, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_CFDP_S_Cancel()
  * ----------------------------------------------------
  */
@@ -242,6 +242,22 @@ CFE_Status_t CF_CFDP_S_SendFileData(CF_Transaction_t *txn, uint32 foffs, uint32 
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_S_SendFinAck()
+ * ----------------------------------------------------
+ */
+CFE_Status_t CF_CFDP_S_SendFinAck(CF_Transaction_t *txn)
+{
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_S_SendFinAck, CFE_Status_t);
+
+    UT_GenStub_AddParam(CF_CFDP_S_SendFinAck, CF_Transaction_t *, txn);
+
+    UT_GenStub_Execute(CF_CFDP_S_SendFinAck, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_CFDP_S_SendFinAck, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_CFDP_S_SubstateSendFileData()
  * ----------------------------------------------------
  */
@@ -250,18 +266,6 @@ void CF_CFDP_S_SubstateSendFileData(CF_Transaction_t *txn)
     UT_GenStub_AddParam(CF_CFDP_S_SubstateSendFileData, CF_Transaction_t *, txn);
 
     UT_GenStub_Execute(CF_CFDP_S_SubstateSendFileData, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_CFDP_S_SubstateSendFinAck()
- * ----------------------------------------------------
- */
-void CF_CFDP_S_SubstateSendFinAck(CF_Transaction_t *txn)
-{
-    UT_GenStub_AddParam(CF_CFDP_S_SubstateSendFinAck, CF_Transaction_t *, txn);
-
-    UT_GenStub_Execute(CF_CFDP_S_SubstateSendFinAck, Basic, NULL);
 }
 
 /*

--- a/unit-test/stubs/cf_cfdp_stubs.c
+++ b/unit-test/stubs/cf_cfdp_stubs.c
@@ -29,7 +29,6 @@
 void UT_DefaultHandler_CF_CFDP_CancelTransaction(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CFDP_ConstructPduHeader(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CFDP_PlaybackDir(void *, UT_EntryKey_t, const UT_StubContext_t *);
-void UT_DefaultHandler_CF_CFDP_ResetTransaction(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_CFDP_TxFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
 
 /*
@@ -245,6 +244,19 @@ void CF_CFDP_EncodeStart(CF_EncoderState_t *penc, void *msgbuf, CF_Logical_PduBu
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_FinishTransaction()
+ * ----------------------------------------------------
+ */
+void CF_CFDP_FinishTransaction(CF_Transaction_t *txn, bool keep_history)
+{
+    UT_GenStub_AddParam(CF_CFDP_FinishTransaction, CF_Transaction_t *, txn);
+    UT_GenStub_AddParam(CF_CFDP_FinishTransaction, bool, keep_history);
+
+    UT_GenStub_Execute(CF_CFDP_FinishTransaction, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_CFDP_HandleNotKeepFile()
  * ----------------------------------------------------
  */
@@ -446,15 +458,28 @@ CFE_Status_t CF_CFDP_RecvFin(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CFDP_RecvIdle()
+ * Generated stub function for CF_CFDP_RecvHold()
  * ----------------------------------------------------
  */
-void CF_CFDP_RecvIdle(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
+void CF_CFDP_RecvHold(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_AddParam(CF_CFDP_RecvIdle, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_CFDP_RecvIdle, CF_Logical_PduBuffer_t *, ph);
+    UT_GenStub_AddParam(CF_CFDP_RecvHold, CF_Transaction_t *, txn);
+    UT_GenStub_AddParam(CF_CFDP_RecvHold, CF_Logical_PduBuffer_t *, ph);
 
-    UT_GenStub_Execute(CF_CFDP_RecvIdle, Basic, NULL);
+    UT_GenStub_Execute(CF_CFDP_RecvHold, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_RecvInit()
+ * ----------------------------------------------------
+ */
+void CF_CFDP_RecvInit(CF_Transaction_t *txn, CF_Logical_PduBuffer_t *ph)
+{
+    UT_GenStub_AddParam(CF_CFDP_RecvInit, CF_Transaction_t *, txn);
+    UT_GenStub_AddParam(CF_CFDP_RecvInit, CF_Logical_PduBuffer_t *, ph);
+
+    UT_GenStub_Execute(CF_CFDP_RecvInit, Basic, NULL);
 }
 
 /*
@@ -510,15 +535,14 @@ CFE_Status_t CF_CFDP_RecvPh(uint8 chan_num, CF_Logical_PduBuffer_t *ph)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_CFDP_ResetTransaction()
+ * Generated stub function for CF_CFDP_RecycleTransaction()
  * ----------------------------------------------------
  */
-void CF_CFDP_ResetTransaction(CF_Transaction_t *txn, bool keep_history)
+void CF_CFDP_RecycleTransaction(CF_Transaction_t *txn)
 {
-    UT_GenStub_AddParam(CF_CFDP_ResetTransaction, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_CFDP_ResetTransaction, bool, keep_history);
+    UT_GenStub_AddParam(CF_CFDP_RecycleTransaction, CF_Transaction_t *, txn);
 
-    UT_GenStub_Execute(CF_CFDP_ResetTransaction, Basic, UT_DefaultHandler_CF_CFDP_ResetTransaction);
+    UT_GenStub_Execute(CF_CFDP_RecycleTransaction, Basic, NULL);
 }
 
 /*
@@ -652,6 +676,22 @@ void CF_CFDP_SetTxnStatus(CF_Transaction_t *txn, CF_TxnStatus_t txn_stat)
     UT_GenStub_AddParam(CF_CFDP_SetTxnStatus, CF_TxnStatus_t, txn_stat);
 
     UT_GenStub_Execute(CF_CFDP_SetTxnStatus, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_StartRxTransaction()
+ * ----------------------------------------------------
+ */
+CF_Transaction_t *CF_CFDP_StartRxTransaction(uint8 chan_num)
+{
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_StartRxTransaction, CF_Transaction_t *);
+
+    UT_GenStub_AddParam(CF_CFDP_StartRxTransaction, uint8, chan_num);
+
+    UT_GenStub_Execute(CF_CFDP_StartRxTransaction, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_CFDP_StartRxTransaction, CF_Transaction_t *);
 }
 
 /*

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -44,6 +44,19 @@ CFE_Status_t CF_AbandonCmd(const CF_AbandonCmd_t *msg)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_Abandon_TxnCmd()
+ * ----------------------------------------------------
+ */
+void CF_Abandon_TxnCmd(CF_Transaction_t *txn, void *ignored)
+{
+    UT_GenStub_AddParam(CF_Abandon_TxnCmd, CF_Transaction_t *, txn);
+    UT_GenStub_AddParam(CF_Abandon_TxnCmd, void *, ignored);
+
+    UT_GenStub_Execute(CF_Abandon_TxnCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_CancelCmd()
  * ----------------------------------------------------
  */
@@ -60,19 +73,6 @@ CFE_Status_t CF_CancelCmd(const CF_CancelCmd_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_Abandon_TxnCmd()
- * ----------------------------------------------------
- */
-void CF_Abandon_TxnCmd(CF_Transaction_t *txn, void *ignored)
-{
-    UT_GenStub_AddParam(CF_Abandon_TxnCmd, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_Abandon_TxnCmd, void *, ignored);
-
-    UT_GenStub_Execute(CF_Abandon_TxnCmd, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_Cancel_TxnCmd()
  * ----------------------------------------------------
  */
@@ -82,40 +82,6 @@ void CF_Cancel_TxnCmd(CF_Transaction_t *txn, void *ignored)
     UT_GenStub_AddParam(CF_Cancel_TxnCmd, void *, ignored);
 
     UT_GenStub_Execute(CF_Cancel_TxnCmd, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_ValidateChunkSizeCmd()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_ValidateChunkSizeCmd(CF_ChunkSize_t val, uint8 chan_num)
-{
-    UT_GenStub_SetupReturnBuffer(CF_ValidateChunkSizeCmd, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_ValidateChunkSizeCmd, CF_ChunkSize_t, val);
-    UT_GenStub_AddParam(CF_ValidateChunkSizeCmd, uint8, chan_num);
-
-    UT_GenStub_Execute(CF_ValidateChunkSizeCmd, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_ValidateChunkSizeCmd, CF_ChanAction_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_ValidateMaxOutgoingCmd()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_ValidateMaxOutgoingCmd(uint32 val, uint8 chan_num)
-{
-    UT_GenStub_SetupReturnBuffer(CF_ValidateMaxOutgoingCmd, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_ValidateMaxOutgoingCmd, uint32, val);
-    UT_GenStub_AddParam(CF_ValidateMaxOutgoingCmd, uint8, chan_num);
-
-    UT_GenStub_Execute(CF_ValidateMaxOutgoingCmd, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_ValidateMaxOutgoingCmd, CF_ChanAction_Status_t);
 }
 
 /*
@@ -604,6 +570,40 @@ CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg)
     UT_GenStub_Execute(CF_TxFileCmd, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_TxFileCmd, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_ValidateChunkSizeCmd()
+ * ----------------------------------------------------
+ */
+CF_ChanAction_Status_t CF_ValidateChunkSizeCmd(CF_ChunkSize_t val, uint8 chan_num)
+{
+    UT_GenStub_SetupReturnBuffer(CF_ValidateChunkSizeCmd, CF_ChanAction_Status_t);
+
+    UT_GenStub_AddParam(CF_ValidateChunkSizeCmd, CF_ChunkSize_t, val);
+    UT_GenStub_AddParam(CF_ValidateChunkSizeCmd, uint8, chan_num);
+
+    UT_GenStub_Execute(CF_ValidateChunkSizeCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_ValidateChunkSizeCmd, CF_ChanAction_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_ValidateMaxOutgoingCmd()
+ * ----------------------------------------------------
+ */
+CF_ChanAction_Status_t CF_ValidateMaxOutgoingCmd(uint32 val, uint8 chan_num)
+{
+    UT_GenStub_SetupReturnBuffer(CF_ValidateMaxOutgoingCmd, CF_ChanAction_Status_t);
+
+    UT_GenStub_AddParam(CF_ValidateMaxOutgoingCmd, uint32, val);
+    UT_GenStub_AddParam(CF_ValidateMaxOutgoingCmd, uint8, chan_num);
+
+    UT_GenStub_Execute(CF_ValidateMaxOutgoingCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_ValidateMaxOutgoingCmd, CF_ChanAction_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -38,6 +38,22 @@ void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *, UT_EntryKey_t, const U
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CF_CFDP_GetTxnStatus()
+ * ----------------------------------------------------
+ */
+CF_CFDP_AckTxnStatus_t CF_CFDP_GetTxnStatus(CF_Transaction_t *txn)
+{
+    UT_GenStub_SetupReturnBuffer(CF_CFDP_GetTxnStatus, CF_CFDP_AckTxnStatus_t);
+
+    UT_GenStub_AddParam(CF_CFDP_GetTxnStatus, CF_Transaction_t *, txn);
+
+    UT_GenStub_Execute(CF_CFDP_GetTxnStatus, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_CFDP_GetTxnStatus, CF_CFDP_AckTxnStatus_t);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CF_FindTransactionBySequenceNumber()
  * ----------------------------------------------------
  */
@@ -78,11 +94,12 @@ CFE_Status_t CF_FindTransactionBySequenceNumber_Impl(CF_CListNode_t *node, CF_Tr
  * Generated stub function for CF_FindUnusedTransaction()
  * ----------------------------------------------------
  */
-CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *chan)
+CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *chan, CF_Direction_t direction)
 {
     UT_GenStub_SetupReturnBuffer(CF_FindUnusedTransaction, CF_Transaction_t *);
 
     UT_GenStub_AddParam(CF_FindUnusedTransaction, CF_Channel_t *, chan);
+    UT_GenStub_AddParam(CF_FindUnusedTransaction, CF_Direction_t, direction);
 
     UT_GenStub_Execute(CF_FindUnusedTransaction, Basic, UT_DefaultHandler_CF_FindUnusedTransaction);
 
@@ -94,11 +111,45 @@ CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *chan)
  * Generated stub function for CF_FreeTransaction()
  * ----------------------------------------------------
  */
-void CF_FreeTransaction(CF_Transaction_t *txn)
+void CF_FreeTransaction(CF_Transaction_t *txn, uint8 chan)
 {
     UT_GenStub_AddParam(CF_FreeTransaction, CF_Transaction_t *, txn);
+    UT_GenStub_AddParam(CF_FreeTransaction, uint8, chan);
 
     UT_GenStub_Execute(CF_FreeTransaction, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_GetChannelFromTxn()
+ * ----------------------------------------------------
+ */
+CF_Channel_t *CF_GetChannelFromTxn(CF_Transaction_t *txn)
+{
+    UT_GenStub_SetupReturnBuffer(CF_GetChannelFromTxn, CF_Channel_t *);
+
+    UT_GenStub_AddParam(CF_GetChannelFromTxn, CF_Transaction_t *, txn);
+
+    UT_GenStub_Execute(CF_GetChannelFromTxn, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_GetChannelFromTxn, CF_Channel_t *);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CF_GetChunkListHead()
+ * ----------------------------------------------------
+ */
+CF_CListNode_t **CF_GetChunkListHead(CF_Channel_t *chan, uint8 direction)
+{
+    UT_GenStub_SetupReturnBuffer(CF_GetChunkListHead, CF_CListNode_t **);
+
+    UT_GenStub_AddParam(CF_GetChunkListHead, CF_Channel_t *, chan);
+    UT_GenStub_AddParam(CF_GetChunkListHead, uint8, direction);
+
+    UT_GenStub_Execute(CF_GetChunkListHead, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CF_GetChunkListHead, CF_CListNode_t **);
 }
 
 /*

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -103,7 +103,7 @@ typedef struct
 typedef struct
 {
     CF_Transaction_t *txn;
-    bool               keep_history;
+    bool              keep_history;
 } CF_CFDP_ResetTransaction_context_t;
 
 typedef struct


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Updates the state machines to more reliably handle the exception cases and atypical transitions between states.

Importantly:
 - There are now separate "undef" and "init" states for free transactions and newly-allocated transactions, respectively.  This replaces a single "idle" state and makes these distinguishable.
 - Adds a holdover state at the end of a transaction and consolidates closeout synchronization into this state.  Instead of a single reset at the end that wipes everything and immediately returns the transaction to the free list, the process of freeing a transaction now has two parts and the final return to the free list is done by the tick processor after the holdover period.

The segfault issue described in the ticket was the result of these two areas of weakness in the code working together to make an extra bad result.  The sequence was a situation where a brand-new transaction was started and then immediately reset/closed within the same PDU processing cycle.  Because (a) the transaction was completely wiped out and (b) the wiped out transaction was indistinguishable from the newly-allocated transaction, and (c) some atypical state machine transitions occurred causing it to effectively go through some code twice in RecvIdle.

Utimately because the second exit from RecvIdle cannot tell the difference between a txn that is already freed vs one that is left in its original state and still needed to be cleaned, it tried to clean it twice (basically like a double-free bug).

This addresses the fundamental problem on both sides by first making brand-new transactions distinguishable from free transactions (so this alone would have avoided the segfault) but also deferring the final "free" until we can guarantee that nothing else will use the transaction struct (the holdover).  Now there is nothing in any PDU processor that will put the transaction into a state where it can no longer be safely accessed, so even if there are other atypical jumps around the state machine, it will not cause problems (or at least not a segfault) if something finished the transaction in the middle.  The actual free is now done at the end of tick processing which is the very last thing to occur on the wakeup cycle.

Fixes #435

**Testing performed**
Perform multiple file transfers of all types, class 1 and class 2, and dir playbacks.
Also use a python script to generate CFDP PDUs but corrupt them (change order, change bits, etc) to create error cases

**Expected behavior changes**
No segfaults, CF deals with all anomalies 

**System(s) tested on**
Linux

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
