### PR TITLE
Improve unit test coverage for CF_CFDP_CopyStringFromLV

### DIFF
--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -534,9 +534,6 @@ void Test_CF_CFDP_RecvInit(void)
 
 void Test_CF_CFDP_CopyStringFromLV(void)
 {
-    /* Test case for:
-     * int CF_CFDP_CopyStringFromLV(char *buf, size_t buf_maxsz, const CF_Logical_Lv_t *src_lv)
-     */
     char            buf[20];
     const char      refstr[] = "refstr";
     CF_Logical_Lv_t input;
@@ -544,8 +541,38 @@ void Test_CF_CFDP_CopyStringFromLV(void)
     input.data_ptr = refstr;
     input.length   = sizeof(refstr) - 1;
 
-    /* nominal call */
-    UtAssert_INT32_EQ(CF_CFDP_CopyStringFromLV(buf, sizeof(buf), &input), input.length);
+    /* Nominal case */
+    UtAssert_INT32_EQ(
+        CF_CFDP_CopyStringFromLV(buf, sizeof(buf), &input),
+        input.length);
+
+    /* Buffer too small */
+    UtAssert_INT32_EQ(
+        CF_CFDP_CopyStringFromLV(buf, 3, &input),
+        CF_ERROR);
+
+    /* NULL source LV */
+    UtAssert_INT32_EQ(
+        CF_CFDP_CopyStringFromLV(buf, sizeof(buf), NULL),
+        CF_ERROR);
+
+    /* NULL destination buffer */
+    UtAssert_INT32_EQ(
+        CF_CFDP_CopyStringFromLV(NULL, sizeof(buf), &input),
+        CF_ERROR);
+
+    /* Zero buffer size */
+    UtAssert_INT32_EQ(
+        CF_CFDP_CopyStringFromLV(buf, 0, &input),
+        CF_ERROR);
+
+    /* NULL data pointer */
+    input.data_ptr = NULL;
+    input.length   = 5;
+
+    UtAssert_INT32_EQ(
+        CF_CFDP_CopyStringFromLV(buf, sizeof(buf), &input),
+        CF_ERROR);
 }
 
 void Test_CF_CFDP_ConstructPduHeader(void)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [v] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

This contribution improves unit test coverage for CF_CFDP_CopyStringFromLV().

Additional test cases were added to verify existing error handling paths, including:

Destination buffer too small
NULL source logical value pointer
NULL destination buffer pointer
Zero-sized destination buffer
NULL source data pointer with non-zero length

No production code changes are included.

Fixes: N/A

Testing performed

Updated unit-test/cf_cfdp_tests.c
Executed unit tests
Verified successful build and test execution

Expected behavior changes

API Change: None
Behavior Change: None
Impact: No operational impact. This change only improves unit test coverage for existing validation logic.

System(s) tested on

Hardware: PC
OS: Windows 11
Versions:
CF current development branch
Git for Windows
VS Code

Additional context

The new test cases exercise existing defensive input validation paths that were previously not explicitly covered by unit tests.

Third party code

None.

Contributor Info - All information REQUIRED for consideration of pull request

Full name: Albern Surya Adi

Organization: Personal
