### PR TITLE
fix: guard against NULL data_ptr in CF_CFDP_CopyStringFromLV

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -2237,7 +2237,11 @@ void CF_CFDP_SendEotPkt(CF_Transaction_t *txn)
  *-----------------------------------------------------------------*/
 int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t *src_lv)
 {
-    if (src_lv->length < buf_maxsz)
+    /* Guard against a NULL data_ptr, which CF_CFDP_DoDecodeChunk sets when the
+     * claimed LV length exceeds the remaining PDU bytes.  Without this check a
+     * crafted PDU can trigger memcpy(buf, NULL, n) — undefined behaviour that
+     * causes a NULL-pointer dereference on most platforms. */
+    if (src_lv->data_ptr != NULL && src_lv->length < buf_maxsz)
     {
         memcpy(buf, src_lv->data_ptr, src_lv->length);
         buf[src_lv->length] = 0;
@@ -2246,7 +2250,7 @@ int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t 
 
     /* ensure output is empty */
     buf[0] = 0;
-    return CF_ERROR; /* invalid len in lv? */
+    return CF_ERROR;
 }
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
## Summary

`CF_CFDP_DoDecodeChunk()` returns `NULL` when the attacker-supplied LV `length` field in a CFDP Metadata PDU exceeds the remaining bytes in the receive buffer (it also marks the codec state as DONE). Without a corresponding `NULL` check in `CF_CFDP_CopyStringFromLV()`, the `memcpy(buf, src_lv->data_ptr, ...)` call receives a `NULL` source pointer — **undefined behaviour** that causes a NULL-pointer dereference (crash / denial-of-service) on most platforms when a crafted Metadata PDU is received.

Fixes #491.

## Root cause

```c
// CF_CFDP_DoDecodeChunk sets data_ptr = NULL when bounds check fails
pllv->data_ptr = CF_CFDP_DoDecodeChunk(state, pllv->length);

// ...later in CF_CFDP_CopyStringFromLV, no NULL guard:
if (src_lv->length < buf_maxsz)
{
    memcpy(buf, src_lv->data_ptr, src_lv->length);  // UB if data_ptr == NULL
```

## Fix

Add `src_lv->data_ptr != NULL` to the existing guard — one line, no signature changes:

```c
if (src_lv->data_ptr != NULL && src_lv->length < buf_maxsz)
```

`CF_CFDP_CopyStringFromLV()` now returns `CF_ERROR` consistently whether the PDU ran out of data (NULL ptr from decode) or the string would overflow the destination buffer.

Note: `CF_CFDP_RecvMd()` already checks `CF_CODEC_IS_OK()` before calling this function, which catches the malformed PDU at the Metadata level. This fix adds a defence-in-depth guard at the function level.