### PR TITLE
Fix nasa#497, Suppress ignored return value warning in codeSonar

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -2326,7 +2326,9 @@ void CF_CFDP_DisableEngine(void)
         /* finally all queue counters must be reset */
         memset(&CF_AppData.hk.Payload.channel_hk[i].q_size, 0, sizeof(CF_AppData.hk.Payload.channel_hk[i].q_size));
 
-        CFE_SB_DeletePipe(chan->pipe);
+        /* SAD: Suppress Ignored Return Value warning from CodeSonar.  CFE_SB_DeletePipe() will send event message if
+         * there is any error */
+        (void)CFE_SB_DeletePipe(chan->pipe);
     }
 }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
In `fsw/src/cf_cfdp.c` in the function `CF_CFDP_DisableEngine()`, the return value of `CFE_SB_DeletePipe()` is ignored.  Issue is captured in nasa#497.  I suppressed the warning by casting a `(void)` for the `CFE_SB_DeletePipe()` and putting a comment saying that codeSonar should ignore the warning.  

**Testing performed**
I updated and ran the unit tests function `Test_CF_CFDP_DisableEngine()` in `unit-test/cf_cfdp_tests.c`,

**Expected behavior changes**
 - None

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
