### PR TITLE
Fix nasa#497, checked return value for CFE_SB_DeletePipe() in CF_CFDP…

### DIFF
--- a/fsw/inc/cf_eventids.h
+++ b/fsw/inc/cf_eventids.h
@@ -1577,6 +1577,17 @@
  */
 #define CF_EID_INF_CFDP_BUF_EXCEED 166
 
+/**
+ * \brief CF Disable Engine Pipe Delete Failed
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Call to delete SB pipes when disabling CFDP engine fails
+ */
+#define CF_CFDP_DELETE_PIPE_ERR_EID 167
+
 /**\}*/
 
 #endif /* !CF_EVENTIDS_H */

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -2293,6 +2293,7 @@ void CF_CFDP_DisableEngine(void)
     int                        j;
     static const CF_QueueIdx_t CLOSE_QUEUES[] = { CF_QueueIdx_RX, CF_QueueIdx_TX };
     CF_Channel_t              *chan;
+    CFE_Status_t               delete_status;
 
     CF_AppData.engine.enabled = false;
 
@@ -2326,7 +2327,15 @@ void CF_CFDP_DisableEngine(void)
         /* finally all queue counters must be reset */
         memset(&CF_AppData.hk.Payload.channel_hk[i].q_size, 0, sizeof(CF_AppData.hk.Payload.channel_hk[i].q_size));
 
-        CFE_SB_DeletePipe(chan->pipe);
+        delete_status = CFE_SB_DeletePipe(chan->pipe);
+
+        if (delete_status < CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(CF_CFDP_DELETE_PIPE_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "CF: failed to delete pipe for channel %d",
+                              i);
+        }
     }
 }
 

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -1499,6 +1499,7 @@ void Test_CF_CFDP_SendEotPkt(void)
 
 void Test_CF_CFDP_DisableEngine(void)
 {
+    uint8 call_count_CFE_EVS_SendEvent;
     /* Test case for:
      * void CF_CFDP_DisableEngine(void)
      */
@@ -1508,6 +1509,13 @@ void Test_CF_CFDP_DisableEngine(void)
     UtAssert_VOIDCALL(CF_CFDP_DisableEngine());
     UtAssert_STUB_COUNT(CFE_SB_DeletePipe, CF_NUM_CHANNELS);
     UtAssert_BOOL_FALSE(CF_AppData.engine.enabled);
+
+    /* Call where CFE_SB_DeletePipe fails */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_SB_DeletePipe), -1);
+    UtAssert_VOIDCALL(CF_CFDP_DisableEngine());
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, CF_NUM_CHANNELS);
+    UT_ClearDefaultReturnValue(UT_KEY(CFE_SB_DeletePipe));
 
     /* nominal call with playbacks and polls active */
     CF_AppData.engine.channels[UT_CFDP_CHANNEL].playback[0].busy = true;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
In `fsw/src/cf_cfdp.c` in the function `CF_CFDP_DisableEngine()`, the return value of `CFE_SB_DeletePipe()` is ignored.  Issue is captured in nasa#497

**Testing performed**
I updated and ran the unit tests function `Test_CF_CFDP_DisableEngine()` in `unit-test/cf_cfdp_tests.c`,

**Expected behavior changes**
 - API Change: None
 - Behavior Change: If CFE_SB_DeletePipe() returns less than CFE_SUCCESS, then an error event message will be outputted

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
