### PR TITLE
Fix #502, Initialize Variable msg_size in cf_cfdp_sbintf.c

### DIFF
--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -187,13 +187,16 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
     const int        chan_num = (chan - CF_AppData.engine.channels);
     CFE_SB_Buffer_t *bufptr;
     CFE_MSG_Size_t   msg_size;
-    CFE_MSG_Type_t   msg_type = CFE_MSG_Type_Invalid;
+    CFE_MSG_Type_t   msg_type;
 
     CF_Logical_PduBuffer_t *ph;
 
     for (; count < CF_AppData.config_table->chan[chan_num].rx_max_messages_per_wakeup; ++count)
     {
-        status = CFE_SB_ReceiveBuffer(&bufptr, chan->pipe, CFE_SB_POLL);
+        bufptr   = NULL;
+        msg_size = 0;
+        msg_type = CFE_MSG_Type_Invalid;
+        status   = CFE_SB_ReceiveBuffer(&bufptr, chan->pipe, CFE_SB_POLL);
         if (status != CFE_SUCCESS)
         {
             break; /* no more messages */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #502 

**Testing performed**
Workflows and reran CodeSonar. CodeSonar analysis link provided in the internal GitHub issue.

**Expected behavior changes**
Resolve CodeSonar warning of Uninitialized Variable in cf_cfdp_sbintf.c

**System(s) tested on**
GitHub Actions and CodeSonar

**Additional context**
When only msg_size was updated, CodeSonar flagged bufptr as uninitialized. Therefore, bufptr was also updated and CodeSonar was ran again which resolved both uninitialized variable warnings. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
