### PR TITLE
Fix #515, reduce cyclic complexity of command handlers

### DIFF
--- a/config/default_cf_extern_typedefs.h
+++ b/config/default_cf_extern_typedefs.h
@@ -53,6 +53,14 @@ enum CF_CFDP_Class
 typedef uint8 CF_CFDP_Class_Enum_t;
 
 /**
+ * @brief A simple boolean for enable/disable switches
+ *
+ * This is fixed as an 8-bit unsigned value in commands
+ * and telemetry where 0=false/off and 1=true/on
+ */
+typedef uint8 CF_EnableFlag_Enum_t;
+
+/**
  * @brief CF queue identifiers
  */
 typedef enum

--- a/config/default_cf_fcncode_values.h
+++ b/config/default_cf_fcncode_values.h
@@ -35,7 +35,7 @@
 
 #define CF_CCVAL(x) CF_FunctionCode_##x
 
-enum CF_FunctionCode_
+enum CF_FunctionCode
 {
     CF_FunctionCode_NOOP                = 0,
     CF_FunctionCode_RESET_COUNTERS      = 1,

--- a/config/default_cf_msg.h
+++ b/config/default_cf_msg.h
@@ -37,8 +37,7 @@
 #include "cf_msgdefs.h"
 #include "cf_msgstruct.h"
 
-#define CF_COMPOUND_KEY (254)
-#define CF_ALL_CHANNELS (255)
-#define CF_ALL_POLLDIRS (CF_ALL_CHANNELS)
+#define CF_ALL_CHANNELS CF_ChannelSelect_FromInt(0)
+#define CF_ALL_POLLDIRS (0)
 
 #endif

--- a/config/default_cf_msgdefs.h
+++ b/config/default_cf_msgdefs.h
@@ -38,10 +38,11 @@
  */
 typedef enum CF_Type
 {
-    CF_Type_all  = 0, /**< \brief Type all */
-    CF_Type_up   = 1, /**< \brief Type up */
-    CF_Type_down = 2  /**< \brief Type down */
-} CF_Type_t;
+    CF_DirectionType_all  = 0, /**< \brief Unspecified - Select all types */
+    CF_DirectionType_up   = 1, /**< \brief Type up */
+    CF_DirectionType_down = 2, /**< \brief Type down */
+    CF_DirectionType_MAX  = 3  /**< \brief Limit - All valid values are less than this */
+} CF_DirectionType_t;
 
 /**
  * @brief External type to use for CFDP queue type
@@ -49,7 +50,7 @@ typedef enum CF_Type
  * This uses the labels defined in enum CF_Type
  * but maps to a fixed-width type for use in CMD/TLM/Tables
  */
-typedef uint8 CF_Type_Enum_t;
+typedef uint8 CF_DirectionType_Enum_t;
 
 /**
  * @brief Standardized type used for channel selection in commands
@@ -72,10 +73,11 @@ typedef uint8 CF_PollIdxSelect_t;
  */
 enum CF_QueueSelect
 {
-    CF_QueueSelect_Pending = 0, /**< \brief Pending Queue */
-    CF_QueueSelect_Active  = 1, /**< \brief Active Queue */
-    CF_QueueSelect_History = 2, /**< \brief History Queue */
-    CF_QueueSelect_All     = 3, /**< \brief All queues */
+    CF_QueueSelect_All     = 0, /**< \brief Unspecified - Select all queues */
+    CF_QueueSelect_Pending = 1, /**< \brief Pending Queue */
+    CF_QueueSelect_Active  = 2, /**< \brief Active Queue */
+    CF_QueueSelect_History = 3, /**< \brief History Queue */
+    CF_QueueSelect_MAX     = 4  /**< \brief Limit - All valid values are less than this */
 };
 
 /**
@@ -166,12 +168,12 @@ typedef struct CF_HkCounters
  */
 typedef struct CF_HkChannel_Data
 {
-    CF_HkCounters_t counters;                /**< \brief Counters */
-    uint16          q_size[CF_QueueIdx_NUM]; /**< \brief Queue sizes */
-    uint8           poll_counter;            /**< \brief Number of active polling directories */
-    uint8           playback_counter;        /**< \brief Number of active playback directories */
-    uint8           frozen;                  /**< \brief Frozen state: 0 == not frozen, else frozen */
-    uint8           spare;                   /**< \brief Alignment spare (uint64 values in the counters) */
+    CF_HkCounters_t      counters;                /**< \brief Counters */
+    uint16               q_size[CF_QueueIdx_NUM]; /**< \brief Queue sizes */
+    uint8                poll_counter;            /**< \brief Number of active polling directories */
+    uint8                playback_counter;        /**< \brief Number of active playback directories */
+    CF_EnableFlag_Enum_t frozen;                  /**< \brief Frozen state: 0 == not frozen, else frozen */
+    uint8                spare;                   /**< \brief Alignment spare (uint64 values in the counters) */
 } CF_HkChannel_Data_t;
 
 /**
@@ -218,7 +220,8 @@ enum CF_Reset
     CF_Reset_command = 1, /**< \brief Reset command */
     CF_Reset_fault   = 2, /**< \brief Reset fault */
     CF_Reset_up      = 3, /**< \brief Reset up */
-    CF_Reset_down    = 4  /**< \brief Reset down */
+    CF_Reset_down    = 4, /**< \brief Reset down */
+    CF_Reset_MAX     = 5  /**< \brief Limit - All valid values are less than this */
 };
 
 /**
@@ -243,8 +246,8 @@ typedef struct CF_ResetCountersCmd_Payload
  * \brief Single byte channel selector payload
  *
  * Used in all commands needing only a channel selection
- *       - 255 = all channels
- *       - else = single channel
+ *       - 0 = unspecified/all channels
+ *       - else = single channel, 1-based
  */
 typedef struct CF_ChannelSelect_Payload
 {
@@ -257,12 +260,12 @@ typedef struct CF_ChannelSelect_Payload
  * Used in all commands needing a polldir selection
  *
  * Single byte channel selector
- *       - 255 = all channels
- *       - else = single channel
+ *       - 0 = unspecified/all channels
+ *       - else = single channel, 1-based
  *
  * Single byte polling directory index
- *       - 255 = all polling directories
- *       - else = single polling directory index
+ *       - 0 = unspecified/all polling directories
+ *       - else = single polling directory index, 1-based
  */
 typedef struct CF_PollDirSelect_Payload
 {
@@ -281,9 +284,10 @@ typedef struct CF_PollDirSelect_Payload
  *
  *       Single byte queue selection enum
  *       Values indicated by #CF_QueueSelect enum
- *       - 0 = Pending queue
- *       - 1 = History queue
- *       - 2 = Both pending and history queue
+ *       - 0 = Unspecified/all valid queues
+ *       - 1 = Pending queue
+ *       - 2 = Active queue (if applicable; not valid for all commands)
+ *       - 3 = History queue
  */
 typedef struct CF_QueueSelect_Payload
 {
@@ -299,17 +303,17 @@ typedef struct CF_QueueSelect_Payload
  */
 enum CF_GetSet_ValueID
 {
-    CF_GetSet_ValueID_ticks_per_second,                      /**< \brief Ticks per second key */
-    CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup,          /**< \brief Receive CRC calculated bytes per wake-up key */
-    CF_GetSet_ValueID_ack_timer_s,                           /**< \brief ACK timer in seconds key */
-    CF_GetSet_ValueID_nak_timer_s,                           /**< \brief NAK timer in seconds key */
-    CF_GetSet_ValueID_inactivity_timer_s,                    /**< \brief Inactivity timer in seconds key */
-    CF_GetSet_ValueID_outgoing_file_chunk_size,              /**< \brief Outgoing file chunk size key */
-    CF_GetSet_ValueID_ack_limit,                             /**< \brief ACK retry limit key */
-    CF_GetSet_ValueID_nak_limit,                             /**< \brief NAK retry limit key */
-    CF_GetSet_ValueID_local_eid,                             /**< \brief Local entity id key */
-    CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup, /**< \brief Max outgoing messages per wake-up key */
-    CF_GetSet_ValueID_MAX                                    /**< \brief Key limit used for validity check */
+    CF_GetSet_ValueID_ticks_per_second             = 1, /**< \brief Ticks per second key */
+    CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup = 2, /**< \brief Receive CRC calculated bytes per wake-up key */
+    CF_GetSet_ValueID_ack_timer_s                  = 3, /**< \brief ACK timer in seconds key */
+    CF_GetSet_ValueID_nak_timer_s                  = 4, /**< \brief NAK timer in seconds key */
+    CF_GetSet_ValueID_inactivity_timer_s           = 5, /**< \brief Inactivity timer in seconds key */
+    CF_GetSet_ValueID_outgoing_file_chunk_size     = 6, /**< \brief Outgoing file chunk size key */
+    CF_GetSet_ValueID_ack_limit                    = 7, /**< \brief ACK retry limit key */
+    CF_GetSet_ValueID_nak_limit                    = 8, /**< \brief NAK retry limit key */
+    CF_GetSet_ValueID_local_eid                    = 9, /**< \brief Local entity id key */
+    CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup = 10, /**< \brief Max outgoing messages per wake-up key */
+    CF_GetSet_ValueID_MAX                                   = 11  /**< \brief Key limit used for validity check */
 };
 
 /**
@@ -352,7 +356,7 @@ typedef struct CF_SetParam_Payload
 typedef struct CF_TxFile_Payload
 {
     CF_CFDP_Class_Enum_t cfdp_class;                        /**< \brief CFDP class: 0=class 1, 1=class 2 */
-    uint8                keep;                              /**< \brief Keep file flag: 1=keep, else delete */
+    CF_EnableFlag_Enum_t keep;                              /**< \brief Keep file flag: 1=keep, else delete */
     CF_ChannelSelect_t   chan_num;                          /**< \brief Channel number */
     uint8                priority;                          /**< \brief Priority: 0=highest priority */
     CF_EntityId_t        dest_id;                           /**< \brief Destination entity id */
@@ -367,10 +371,10 @@ typedef struct CF_TxFile_Payload
  */
 typedef struct CF_WriteQueue_Payload
 {
-    CF_Type_Enum_t        type;  /**< \brief Transaction direction: all=0, up=1, down=2 */
-    CF_ChannelSelect_t    chan;  /**< \brief Channel number */
-    CF_QueueSelect_Enum_t queue; /**< \brief Queue type: 0=pending, 1=active, 2=history, 3=all */
-    uint8                 spare; /**< \brief Alignment spare, puts filename on 32-bit boundary */
+    CF_DirectionType_Enum_t dir_type; /**< \brief Transaction direction: all=0, up=1, down=2 */
+    CF_ChannelSelect_t      chan_num; /**< \brief Channel number */
+    CF_QueueSelect_Enum_t   queue;    /**< \brief Queue type */
+    uint8                   spare;    /**< \brief Alignment spare, puts filename on 32-bit boundary */
 
     char filename[CF_FILENAME_MAX_LEN]; /**< \brief Filename written to */
 } CF_WriteQueue_Payload_t;
@@ -384,8 +388,10 @@ typedef struct CF_Transaction_Payload
 {
     CF_TransactionSeq_t ts;       /**< \brief Transaction sequence number */
     CF_EntityId_t       eid;      /**< \brief Entity id */
-    CF_ChannelSelect_t  chan_num; /**< \brief Channel number: 254=use ts, 255=all channels, else channel */
-    uint8               spare[3]; /**< \brief Alignment spare for 32-bit multiple */
+    CF_ChannelSelect_t  chan_num; /**< \brief Channel number: 0=all channels, else 1-based channel */
+    CF_EnableFlag_Enum_t
+          use_ts_eid; /**< \brief If true, apply to transactions matching ts+eid, else all transactions */
+    uint8 spare[2];   /**< \brief Alignment spare for 32-bit multiple */
 } CF_Transaction_Payload_t;
 
 /**\}*/

--- a/config/default_cf_tbldefs.h
+++ b/config/default_cf_tbldefs.h
@@ -48,7 +48,7 @@ typedef struct CF_PollDir
     char src_dir[CF_FILENAME_MAX_PATH]; /**< \brief path to source dir */
     char dst_dir[CF_FILENAME_MAX_PATH]; /**< \brief path to destination dir */
 
-    uint8 enabled; /**< \brief Enabled flag */
+    CF_EnableFlag_Enum_t enabled; /**< \brief Enabled flag */
 } CF_PollDir_t;
 
 /**
@@ -73,9 +73,9 @@ typedef struct CF_ChannelConfig
 
     CF_PollDir_t polldir[CF_MAX_POLLING_DIR_PER_CHAN]; /**< \brief Configuration for polled directories */
 
-    char  sem_name[OS_MAX_API_NAME]; /**< \brief name of throttling semaphore in TO */
-    uint8 dequeue_enabled;           /**< \brief if 1, then the channel will make pending transactions active */
-    char  move_dir[OS_MAX_PATH_LEN]; /**< \brief Move directory if not empty */
+    char                 sem_name[OS_MAX_API_NAME]; /**< \brief name of throttling semaphore in TO */
+    CF_EnableFlag_Enum_t dequeue_enabled; /**< \brief if 1, then the channel will make pending transactions active */
+    char                 move_dir[OS_MAX_PATH_LEN]; /**< \brief Move directory if not empty */
 } CF_ChannelConfig_t;
 
 /*

--- a/config/eds_cf_extern_typedefs.h
+++ b/config/eds_cf_extern_typedefs.h
@@ -34,8 +34,16 @@
 
 /* Define type mappings for CF-specific types */
 
-#define CF_QueueIdx_NUM       (1 + EdsDataType_EdsEnum_CF_QueueIdx_t_MAX)
-#define CF_GetSet_ValueID_MAX (1 + EdsDataType_EdsEnum_CF_GetSet_ValueID_t_MAX)
+/* Define additional enum mappings based on EDS defines */
+/* This is done as an enum so these values have to be fixed integers */
+enum
+{
+    CF_QueueSelect_MAX    = (1 + EdsDataType_EdsEnum_CF_QueueSelect_t_MAX),
+    CF_DirectionType_MAX  = (1 + EdsDataType_EdsEnum_CF_DirectionType_t_MAX),
+    CF_QueueIdx_NUM       = (1 + EdsDataType_EdsEnum_CF_QueueIdx_t_MAX),
+    CF_GetSet_ValueID_MAX = (1 + EdsDataType_EdsEnum_CF_GetSet_ValueID_t_MAX),
+    CF_Reset_MAX          = (1 + EdsDataType_EdsEnum_CF_Reset_t_MAX),
+};
 
 typedef EdsDataType_CF_EntityId_t       CF_EntityId_t;
 typedef EdsDataType_CF_TransactionSeq_t CF_TransactionSeq_t;

--- a/eds/cf.xml
+++ b/eds/cf.xml
@@ -89,10 +89,10 @@
 
      <EnumeratedDataType name="QueueSelect">
           <EnumerationList>
-            <Enumeration label="Pending" value="0" shortDescription="Pending Queue" />
-            <Enumeration label="Active" value="1" shortDescription="Active Queue" />
-            <Enumeration label="History" value="2" shortDescription="History Queue" />
-            <Enumeration label="All" value="3" shortDescription="All Queues" />
+            <Enumeration label="All" value="0" shortDescription="Unspecified / selects all queues" />
+            <Enumeration label="Pending" value="1" shortDescription="Pending Queue" />
+            <Enumeration label="Active" value="2" shortDescription="Active Queue" />
+            <Enumeration label="History" value="3" shortDescription="History Queue" />
           </EnumerationList>
        <IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
      </EnumeratedDataType>
@@ -111,23 +111,23 @@
                CF_SetParamCmd_t message structures.
           </LongDescription>
           <EnumerationList>
-               <Enumeration label="ticks_per_second"                      shortDescription="Ticks per second key" />
-               <Enumeration label="rx_crc_calc_bytes_per_wakeup"          shortDescription="Receive CRC calculated bytes per wake-up key" />
-               <Enumeration label="ack_timer_s"                           shortDescription="ACK timer in seconds key" />
-               <Enumeration label="nak_timer_s"                           shortDescription="NAK timer in seconds key" />
-               <Enumeration label="inactivity_timer_s"                    shortDescription="Inactivity timer in seconds key" />
-               <Enumeration label="outgoing_file_chunk_size"              shortDescription="Outgoing file chunk size key" />
-               <Enumeration label="ack_limit"                             shortDescription="ACK retry limit key" />
-               <Enumeration label="nak_limit"                             shortDescription="NAK retry limit key" />
-               <Enumeration label="local_eid"                             shortDescription="Local entity id key" />
-               <Enumeration label="chan_max_outgoing_messages_per_wakeup" shortDescription="Max outgoing messages per wake-up key" />
+               <Enumeration label="ticks_per_second" value="1" shortDescription="Ticks per second key" />
+               <Enumeration label="rx_crc_calc_bytes_per_wakeup" value="2" shortDescription="Receive CRC calculated bytes per wake-up key" />
+               <Enumeration label="ack_timer_s" value="3" shortDescription="ACK timer in seconds key" />
+               <Enumeration label="nak_timer_s" value="4" shortDescription="NAK timer in seconds key" />
+               <Enumeration label="inactivity_timer_s" value="5" shortDescription="Inactivity timer in seconds key" />
+               <Enumeration label="outgoing_file_chunk_size" value="6" shortDescription="Outgoing file chunk size key" />
+               <Enumeration label="ack_limit" value="7" shortDescription="ACK retry limit key" />
+               <Enumeration label="nak_limit" value="8" shortDescription="NAK retry limit key" />
+               <Enumeration label="local_eid" value="9" shortDescription="Local entity id key" />
+               <Enumeration label="chan_max_outgoing_messages_per_wakeup" value="10" shortDescription="Max outgoing messages per wake-up key" />
           </EnumerationList>
        <IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
      </EnumeratedDataType>
 
      <EnumeratedDataType name="Reset" shortDescription="IDs for use for Reset cmd" >
           <EnumerationList>
-               <Enumeration label="all" value="0" shortDescription="Reset all" />
+               <Enumeration label="all" value="0" shortDescription="Unspecified/Reset all values" />
                <Enumeration label="command" value="1" shortDescription="Reset command" />
                <Enumeration label="fault" value="2" shortDescription="Reset fault" />
                <Enumeration label="up" value="3" shortDescription="Reset up" />
@@ -207,7 +207,7 @@
       <ContainerDataType name="HkCmdCounters" shortDescription="Housekeeping command counters">
         <EntryList>
           <Entry name="cmd" type="BASE_TYPES/uint16" shortDescription="Command success counter" />
-          <Entry name="err" type="BASE_TYPES/uint16"  shortDescription="Command error counter" />
+          <Entry name="err" type="BASE_TYPES/uint16" shortDescription="Command error counter" />
         </EntryList>
       </ContainerDataType>
 
@@ -224,9 +224,9 @@
       <ContainerDataType name="HkRecv" shortDescription="Housekeeping received counters">
         <EntryList>
           <Entry name="file_data_bytes" type="BASE_TYPES/uint64" shortDescription="Sent file data bytes" />
-          <Entry name="pdu" type="BASE_TYPES/uint32"  shortDescription="Sent PDUs with valid header counter" />
-          <Entry name="error" type="BASE_TYPES/uint32"  shortDescription="Sent PDUs with error counter" />
-          <Entry name="spurious" type="BASE_TYPES/uint16"  shortDescription="Received PDUs with invalid directive code for current context or
+          <Entry name="pdu" type="BASE_TYPES/uint32" shortDescription="Sent PDUs with valid header counter" />
+          <Entry name="error" type="BASE_TYPES/uint32" shortDescription="Sent PDUs with error counter" />
+          <Entry name="spurious" type="BASE_TYPES/uint16" shortDescription="Received PDUs with invalid directive code for current context or
                                                            file directive FIN without matching active transaction counter" />
           <Entry name="dropped" type="BASE_TYPES/uint16"  shortDescription="Received PDUs dropped due to a transaction error" />
           <Entry name="nak_segment_requests" type="BASE_TYPES/uint32"  shortDescription="Received NAK segment requests counter" />
@@ -238,16 +238,16 @@
       <ContainerDataType name="HkFault" shortDescription="Housekeeping fault counters">
         <EntryList>
           <Entry name="file_open" type="BASE_TYPES/uint16" shortDescription="File open fault counter" />
-          <Entry name="file_read" type="BASE_TYPES/uint16"  shortDescription="File read fault counter" />
-          <Entry name="file_seek" type="BASE_TYPES/uint16"  shortDescription="File seek fault counter" />
-          <Entry name="file_write" type="BASE_TYPES/uint16"  shortDescription="File write fault counter" />
-          <Entry name="file_rename" type="BASE_TYPES/uint16"  shortDescription="File rename fault counter" />
-          <Entry name="directory_read" type="BASE_TYPES/uint16"  shortDescription="Directory read fault counter" />
-          <Entry name="crc_mismatch" type="BASE_TYPES/uint16"  shortDescription="CRC mismatch fault counter" />
-          <Entry name="file_size_mismatch" type="BASE_TYPES/uint16"  shortDescription="File size mismatch fault counter" />
-          <Entry name="nak_limit" type="BASE_TYPES/uint16"  shortDescription="NAK limit exceeded fault counter" />
-          <Entry name="ack_limit" type="BASE_TYPES/uint16"  shortDescription="ACK limit exceeded fault counter" />
-          <Entry name="inactivity_timer" type="BASE_TYPES/uint16"  shortDescription="Inactivity timer exceeded counter" />
+          <Entry name="file_read" type="BASE_TYPES/uint16" shortDescription="File read fault counter" />
+          <Entry name="file_seek" type="BASE_TYPES/uint16" shortDescription="File seek fault counter" />
+          <Entry name="file_write" type="BASE_TYPES/uint16" shortDescription="File write fault counter" />
+          <Entry name="file_rename" type="BASE_TYPES/uint16" shortDescription="File rename fault counter" />
+          <Entry name="directory_read" type="BASE_TYPES/uint16" shortDescription="Directory read fault counter" />
+          <Entry name="crc_mismatch" type="BASE_TYPES/uint16" shortDescription="CRC mismatch fault counter" />
+          <Entry name="file_size_mismatch" type="BASE_TYPES/uint16" shortDescription="File size mismatch fault counter" />
+          <Entry name="nak_limit" type="BASE_TYPES/uint16" shortDescription="NAK limit exceeded fault counter" />
+          <Entry name="ack_limit" type="BASE_TYPES/uint16" shortDescription="ACK limit exceeded fault counter" />
+          <Entry name="inactivity_timer" type="BASE_TYPES/uint16" shortDescription="Inactivity timer exceeded counter" />
           <PaddingEntry sizeInBits="16" shortDescription="Spare bytes for alignment"/>
         </EntryList>
       </ContainerDataType>
@@ -348,8 +348,8 @@
       <ContainerDataType name="ChannelSelect_Payload" shortDescription="Single byte channel selector payload">
         <LongDescription>
           Single byte channel selector payload
-           - 255 = all channels
-           - else = single channel
+           - 0 = unspecified / all channels
+           - else = single channel, 1-based
         </LongDescription>
         <EntryList>
           <Entry name="ChannelSelect" type="ChannelSelect" shortDescription="Channel to operate on" />
@@ -361,12 +361,12 @@
            Polling directory selector payload
 
            Single byte channel selector
-                 - 255 = all channels
-                 - else = single channel
+            - 0 = unspecified / all channels
+            - else = single channel, 1-based
 
            Single byte polling directory index
-                 - 255 = all polling directories
-                 - else = single polling directory index
+            - 0 = unspecified / all polling directories
+            - else = single polling directory index, 1-based
         </LongDescription>
         <EntryList>
           <Entry name="ChannelSelect" type="ChannelSelect" shortDescription="Channel to operate on" />
@@ -376,17 +376,14 @@
 
       <ContainerDataType name="QueueSelect_Payload" shortDescription="Queue selector payload">
         <LongDescription>
-              Queue selector payload
+           Queue selector payload
 
-              Single byte channel selector
-              - 255 = all channels
-              - else = single channel
+           Single byte channel selector
+            - 0 = unspecified / all channels
+            - else = single channel, 1-based
 
-              Single byte queue selection enum
+           Single byte queue selection enum
               Values indicated by #CF_QueueSelect enum
-              - 0 = Pending queue
-              - 1 = History queue
-              - 2 = Both pending and history queue
         </LongDescription>
         <EntryList>
           <Entry name="ChannelSelect" type="ChannelSelect" shortDescription="Channel to operate on" />
@@ -422,7 +419,7 @@
         </EntryList>
       </ContainerDataType>
 
-     <EnumeratedDataType name="Type" ShortDescription="Type IDs for use for Write Queue cmd">
+     <EnumeratedDataType name="DirectionType" ShortDescription="Direction indicators for use for Write Queue cmd">
           <EnumerationList>
                <Enumeration label="all" value="0" />
                <Enumeration label="up" value="1" />
@@ -431,22 +428,12 @@
        <IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
      </EnumeratedDataType>
 
-     <EnumeratedDataType name="Queue" ShortDescription="Queue IDs for use for Write Queue cmd">
-          <EnumerationList>
-               <Enumeration label="pend" value="0" />
-               <Enumeration label="active" value="1" />
-               <Enumeration label="history" value="2" />
-               <Enumeration label="all" value="3" />
-          </EnumerationList>
-       <IntegerDataEncoding sizeInBits="8" encoding="unsigned" />
-     </EnumeratedDataType>
-
 
      <ContainerDataType name="WriteQueue_Payload" shortDescription="Write Queue command structure">
         <EntryList>
-          <Entry name="type" type="Type" shortDescription="Transaction direction: all=0, up=1, down=2" />
-          <Entry name="chan" type="ChannelSelect" shortDescription="Channel number" />
-          <Entry name="queue" type="Queue" shortDescription="Queue type: 0=pending, 1=active, 2=history, 3=all" />
+          <Entry name="dir_type" type="DirectionType" shortDescription="Transaction direction: all=0, up=1, down=2" />
+          <Entry name="chan_num" type="ChannelSelect" shortDescription="Channel number" />
+          <Entry name="queue" type="QueueSelect" shortDescription="Queue selector" />
           <PaddingEntry sizeInBits="8" shortDescription="Alignment spare, puts filename on 32-bit boundary"/>
           <Entry name="filename" type="BASE_TYPES/PathName" shortDescription="Filename written to" />
         </EntryList>
@@ -454,10 +441,11 @@
 
       <ContainerDataType name="Transaction_Payload" shortDescription="Transaction command structure">
         <EntryList>
-          <Entry name="ts" type="BASE_TYPES/uint32" shortDescription="Transaction sequence number" />
-          <Entry name="eid" type="BASE_TYPES/uint32" shortDescription="Entity id" />
-          <Entry name="chan_num" type="ChannelSelect" shortDescription="Channel number: 254=use ts, 255=all channels, else channel" />
-          <PaddingEntry sizeInBits="24" shortDescription="Alignment spare for 32-bit multiple"/>
+          <Entry name="ts" type="TransactionSeq" shortDescription="Transaction sequence number" />
+          <Entry name="eid" type="EntityId" shortDescription="Entity id" />
+          <Entry name="chan_num" type="ChannelSelect" shortDescription="Channel number: 0=all channels, else channel 1-based" />
+          <Entry name="use_ts_eid" type="EnableFlag" shortDescription="Filter by ts+eid if true, else do all transactions" />
+          <PaddingEntry sizeInBits="16" shortDescription="Alignment spare for 32-bit multiple"/>
         </EntryList>
       </ContainerDataType>
 
@@ -720,7 +708,7 @@
             This command may fail for the following reason(s):
             - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
             - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
             - Already in requested state, #CF_CMD_SUSPRES_SAME_ERR_EID
             - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
 
@@ -763,7 +751,7 @@
             This command may fail for the following reason(s):
             - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
             - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
             - Already in requested state, #CF_CMD_SUSPRES_SAME_ERR_EID
             - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
 
@@ -805,7 +793,7 @@
             This command may fail for the following reason(s):
             - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
             - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
             - No matching transaction, #CF_CMD_CANCEL_CHAN_ERR_EID
 
        \par Evidence of failure may be found in the following telemetry:
@@ -846,7 +834,7 @@
             This command may fail for the following reason(s):
             - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
             - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
-            - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
             - No matching transaction, #CF_CMD_ABANDON_CHAN_ERR_EID
 
        \par Evidence of failure may be found in the following telemetry:
@@ -885,7 +873,7 @@
             This command may fail for the following reason(s):
             - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
             - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
-            - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
+            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
             - Parameter value failed validation, #CF_CMD_GETSET_VALIDATE_ERR_EID
 
        \par Evidence of failure may be found in the following telemetry:
@@ -924,7 +912,7 @@
             This command may fail for the following reason(s):
             - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
             - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
-            - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
+            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
 
        \par Evidence of failure may be found in the following telemetry:
             - #CF_HkPacket_t.counters #CF_HkCmdCounters_t.err will increment
@@ -962,7 +950,7 @@
             This command may fail for the following reason(s):
             - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
             - Invalid parameter combination, #CF_CMD_WQ_ARGS_ERR_EID
-            - Invalid channel number, #CF_CMD_WQ_CHAN_ERR_EID
+            - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
             - Open file to write failed, #CF_CMD_WQ_OPEN_ERR_EID
             - Write RX data failed, #CF_CMD_WQ_WRITEQ_RX_ERR_EID
             - Write RX history data failed, #CF_CMD_WQ_WRITEHIST_RX_ERR_EID

--- a/fsw/inc/cf_eventids.h
+++ b/fsw/inc/cf_eventids.h
@@ -1170,16 +1170,10 @@
  */
 #define CF_CMD_TRANS_NOT_FOUND_ERR_EID 131
 
-/**
- * \brief CF Command All Transaction Channel Invalid Event ID
- *
- *  \par Type: ERROR
- *
- *  \par Cause:
- *
- *  Command received to act on all transactions with invalid channel
+/*
+ * Note: CF_CMD_TSN_CHAN_INVALID_ERR_EID (132) removed, now uses
+ * common handling and sends CF_CMD_CHAN_PARAM_ERR_EID
  */
-#define CF_CMD_TSN_CHAN_INVALID_ERR_EID 132
 
 /**
  * \brief CF Suspend/Resume Command For Single Transaction State Unchanged Event ID
@@ -1225,16 +1219,10 @@
  */
 #define CF_CMD_PURGE_ARG_ERR_EID 136
 
-/**
- * \brief CF Write Queue Command Invalid Channel Event ID
- *
- *  \par Type: ERROR
- *
- *  \par Cause:
- *
- *  Write Queue command received with invalid channel argument
+/*
+ * Note: CF_CMD_WQ_CHAN_ERR_EID (137) removed, now uses
+ * common handling and sends CF_CMD_CHAN_PARAM_ERR_EID
  */
-#define CF_CMD_WQ_CHAN_ERR_EID 137
 
 /**
  * \brief CF Write Queue Command Invalid Queue Event ID
@@ -1335,16 +1323,10 @@
  */
 #define CF_CMD_GETSET_PARAM_ERR_EID 146
 
-/**
- * \brief CF Set/Get Parameter Command Invalid Channel Event ID
- *
- *  \par Type: ERROR
- *
- *  \par Cause:
- *
- *  Invalid channel value received in set or get parameter command
+/*
+ * Note: CF_CMD_GETSET_CHAN_ERR_EID (147) removed, now uses
+ * common handling and sends CF_CMD_CHAN_PARAM_ERR_EID
  */
-#define CF_CMD_GETSET_CHAN_ERR_EID 147
 
 /**
  * \brief CF Enable Engine Command Failed Event ID

--- a/fsw/inc/cf_fcncodes.h
+++ b/fsw/inc/cf_fcncodes.h
@@ -255,7 +255,7 @@
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
  *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
- *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+ *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
  *       - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
  *
  *  \par Evidence of failure may be found in the following telemetry:
@@ -291,7 +291,7 @@
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
  *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
- *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+ *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
  *       - No matching transaction, #CF_CMD_SUSPRES_CHAN_ERR_EID
  *
  *  \par Evidence of failure may be found in the following telemetry:
@@ -325,7 +325,7 @@
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
  *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
- *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+ *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
  *       - No matching transaction, #CF_CMD_CANCEL_CHAN_ERR_EID
  *
  *  \par Evidence of failure may be found in the following telemetry:
@@ -359,7 +359,7 @@
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
  *       - Transaction not found using compound key, #CF_CMD_TRANS_NOT_FOUND_ERR_EID
- *       - Invalid channel number, #CF_CMD_TSN_CHAN_INVALID_ERR_EID
+ *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
  *       - No matching transaction, #CF_CMD_ABANDON_CHAN_ERR_EID
  *
  *  \par Evidence of failure may be found in the following telemetry:
@@ -391,7 +391,7 @@
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
  *       - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
- *       - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
+ *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
  *       - Parameter value failed validation, #CF_CMD_GETSET_VALIDATE_ERR_EID
  *
  *  \par Evidence of failure may be found in the following telemetry:
@@ -423,7 +423,7 @@
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
  *       - Invalid configuration parameter key, #CF_CMD_GETSET_PARAM_ERR_EID
- *       - Invalid channel number, #CF_CMD_GETSET_CHAN_ERR_EID
+ *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CF_HkPacket_Payload_t.counters #CF_HkCmdCounters_t.err will increment
@@ -454,7 +454,7 @@
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected, #CF_CMD_LEN_ERR_EID
  *       - Invalid parameter combination, #CF_CMD_WQ_ARGS_ERR_EID
- *       - Invalid channel number, #CF_CMD_WQ_CHAN_ERR_EID
+ *       - Invalid channel number, #CF_CMD_CHAN_PARAM_ERR_EID
  *       - Open file to write failed, #CF_CMD_WQ_OPEN_ERR_EID
  *       - Write RX data failed, #CF_CMD_WQ_WRITEQ_RX_ERR_EID
  *       - Write RX history data failed, #CF_CMD_WQ_WRITEHIST_RX_ERR_EID

--- a/fsw/src/cf_app.c
+++ b/fsw/src/cf_app.c
@@ -50,8 +50,8 @@ CF_AppData_t CF_AppData;
 static int32 CF_DoChannelConfig(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg)
 {
     const CF_ConfigTable_t   *config      = arg;
-    const int                 chan_num    = CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(chan));
-    const CF_ChannelConfig_t *chan_config = &config->chan[chan_num];
+    const int                 chan_idx    = CF_ChannelSelect_AsIndex(CF_GetChannelFromPtr(chan));
+    const CF_ChannelConfig_t *chan_config = &config->chan[chan_idx];
     const CF_PollDir_t       *tbl_pd_config;
     CF_LocalPdConfig_t       *pd_config;
     int                       pd;

--- a/fsw/src/cf_app.h
+++ b/fsw/src/cf_app.h
@@ -165,43 +165,7 @@ static inline bool CF_IsValidClass(CF_CFDP_Class_Enum_t cv)
  */
 static inline bool CF_IsValidChannel(CF_ChannelSelect_t cs)
 {
-    return (cs < CF_NUM_CHANNELS);
-}
-
-/************************************************************************/
-/**
- * @brief Checks if a channel identifier represents "all channels"
- *
- * @par Description
- *      checks if the given channel number matches the special all channels value
- *
- * @par Assumptions, External Events, and Notes:
- *      This only checks if it matches all channels.
- *
- * @retval true if value is valid/acceptable
- * @retval false if value is invalid
- */
-static inline bool CF_IsAllChannels(CF_ChannelSelect_t cs)
-{
-    return (cs == CF_ALL_CHANNELS);
-}
-
-/************************************************************************/
-/**
- * @brief Checks if a channel identifier represents "all channels"
- *
- * @par Description
- *      checks if the given channel number matches the special all channels value
- *
- * @par Assumptions, External Events, and Notes:
- *      This only checks if it matches all channels.
- *
- * @retval true if value is valid/acceptable
- * @retval false if value is invalid
- */
-static inline bool CF_IsCompoundKey(CF_ChannelSelect_t cs)
-{
-    return (cs == CF_COMPOUND_KEY);
+    return (cs > 0 && cs <= CF_NUM_CHANNELS);
 }
 
 /************************************************************************/
@@ -224,6 +188,24 @@ static inline int CF_ChannelSelect_AsInt(CF_ChannelSelect_t cs)
 
 /************************************************************************/
 /**
+ * @brief Gets the channel number as an array index (0-based)
+ *
+ * @par Description
+ *      For use when indexing the channel number in a another array such
+ *      as configuration tables or performance logs, requiriing a 0-based index.
+ *
+ * @par Assumptions, External Events, and Notes:
+ *      Format log messages with printf "%d" conversion
+ *
+ * @returns channel number represented as "int" type
+ */
+static inline int CF_ChannelSelect_AsIndex(CF_ChannelSelect_t cs)
+{
+    return CF_ChannelSelect_AsInt(cs) - 1;
+}
+
+/************************************************************************/
+/**
  * @brief Gets the channel number from integer
  *
  * @par Description
@@ -238,7 +220,25 @@ static inline int CF_ChannelSelect_AsInt(CF_ChannelSelect_t cs)
  */
 static inline CF_ChannelSelect_t CF_ChannelSelect_FromInt(int c)
 {
-    return (c);
+    return (CF_ChannelSelect_t) { c };
+}
+
+/************************************************************************/
+/**
+ * @brief Checks if a channel identifier represents "all channels"
+ *
+ * @par Description
+ *      checks if the given channel number matches the special all channels value
+ *
+ * @par Assumptions, External Events, and Notes:
+ *      This only checks if it matches all channels.
+ *
+ * @retval true if value is valid/acceptable
+ * @retval false if value is invalid
+ */
+static inline bool CF_IsAllChannels(CF_ChannelSelect_t cs)
+{
+    return (cs == CF_ALL_CHANNELS);
 }
 
 /************************************************************************/
@@ -258,7 +258,8 @@ static inline CF_Channel_t *CF_GetChannelPtr(CF_ChannelSelect_t cs)
 {
     if (CF_IsValidChannel(cs))
     {
-        return &CF_GetEngine()->channels[cs];
+        /* the channel value from user interface should be 1-based */
+        return &CF_GetEngine()->channels[CF_ChannelSelect_AsIndex(cs)];
     }
     else
     {
@@ -281,7 +282,8 @@ static inline CF_Channel_t *CF_GetChannelPtr(CF_ChannelSelect_t cs)
 static inline CF_ChannelSelect_t CF_GetChannelFromPtr(const CF_Channel_t *ChanPtr)
 {
     CF_Engine_t *engine_ptr = CF_GetEngine();
-    return (CF_ChannelSelect_t) { (ChanPtr - engine_ptr->channels) };
+    /* the channel value to user interface should be 1-based */
+    return (CF_ChannelSelect_t) { 1 + (ChanPtr - engine_ptr->channels) };
 }
 
 /************************************************************************/

--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -1257,7 +1257,7 @@ static int32 CF_CFDP_DoEngineChannelInit(CF_Engine_t *engine_ptr, CF_Channel_t *
     CF_CListNode_t      **list_head;
     int                   j;
     int                   k;
-    const int             chan_num = CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(chan));
+    const int             chan_idx = CF_ChannelSelect_AsIndex(CF_GetChannelFromPtr(chan));
     char                  nbuf[64];
     CFE_Status_t          ret = CFE_SUCCESS;
 
@@ -1273,7 +1273,7 @@ static int32 CF_CFDP_DoEngineChannelInit(CF_Engine_t *engine_ptr, CF_Channel_t *
     chan->sem_id      = OS_OBJECT_ID_UNDEFINED;
     chan->tick_resume = NULL;
 
-    snprintf(nbuf, sizeof(nbuf) - 1, "%s%d", CF_CHANNEL_PIPE_PREFIX, chan_num);
+    snprintf(nbuf, sizeof(nbuf) - 1, "%s%d", CF_CHANNEL_PIPE_PREFIX, chan_idx);
     ret = CFE_SB_CreatePipe(&chan->pipe, chan->config.pipe_depth_input, nbuf);
     if (ret != CFE_SUCCESS)
     {
@@ -1342,9 +1342,9 @@ static int32 CF_CFDP_DoEngineChannelInit(CF_Engine_t *engine_ptr, CF_Channel_t *
             list_head = CF_GetChunkListHead(chan, k);
 
             CF_ChunkListInit(&state->cw->chunks,
-                             CF_DIR_MAX_CHUNKS[k][chan_num],
+                             CF_DIR_MAX_CHUNKS[k][chan_idx],
                              &engine_ptr->chunk_mem[state->chunk_mem_offset]);
-            state->chunk_mem_offset += CF_DIR_MAX_CHUNKS[k][chan_num];
+            state->chunk_mem_offset += CF_DIR_MAX_CHUNKS[k][chan_idx];
             CF_CList_InitNode(&state->cw->cl_node);
             CF_CList_InsertBack(list_head, &state->cw->cl_node);
 
@@ -1417,7 +1417,7 @@ CFE_Status_t CF_CFDP_InitEngine(CF_Engine_t *engine_ptr)
 static void CF_CFDP_S_Tick_SendFileData(CF_Transaction_t *txn)
 {
     CF_Channel_t *chan     = CF_GetChannelFromTxn(txn);
-    const int     chan_num = CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(chan)); /* for perf log */
+    const int     chan_idx = CF_ChannelSelect_AsIndex(CF_GetChannelFromPtr(chan)); /* for perf log */
     uint32        last_outgoing_counter;
 
     CF_Assert(chan);
@@ -1441,9 +1441,9 @@ static void CF_CFDP_S_Tick_SendFileData(CF_Transaction_t *txn)
     {
         last_outgoing_counter = chan->stat.outgoing_counter;
 
-        CFE_ES_PerfLogEntry(CF_PERF_ID_PDUSENT(chan_num));
+        CFE_ES_PerfLogEntry(CF_PERF_ID_PDUSENT(chan_idx));
         CF_CFDP_S_SubstateSendFileData(txn);
-        CFE_ES_PerfLogExit(CF_PERF_ID_PDUSENT(chan_num));
+        CFE_ES_PerfLogExit(CF_PERF_ID_PDUSENT(chan_idx));
 
     } while (last_outgoing_counter != chan->stat.outgoing_counter);
 }
@@ -2297,7 +2297,7 @@ void CF_CFDP_SendEotPkt(CF_Transaction_t *txn)
 
         CFE_MSG_Init(CFE_MSG_PTR(EotPktPtr->TelemetryHeader), CFE_SB_ValueToMsgId(CF_EOT_TLM_MID), sizeof(*EotPktPtr));
 
-        EotPktPtr->Payload.channel    = CF_GetChannelFromPtr(CF_GetChannelFromTxn(txn));
+        EotPktPtr->Payload.channel    = CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(CF_GetChannelFromTxn(txn)));
         EotPktPtr->Payload.direction  = txn->history->dir;
         EotPktPtr->Payload.fnames     = txn->history->fnames;
         EotPktPtr->Payload.state      = txn->state;

--- a/fsw/src/cf_cfdp_sbintf.c
+++ b/fsw/src/cf_cfdp_sbintf.c
@@ -186,7 +186,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
 {
     uint32                  count = 0;
     int32                   status;
-    const int               chan_num = CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(chan)); /* for perf log */
+    const int               chan_idx = CF_ChannelSelect_AsIndex(CF_GetChannelFromPtr(chan)); /* for perf log */
     CFE_SB_Buffer_t        *bufptr;
     CFE_MSG_Size_t          msg_size;
     CFE_MSG_Type_t          msg_type;
@@ -205,7 +205,7 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
         }
 
         ph = &engine_ptr->in.rx_pdudata;
-        CFE_ES_PerfLogEntry(CF_PERF_ID_PDURCVD(chan_num));
+        CFE_ES_PerfLogEntry(CF_PERF_ID_PDURCVD(chan_idx));
         CFE_MSG_GetSize(&bufptr->Msg, &msg_size);
         CFE_MSG_GetType(&bufptr->Msg, &msg_type);
         if (msg_size > CF_PDU_ENCAPSULATION_EXTRA_TRAILING_BYTES)
@@ -230,6 +230,6 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
         /* Identify and dispatch this PDU */
         CF_CFDP_ReceivePdu(chan, ph);
 
-        CFE_ES_PerfLogExit(CF_PERF_ID_PDURCVD(chan_num));
+        CFE_ES_PerfLogExit(CF_PERF_ID_PDURCVD(chan_idx));
     }
 }

--- a/fsw/src/cf_cmd.c
+++ b/fsw/src/cf_cmd.c
@@ -39,64 +39,492 @@
 
 #include <string.h>
 
-/* Helper struct for CF_DoChanAction() */
-typedef struct CF_ChanActionContext
+/**
+ * Type used for dispatch table in generic handlers
+ *
+ * Currently this is always just a function pointer, but
+ * is declared as a union to permit other items in future use
+ */
+typedef union CF_GenericAction_TableEntry
 {
-    CF_ChanAction_Status_t ret;
-    CF_ChanActionFn_t      fn;
-    void                  *context;
-} CF_ChanActionContext_t;
+    CF_GenericAction_Func_t fn;     /**< Implementation to execute for this table entry */
+    const void             *object; /**< Generic Pointer to data object */
+
+} CF_GenericAction_TableEntry_t;
+
+/**
+ * Helper functions for generic actions
+ *
+ * This defines _how_ to process the matched entry in the dispatch table
+ * If the entry is a function pointer, it may invoke the function, or if
+ * the entry is a data object it may call some other routine using
+ * that object.
+ *
+ * The chan pointer is passed through from the initial loop
+ * of applicable channels (e.g. when CF_ForEachChannel() is used)
+ *
+ * @param entry   the dispatcher table entry
+ * @param ga      pointer to the (base) context struct
+ * @param chan    CFDP channel - passed through to function
+ *
+ * @returns CFE Status code.  If an error is returned, dispatching will stop
+ * @retval  #CFE_SUCCESS in normal operation, will continue dispatching
+ */
+typedef CFE_Status_t (*CF_GenericAction_HelperFn_t)(CF_GenericAction_TableEntry_t entry,
+                                                    CF_GenericAction_Context_t   *ga,
+                                                    CF_Channel_t                 *chan);
+
+/**
+ * Intermediate context struct for use with CF_ForEachChannel()
+ *
+ * When operating across multiple channels via CF_ForEachChannel(), this
+ * stores the original callback and context, and a local intermediate function
+ * is used as the direct callback.  This intermediate function then calls
+ * the originally-requested callback with the original context, combined
+ * with the channel pointer.
+ */
+typedef struct CF_ActionContext_FEC
+{
+    uint32                      match_count;
+    CF_GenericAction_Func_t     fn;
+    CF_GenericAction_Context_t *context;
+} CF_ActionContext_FEC_t;
+
+/**
+ * Context object for use when matching transaction-based commands
+ *
+ * This is used for commands that operate on a transaction, via the #CF_Transaction_Payload_t
+ * command structure.  The normal channel loop is combined with CF_TraverseAllTransactions()
+ * on each channel to find the applicable transaction(s).
+ */
+typedef struct
+{
+    CF_GenericAction_Context_t ga;
+
+    CF_TraverseAllTransactions_fn_t action_cb;
+    void                           *action_arg;
+
+    /* original params from request */
+    bool use_ts_eid;
+
+    CF_TransactionSeq_t ts;
+    CF_EntityId_t       eid;
+
+} CF_GenericAction_TxnContext_t;
+
+/**
+ * Context object used with ResetCounters command
+ */
+typedef struct CF_DoResetFault_Context
+{
+    CF_GenericAction_Context_t ga; /* always first */
+
+    /* original params from request */
+    CF_Reset_Enum_t user_resetsel;
+
+} CF_DoResetFault_Context_t;
+
+/**
+ * Context object used with WriteQueue command
+ */
+typedef struct CF_WriteQueue_FullContext
+{
+    CF_GenericAction_Context_t ga; /* always first */
+
+    /* file descriptor to write queue data to */
+    osal_id_t fd;
+
+    /* original params from request */
+    CF_QueueSelect_Enum_t   user_qsel;
+    CF_DirectionType_Enum_t user_dirsel;
+
+} CF_WriteQueue_FullContext_t;
+
+/**
+ * Intermediate context object used with WriteQueue command
+ *
+ * The write queue command dispatches on both queue type and direction
+ * The direction is dispatched first.  This captures the original request
+ * info so that the direction handler can invoke the queue handler.
+ */
+typedef struct CF_WriteQueue_DirContext
+{
+    CF_GenericAction_Context_t   ga;       /* always first */
+    CF_GenericAction_HelperFn_t  q_action; /* next action (for queues) */
+    CF_WriteQueue_FullContext_t *ctxt;
+} CF_WriteQueue_DirContext_t;
+
+/**
+ * A context object used with purge queue commands
+ */
+typedef struct CF_DoPurgeQueue_Context
+{
+    CF_GenericAction_Context_t ga; /* always first */
+
+    /* original params from request */
+    CF_QueueSelect_Enum_t user_qsel;
+
+} CF_DoPurgeQueue_Context_t;
+
+/**
+ * A context object used with actions requiring only a boolean argument
+ *
+ * This combines a boolean value with an output that indicates if it
+ * was a change or not.
+ */
+typedef struct CF_GenericAction_BoolArg
+{
+    CF_GenericAction_Context_t ga; /* always first */
+
+    bool   barg;       /* desired value to set in matched field(s) */
+    uint32 noop_count; /* count where the requested value was already set, resulting in no change */
+
+} CF_GenericAction_BoolArg_t;
+
+/**
+ * A context object used with enable/disable polling dir commands
+ */
+typedef struct CF_EnableDisablePollDir_Context
+{
+    CF_GenericAction_BoolArg_t barg; /* always first */
+
+    /* original params from request */
+    CF_PollIdxSelect_t user_pollidx;
+
+} CF_EnableDisablePollDir_Context_t;
+
+/**
+ * A context object used with get/set parameter commands
+ */
+typedef struct CF_GetSetParam_Context
+{
+    CF_GenericAction_Context_t ga; /* always first */
+
+    /* original params from request */
+    bool                is_set;
+    CF_GetSet_ValueID_t param_id;
+    uint32              value;
+
+} CF_GetSetParam_Context_t;
 
 /*----------------------------------------------------------------
  *
- * Local Helper Function, compatible with CF_ForEachChannel()
- * Resets fault counters
+ * Local action helper function
+ *
+ * This does not invoke the action.  It just checks if the action entry is
+ * valid, and increments the valid count.
+ *
+ * This is intended for pre-validating a command before doing any more
+ * expensive work.  The ValidCount should be nonzero after using this.
  *
  *-----------------------------------------------------------------*/
-static int32 CF_DoResetFaultCount(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg)
+static CFE_Status_t
+CF_GenericAction_DoCheck(CF_GenericAction_TableEntry_t entry, CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    memset(&chan->stat.counters.fault, 0, sizeof(chan->stat.counters.fault));
-    return CFE_SUCCESS;
-}
+    if (entry.fn != NULL)
+    {
+        /* this matched a valid action, increment the count */
+        ++ga->ValidCount;
+    }
 
-/*----------------------------------------------------------------
- *
- * Local Helper Function, compatible with CF_ForEachChannel()
- * Resets up counters
- *
- *-----------------------------------------------------------------*/
-static int32 CF_DoResetUpCount(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg)
-{
-    memset(&chan->stat.counters.recv, 0, sizeof(chan->stat.counters.recv));
-    return CFE_SUCCESS;
-}
-
-/*----------------------------------------------------------------
- *
- * Local Helper Function, compatible with CF_ForEachChannel()
- * Resets down counters
- *
- *-----------------------------------------------------------------*/
-static int32 CF_DoResetDownCount(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg)
-{
-    memset(&chan->stat.counters.sent, 0, sizeof(chan->stat.counters.sent));
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
  *
  * Local helper function
- * Invokes the requested action on a single channel
- * compatible with CF_ForEachChannel()
+ * invokes the action entry for each valid entry
+ * at this stage empty entries are considered a no-op (successful)
  *
  *-----------------------------------------------------------------*/
-static int32 CF_DoSingleChannelAction(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg)
+static CFE_Status_t
+CF_GenericAction_DoInvokeAction(CF_GenericAction_TableEntry_t entry, CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    CF_ChanActionContext_t *ctxt = arg;
+    CFE_Status_t ret;
 
-    ctxt->ret |= ctxt->fn(chan, ctxt->context);
+    if (entry.fn == NULL)
+    {
+        /*
+         * note: if no-ops are considered an error, then CF_GenericAction_DoCheck() should
+         * be used to validate the request first.  At this stage empty entries are benign.
+         */
+        ret = CFE_SUCCESS;
+    }
+    else
+    {
+        ret = entry.fn(ga, chan);
+        if (ret == CFE_SUCCESS)
+        {
+            /* this count shows _real_ (non-noop) callbacks that returned success */
+            ++ga->SuccessCount;
+        }
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Allows a generic action to be invoked through CF_ForEachChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GenericAction_DoChannel(CF_Engine_t *engine, CF_Channel_t *chan, void *arg)
+{
+    CF_ActionContext_FEC_t *dca_ctxt = arg;
+
+    if (chan != NULL)
+    {
+        /* execute action operations on this channel, using original values */
+        ++dca_ctxt->match_count;
+        dca_ctxt->fn(dca_ctxt->context, chan);
+    }
 
     return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Call the handler function for every matched channel
+ * Returns the number of channels called
+ *
+ *-----------------------------------------------------------------*/
+static uint32 CF_GenericAction_DispatchChannel(CF_GenericAction_Func_t     func,
+                                               CF_GenericAction_Context_t *context,
+                                               CF_ChannelSelect_t          chan_select)
+{
+    CF_ActionContext_FEC_t dca_ctxt;
+
+    memset(&dca_ctxt, 0, sizeof(dca_ctxt));
+
+    dca_ctxt.fn      = func;
+    dca_ctxt.context = context;
+
+    /*
+     * Currently this is a singleton so its always the same.
+     * If that ever changes this should be passed in indicating
+     * the CFDP engine to operate on.
+     */
+    context->engine = CF_GetEngine();
+
+    /* this function is generic for any ground command that takes a single channel
+     * argument which must be less than CF_NUM_CHANNELS or 255 which is a special
+     * value that means apply command to all channels */
+    if (CF_IsAllChannels(chan_select))
+    {
+        /* apply to all channels */
+        CF_ForEachChannel(context->engine, CF_GenericAction_DoChannel, &dca_ctxt);
+    }
+    else
+    {
+        /* apply to only the specified channel number */
+        CF_GenericAction_DoChannel(context->engine, CF_GetChannelPtr(chan_select), &dca_ctxt);
+    }
+
+    /* if successful, return a positive channel count match */
+    return dca_ctxt.match_count;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ *
+ * Same as CF_GenericAction_DispatchChannel() but sends an event if
+ * no channels were match in the process, meaning that the user-supplied
+ * channel number was invalid.  The CF_CMD_CHAN_PARAM_ERR_EID event
+ * is generated in this case.
+ *
+ *-----------------------------------------------------------------*/
+static int32 CF_GenericAction_CheckAndDispatchChannel(const char                 *action_str,
+                                                      CF_GenericAction_Func_t     func,
+                                                      CF_GenericAction_Context_t *context,
+                                                      CF_ChannelSelect_t          chan_select)
+{
+    int32 count;
+
+    count = CF_GenericAction_DispatchChannel(func, context, chan_select);
+
+    if (count == 0)
+    {
+        /* no channels were matched by the chan_select parameter */
+        CFE_EVS_SendEvent(CF_CMD_CHAN_PARAM_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: %s: channel parameter out of range (%d)",
+                          action_str,
+                          CF_ChannelSelect_AsInt(chan_select));
+    }
+
+    return count;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Dispatch a generic action using common selector patterns.
+ *
+ * If the user selection is 0, treat it as "all" and loop through
+ * all entries in the map.  Otherwise invoke the single specified
+ * handler from the map, or no handler at all if the selector was
+ * out of range.
+ *
+ * NOTE: the action in the map is not _directly_ invoked here.  Rather,
+ * the given helper function is invoked with the map entry as a parameter.
+ * The action helper may choose to call the routine or do something else
+ * like count it.
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GenericAction_DoDispatch(CF_GenericAction_Context_t          *ga,
+                                                CF_GenericAction_HelperFn_t          act_helper,
+                                                const CF_GenericAction_TableEntry_t *map_baseptr,
+                                                size_t                               map_size,
+                                                uint32                               selector,
+                                                CF_Channel_t                        *chan)
+{
+    const CF_GenericAction_TableEntry_t *MapCurrPtr;
+    uint32                               NumEntries;
+    CFE_Status_t                         ret;
+
+    NumEntries = map_size / sizeof(*map_baseptr);
+    MapCurrPtr = map_baseptr;
+    ret        = CFE_STATUS_RANGE_ERROR;
+
+    if (selector != 0)
+    {
+        if (selector < NumEntries)
+        {
+            /* do just a single entry */
+            MapCurrPtr += selector;
+            NumEntries  = 1;
+        }
+        else
+        {
+            NumEntries = 0;
+        }
+    }
+
+    while (NumEntries > 0)
+    {
+        ++ga->TotalCount;
+        ret = act_helper(*MapCurrPtr, ga, chan);
+        if (ret != CFE_SUCCESS)
+        {
+            break;
+        }
+
+        ++MapCurrPtr;
+        --NumEntries;
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Sets a single boolean while also checking if it was already set to the same value
+ *
+ *-----------------------------------------------------------------*/
+static void CF_GenericAction_DoSetBoolArg(CF_GenericAction_BoolArg_t *barg, bool *ref)
+{
+    ++barg->ga.TotalCount;
+    if (*ref == barg->barg)
+    {
+        /* it was already set to the requested value, nothing changed */
+        ++barg->noop_count;
+    }
+    else
+    {
+        *ref = barg->barg;
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Invokes per-transaction callback
+ *
+ * This is an intermediate routine compatible with CF_TraverseAllTransactions()
+ *
+ *-----------------------------------------------------------------*/
+static void CF_GenericAction_DoSingleTxnActionImpl(CF_Transaction_t *txn, void *arg)
+{
+    CF_GenericAction_TxnContext_t *ctxt = arg;
+
+    ++ctxt->ga.ValidCount;
+    ctxt->action_cb(txn, ctxt->action_arg);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Finds a transaction by sequence and entity id
+ *
+ *-----------------------------------------------------------------*/
+CFE_Status_t CF_GenericAction_FindTxnActionImpl(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GenericAction_TxnContext_t *ctxt = (CF_GenericAction_TxnContext_t *)ga;
+    CF_Transaction_t              *txn;
+
+    if (ctxt->use_ts_eid)
+    {
+        /* perform action only on  matching ts+eid */
+        txn = CF_FindTransactionBySequenceNumber(chan, ctxt->ts, ctxt->eid);
+        if (txn != NULL)
+        {
+            /* got a match */
+            CF_GenericAction_DoSingleTxnActionImpl(txn, ga);
+        }
+    }
+    else
+    {
+        /* perform action on this channel, all transactions */
+        CF_TraverseAllTransactions(chan, CF_GenericAction_DoSingleTxnActionImpl, ga);
+    }
+
+    return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Common handler for routines that operate on a transaction
+ *
+ *-----------------------------------------------------------------*/
+int32 CF_GenericAction_CheckAndDispatchTxn(const char                     *action_str,
+                                           const CF_Transaction_Payload_t *data,
+                                           CF_TraverseAllTransactions_fn_t fn,
+                                           void                           *arg)
+{
+    CF_GenericAction_TxnContext_t ctxt;
+    int32                         count;
+
+    memset(&ctxt, 0, sizeof(ctxt));
+
+    ctxt.action_cb  = fn;
+    ctxt.action_arg = arg;
+    ctxt.use_ts_eid = data->use_ts_eid;
+    ctxt.eid        = data->eid;
+    ctxt.ts         = data->ts;
+
+    /* First dispatch based on chan_num like all other ops do */
+    count = CF_GenericAction_CheckAndDispatchChannel(action_str,
+                                                     CF_GenericAction_FindTxnActionImpl,
+                                                     &ctxt.ga,
+                                                     data->chan_num);
+
+    if (count != 0 && ctxt.use_ts_eid && ctxt.ga.ValidCount == 0)
+    {
+        CFE_EVS_SendEvent(CF_CMD_TRANS_NOT_FOUND_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: %s cmd: failed to find transaction for (eid %lu, ts %lu)",
+                          action_str,
+                          (unsigned long)data->eid,
+                          (unsigned long)data->ts);
+    }
+
+    /* this should reflect the matched transaction count */
+    return ctxt.ga.ValidCount;
 }
 
 /*----------------------------------------------------------------
@@ -122,19 +550,114 @@ CFE_Status_t CF_NoopCmd(const CF_NoopCmd_t *msg)
 
 /*----------------------------------------------------------------
  *
+ * Local Helper Function, compatible with generic action dispatch table
+ * Resets command counters
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_ResetCounters_DoResetCommandCount(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    memset(&CF_AppData.counters, 0, sizeof(CF_AppData.counters));
+    return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function, compatible with generic action dispatch table
+ * Resets fault counters
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_ResetCounters_DoResetFaultCount(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    memset(&chan->stat.counters.fault, 0, sizeof(chan->stat.counters.fault));
+    return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function, compatible with generic action dispatch table
+ * Resets up (rx) counters
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_ResetCounters_DoResetUpCount(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    memset(&chan->stat.counters.recv, 0, sizeof(chan->stat.counters.recv));
+    return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function, compatible with generic action dispatch table
+ * Resets down (tx) counters
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_ResetCounters_DoResetDownCount(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    memset(&chan->stat.counters.sent, 0, sizeof(chan->stat.counters.sent));
+    return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function
+ * Dispatches action for Reset counters command
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t
+CF_ResetCounters_Dispatch(CF_DoResetFault_Context_t *ctxt, CF_GenericAction_HelperFn_t act_helper, CF_Channel_t *chan)
+{
+    static const CF_GenericAction_TableEntry_t CF_RESETCOUNTER_HANDLER_MAP[CF_Reset_MAX] = {
+        [CF_Reset_command] = { CF_ResetCounters_DoResetCommandCount },
+        [CF_Reset_fault]   = { CF_ResetCounters_DoResetFaultCount },
+        [CF_Reset_up]      = { CF_ResetCounters_DoResetUpCount },
+        [CF_Reset_down]    = { CF_ResetCounters_DoResetDownCount },
+    };
+
+    return CF_GenericAction_DoDispatch(&ctxt->ga,
+                                       act_helper,
+                                       CF_RESETCOUNTER_HANDLER_MAP,
+                                       sizeof(CF_RESETCOUNTER_HANDLER_MAP),
+                                       ctxt->user_resetsel,
+                                       chan);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function, compatible with CF_ForEachChannel()
+ * Resets down counters
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_ResetCounters_ChanActionImpl(CF_Engine_t *engine, CF_Channel_t *chan, void *arg)
+{
+    return CF_ResetCounters_Dispatch(arg, CF_GenericAction_DoInvokeAction, chan);
+}
+
+/*----------------------------------------------------------------
+ *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_ResetCountersCmd(const CF_ResetCountersCmd_t *msg)
 {
-    const CF_ResetCountersCmd_Payload_t *data       = &msg->Payload;
-    static const char                   *names[5]   = { "all", "cmd", "fault", "up", "down" };
-    /* 0=all, 1=cmd, 2=fault 3=up 4=down */
-    bool                                 acc        = true;
-    CF_Engine_t                         *engine_ptr = CF_GetEngine();
+    const CF_ResetCountersCmd_Payload_t *data = &msg->Payload;
+    CF_DoResetFault_Context_t            ctxt;
 
-    if (data->ResetType > 4)
+    static const char *names[CF_Reset_MAX] = { [CF_Reset_all]     = "all",
+                                               [CF_Reset_command] = "cmd",
+                                               [CF_Reset_fault]   = "fault",
+                                               [CF_Reset_up]      = "up",
+                                               [CF_Reset_down]    = "down" };
+
+    memset(&ctxt, 0, sizeof(ctxt));
+
+    ctxt.user_resetsel = data->ResetType;
+
+    /* checking the validity of parameters first.  if something is bad
+     * we should do nothing at all and send the error event */
+    CF_ResetCounters_Dispatch(&ctxt, CF_GenericAction_DoCheck, NULL);
+
+    if (ctxt.ga.ValidCount == 0)
     {
         CFE_EVS_SendEvent(CF_CMD_RESET_INVALID_ERR_EID,
                           CFE_EVS_EventType_ERROR,
@@ -149,39 +672,11 @@ CFE_Status_t CF_ResetCountersCmd(const CF_ResetCountersCmd_t *msg)
                           "CF: Received RESET COUNTERS command: %s",
                           names[data->ResetType]);
 
-        /* if the param is CF_Reset_command, or all counters */
-        if ((data->ResetType == CF_Reset_all) || (data->ResetType == CF_Reset_command))
-        {
-            /* command counters */
-            memset(&CF_AppData.counters, 0, sizeof(CF_AppData.counters));
-            acc = false; /* don't increment accept counter on command counter reset */
-        }
+        /* Incrementing the command counter FIRST -- this way, if the reset includes
+         * the command counter, then it will be left at 0 rather than 1. */
+        ++CF_AppData.counters.cmd;
 
-        /* if the param is CF_Reset_fault, or all counters */
-        if ((data->ResetType == CF_Reset_all) || (data->ResetType == CF_Reset_fault))
-        {
-            /* fault counters */
-            CF_ForEachChannel(engine_ptr, CF_DoResetFaultCount, NULL);
-        }
-
-        /* if the param is CF_Reset_up, or all counters */
-        if ((data->ResetType == CF_Reset_all) || (data->ResetType == CF_Reset_up))
-        {
-            /* up counters */
-            CF_ForEachChannel(engine_ptr, CF_DoResetUpCount, NULL);
-        }
-
-        /* if the param is CF_Reset_down, or all counters */
-        if ((data->ResetType == CF_Reset_all) || (data->ResetType == CF_Reset_down))
-        {
-            /* down counters */
-            CF_ForEachChannel(engine_ptr, CF_DoResetDownCount, NULL);
-        }
-
-        if (acc)
-        {
-            ++CF_AppData.counters.cmd;
-        }
+        CF_ForEachChannel(CF_GetEngine(), CF_ResetCounters_ChanActionImpl, &ctxt);
     }
 
     return CFE_SUCCESS;
@@ -191,6 +686,7 @@ CFE_Status_t CF_ResetCountersCmd(const CF_ResetCountersCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg)
@@ -213,23 +709,28 @@ CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg)
                           (unsigned int)tx->cfdp_class,
                           (unsigned int)tx->keep);
         ++CF_AppData.counters.err;
-
-        /* This must return CFE_SUCCESS because the command is done (error counter was incremented, no more events) */
-        return CFE_SUCCESS;
-    }
-
-    ret = CF_CFDP_TxFile(tx->src_filename, tx->dst_filename, tx->cfdp_class, tx->keep, chan, tx->priority, tx->dest_id);
-    if (ret == CFE_SUCCESS)
-    {
-        CFE_EVS_SendEvent(CF_CMD_TX_FILE_INF_EID,
-                          CFE_EVS_EventType_INFORMATION,
-                          "CF: file transfer successfully initiated");
-        ++CF_AppData.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_TX_FILE_ERR_EID, CFE_EVS_EventType_ERROR, "CF: file transfer initiation failed");
-        ++CF_AppData.counters.err;
+        ret = CF_CFDP_TxFile(tx->src_filename,
+                             tx->dst_filename,
+                             tx->cfdp_class,
+                             tx->keep,
+                             chan,
+                             tx->priority,
+                             tx->dest_id);
+        if (ret == CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(CF_CMD_TX_FILE_INF_EID,
+                              CFE_EVS_EventType_INFORMATION,
+                              "CF: file transfer successfully initiated");
+            ++CF_AppData.counters.cmd;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CF_CMD_TX_FILE_ERR_EID, CFE_EVS_EventType_ERROR, "CF: file transfer initiation failed");
+            ++CF_AppData.counters.err;
+        }
     }
 
     return CFE_SUCCESS;
@@ -239,6 +740,7 @@ CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg)
@@ -261,31 +763,30 @@ CFE_Status_t CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg)
                           (unsigned int)tx->cfdp_class,
                           (unsigned int)tx->keep);
         ++CF_AppData.counters.err;
-
-        /* This must return CFE_SUCCESS because the command is done (error counter was incremented, no more events) */
-        return CFE_SUCCESS;
-    }
-
-    ret = CF_CFDP_PlaybackDir(tx->src_filename,
-                              tx->dst_filename,
-                              tx->cfdp_class,
-                              tx->keep,
-                              chan,
-                              tx->priority,
-                              tx->dest_id);
-    if (ret == CFE_SUCCESS)
-    {
-        CFE_EVS_SendEvent(CF_CMD_PLAYBACK_DIR_INF_EID,
-                          CFE_EVS_EventType_INFORMATION,
-                          "CF: directory playback initiation successful");
-        ++CF_AppData.counters.cmd;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_PLAYBACK_DIR_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "CF: directory playback initiation failed");
-        ++CF_AppData.counters.err;
+        ret = CF_CFDP_PlaybackDir(tx->src_filename,
+                                  tx->dst_filename,
+                                  tx->cfdp_class,
+                                  tx->keep,
+                                  chan,
+                                  tx->priority,
+                                  tx->dest_id);
+        if (ret == CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(CF_CMD_PLAYBACK_DIR_INF_EID,
+                              CFE_EVS_EventType_INFORMATION,
+                              "CF: directory playback initiation successful");
+            ++CF_AppData.counters.cmd;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CF_CMD_PLAYBACK_DIR_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "CF: directory playback initiation failed");
+            ++CF_AppData.counters.err;
+        }
     }
 
     return CFE_SUCCESS;
@@ -293,72 +794,36 @@ CFE_Status_t CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Sets the "frozen" bool in every matched channel
  *
  *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t
-CF_DoChanAction(CF_ChannelSelect_t chan_select, const char *errstr, CF_ChanActionFn_t fn, void *context)
+static CFE_Status_t CF_FreezeThaw_ChanActionImpl(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    CF_Engine_t           *engine_ptr = CF_GetEngine();
-    CF_ChanActionContext_t local_ctxt;
-
-    memset(&local_ctxt, 0, sizeof(local_ctxt));
-    local_ctxt.fn      = fn;
-    local_ctxt.context = context;
-
-    /* this function is generic for any ground command that takes a single channel
-     * argument which must be less than CF_NUM_CHANNELS or 255 which is a special
-     * value that means apply command to all channels */
-    if (CF_IsAllChannels(chan_select))
-    {
-        /* apply to all channels */
-        CF_ForEachChannel(engine_ptr, CF_DoSingleChannelAction, &local_ctxt);
-    }
-    else if (CF_IsValidChannel(chan_select))
-    {
-        CF_DoSingleChannelAction(engine_ptr, CF_GetChannelPtr(chan_select), &local_ctxt);
-    }
-    else
-    {
-        /* bad parameter */
-        CFE_EVS_SendEvent(CF_CMD_CHAN_PARAM_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "CF: %s: channel parameter out of range. received %d",
-                          errstr,
-                          CF_ChannelSelect_AsInt(chan_select));
-        local_ctxt.ret = CF_ChanAction_Status_ERROR;
-    }
-
-    return local_ctxt.ret;
+    CF_GenericAction_DoSetBoolArg((CF_GenericAction_BoolArg_t *)ga, &chan->stat.frozen);
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
- *
- *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t CF_DoFreezeThaw(CF_Channel_t *chan, void *arg)
-{
-    const CF_ChanAction_BoolArg_t *context = arg;
-
-    /* no need to bounds check chan_num, done in caller */
-    chan->stat.frozen = context->barg;
-    return CF_ChanAction_Status_SUCCESS;
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_FreezeCmd(const CF_FreezeCmd_t *msg)
 {
-    CF_ChanAction_BoolArg_t barg = { 1 }; /* param is frozen, so 1 means freeze */
+    CF_GenericAction_BoolArg_t barg;
 
-    if (CF_ChanAction_Status_IS_SUCCESS(CF_DoChanAction(msg->Payload.ChannelSelect, "freeze", CF_DoFreezeThaw, &barg)))
+    memset(&barg, 0, sizeof(barg));
+    barg.barg = true; /* param is frozen, so true means freeze */
+
+    CF_GenericAction_CheckAndDispatchChannel("freeze",
+                                             CF_FreezeThaw_ChanActionImpl,
+                                             &barg.ga,
+                                             msg->Payload.ChannelSelect);
+
+    if (barg.ga.TotalCount > 0)
     {
         CFE_EVS_SendEvent(CF_CMD_FREEZE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: freeze successful");
         ++CF_AppData.counters.cmd;
@@ -376,13 +841,22 @@ CFE_Status_t CF_FreezeCmd(const CF_FreezeCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_ThawCmd(const CF_ThawCmd_t *msg)
 {
-    CF_ChanAction_BoolArg_t barg = { 0 }; /* param is frozen, so 0 means thawed */
+    CF_GenericAction_BoolArg_t barg;
 
-    if (CF_ChanAction_Status_IS_SUCCESS(CF_DoChanAction(msg->Payload.ChannelSelect, "thaw", CF_DoFreezeThaw, &barg)))
+    memset(&barg, 0, sizeof(barg));
+    barg.barg = false; /* param is frozen, so false means thaw */
+
+    CF_GenericAction_CheckAndDispatchChannel("thaw",
+                                             CF_FreezeThaw_ChanActionImpl,
+                                             &barg.ga,
+                                             msg->Payload.ChannelSelect);
+
+    if (barg.ga.TotalCount > 0)
     {
         CFE_EVS_SendEvent(CF_CMD_THAW_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: thaw successful");
         ++CF_AppData.counters.cmd;
@@ -395,115 +869,16 @@ CFE_Status_t CF_ThawCmd(const CF_ThawCmd_t *msg)
 
     return CFE_SUCCESS;
 }
-
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_CheckAndDispatchTxn()
+ * Sets the "suspended" bool in every matched transaction record
  *
  *-----------------------------------------------------------------*/
-CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSeq_t ts, CF_EntityId_t eid)
-{
-    int               i;
-    CF_Transaction_t *ret = NULL;
-
-    /* transaction sequence numbers are referenced with the tuple (eid, tsn)
-     * Even though these tuples are unique to a channel, they should be unique
-     * across the entire system. Meaning, it isn't correct to have the same
-     * EID re-using a TSN in the same system. So, in order to locate the transaction
-     * to suspend, we need to search across all channels for it. */
-    for (i = 0; i < CF_NUM_CHANNELS; ++i)
-    {
-        CF_Channel_t *chan = CF_GetChannelPtr(CF_ChannelSelect_FromInt(i));
-
-        ret = CF_FindTransactionBySequenceNumber(chan, ts, eid);
-        if (ret)
-        {
-            break;
-        }
-    }
-
-    return ret;
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
- *
- *-----------------------------------------------------------------*/
-int32 CF_TsnChanAction(const CF_Transaction_Payload_t *data,
-                       const char                     *cmdstr,
-                       CF_TsnChanAction_fn_t           fn,
-                       void                           *context)
-{
-    CF_Transaction_t *txn;
-    CF_Channel_t     *chan;
-    int32             ret = -1;
-
-    if (CF_IsCompoundKey(data->chan_num))
-    {
-        /* special value 254 means to use the compound key (data->eid, data->ts) to find the transaction
-         * to act upon */
-        txn = CF_FindTransactionBySequenceNumberAllChannels(data->ts, data->eid);
-        if (txn)
-        {
-            fn(txn, context);
-            ret = 1; /* because one transaction was matched - this should return a count */
-        }
-        else
-        {
-            CFE_EVS_SendEvent(CF_CMD_TRANS_NOT_FOUND_ERR_EID,
-                              CFE_EVS_EventType_ERROR,
-                              "CF: %s cmd: failed to find transaction for (eid %lu, ts %lu)",
-                              cmdstr,
-                              (unsigned long)data->eid,
-                              (unsigned long)data->ts);
-        }
-    }
-    else if (CF_IsAllChannels(data->chan_num))
-    {
-        /* perform action on all channels, all transactions */
-        ret = CF_TraverseAllTransactions_All_Channels(fn, context);
-    }
-    else
-    {
-        chan = CF_GetChannelPtr(data->chan_num);
-        if (chan != NULL)
-        {
-            /* perform action on a specific channel, all transactions */
-            ret = CF_TraverseAllTransactions(chan, fn, context);
-        }
-        else
-        {
-            CFE_EVS_SendEvent(CF_CMD_TSN_CHAN_INVALID_ERR_EID,
-                              CFE_EVS_EventType_ERROR,
-                              "CF: %s cmd: invalid channel %d",
-                              cmdstr,
-                              CF_ChannelSelect_AsInt(data->chan_num));
-        }
-    }
-
-    return ret;
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
- *
- *-----------------------------------------------------------------*/
-void CF_DoSuspRes_Txn(CF_Transaction_t *txn, CF_ChanAction_SuspResArg_t *context)
+static void CF_SuspRes_TxnActionImpl(CF_Transaction_t *txn, void *context)
 {
     CF_Assert(txn);
-    if (txn->flags.com.suspended == context->action)
-    {
-        context->same = 1;
-    }
-    else
-    {
-        txn->flags.com.suspended = context->action;
-    }
+    CF_GenericAction_DoSetBoolArg(context, &txn->flags.com.suspended);
 }
 
 /*----------------------------------------------------------------
@@ -512,12 +887,15 @@ void CF_DoSuspRes_Txn(CF_Transaction_t *txn, CF_ChanAction_SuspResArg_t *context
  * See description in cf_cmd.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action)
+void CF_SuspRes_CommonHandler(const char *action_str, const CF_Transaction_Payload_t *payload, bool is_suspend)
 {
-    /* ok to not bounds check action, because the caller is using it in two places with constant values 0 or 1 */
-    static const char         *msgstr[] = { "resume", "suspend" };
-    CF_ChanAction_SuspResArg_t args     = { 0, action };
-    int ret = CF_TsnChanAction(payload, msgstr[action], (CF_TsnChanAction_fn_t)CF_DoSuspRes_Txn, &args);
+    CF_GenericAction_BoolArg_t args;
+    int                        count;
+
+    memset(&args, 0, sizeof(args));
+    args.barg = is_suspend;
+
+    count = CF_GenericAction_CheckAndDispatchTxn(action_str, payload, CF_SuspRes_TxnActionImpl, &args);
 
     /*
      * Note that this command may affect multiple transactions, depending on the value of the "chan" argument.
@@ -525,32 +903,32 @@ void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action)
      * that one of the affected channels was already set that way.
      */
 
-    if (ret == 1 && args.same)
-    {
-        /* A single transaction was mached, and it was already set the same way */
-        CFE_EVS_SendEvent(CF_CMD_SUSPRES_SAME_INF_EID,
-                          CFE_EVS_EventType_INFORMATION,
-                          "CF: %s cmd: setting suspend flag to current value of %d",
-                          msgstr[action],
-                          action);
-        ++CF_AppData.counters.cmd;
-    }
-    else if (ret <= 0)
+    if (count <= 0)
     {
         /* No transaction was matched for the given combination of chan + eid + ts  */
         CFE_EVS_SendEvent(CF_CMD_SUSPRES_CHAN_ERR_EID,
                           CFE_EVS_EventType_ERROR,
                           "CF: %s cmd: no transaction found",
-                          msgstr[action]);
+                          action_str);
         ++CF_AppData.counters.err;
+    }
+    else if (count == args.noop_count)
+    {
+        /* Success, but all matched transaction(s) were already set the same way, so nothing was done */
+        CFE_EVS_SendEvent(CF_CMD_SUSPRES_SAME_INF_EID,
+                          CFE_EVS_EventType_INFORMATION,
+                          "CF: %s cmd: setting suspend flag to current value of %d",
+                          action_str,
+                          (int)is_suspend);
+        ++CF_AppData.counters.cmd;
     }
     else
     {
         CFE_EVS_SendEvent(CF_CMD_SUSPRES_INF_EID,
                           CFE_EVS_EventType_INFORMATION,
-                          "CF: %s cmd: setting suspend flag to %d",
-                          msgstr[action],
-                          action);
+                          "CF: %s cmd: set suspend flag to %d",
+                          action_str,
+                          (int)is_suspend);
         ++CF_AppData.counters.cmd;
     }
 }
@@ -559,11 +937,12 @@ void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_SuspendCmd(const CF_SuspendCmd_t *msg)
 {
-    CF_DoSuspRes(&msg->Payload, 1);
+    CF_SuspRes_CommonHandler("suspend", &msg->Payload, true);
     return CFE_SUCCESS;
 }
 
@@ -571,21 +950,22 @@ CFE_Status_t CF_SuspendCmd(const CF_SuspendCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_ResumeCmd(const CF_ResumeCmd_t *msg)
 {
-    CF_DoSuspRes(&msg->Payload, 0);
+    CF_SuspRes_CommonHandler("resume", &msg->Payload, false);
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_CheckAndDispatchTxn()
+ * Cancels every matched transaction record
  *
  *-----------------------------------------------------------------*/
-void CF_Cancel_TxnCmd(CF_Transaction_t *txn, void *ignored)
+static void CF_Cancel_TxnActionImpl(CF_Transaction_t *txn, void *ignored)
 {
     CF_CFDP_CancelTransaction(txn);
 }
@@ -594,11 +974,16 @@ void CF_Cancel_TxnCmd(CF_Transaction_t *txn, void *ignored)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_CancelCmd(const CF_CancelCmd_t *msg)
 {
-    if (CF_TsnChanAction(&msg->Payload, "cancel", CF_Cancel_TxnCmd, NULL) > 0)
+    int32 count;
+
+    count = CF_GenericAction_CheckAndDispatchTxn("cancel", &msg->Payload, CF_Cancel_TxnActionImpl, NULL);
+
+    if (count > 0)
     {
         CFE_EVS_SendEvent(CF_CMD_CANCEL_INF_EID,
                           CFE_EVS_EventType_INFORMATION,
@@ -617,11 +1002,11 @@ CFE_Status_t CF_CancelCmd(const CF_CancelCmd_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_CheckAndDispatchTxn()
+ * Abandons every matched transaction record
  *
  *-----------------------------------------------------------------*/
-void CF_Abandon_TxnCmd(CF_Transaction_t *txn, void *ignored)
+static void CF_Abandon_TxnActionImpl(CF_Transaction_t *txn, void *ignored)
 {
     CF_CFDP_FinishTransaction(txn, false);
 }
@@ -630,11 +1015,16 @@ void CF_Abandon_TxnCmd(CF_Transaction_t *txn, void *ignored)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_AbandonCmd(const CF_AbandonCmd_t *msg)
 {
-    if (CF_TsnChanAction(&msg->Payload, "abandon", CF_Abandon_TxnCmd, NULL) > 0)
+    int32 count;
+
+    count = CF_GenericAction_CheckAndDispatchTxn("abandon", &msg->Payload, CF_Abandon_TxnActionImpl, NULL);
+
+    if (count > 0)
     {
         CFE_EVS_SendEvent(CF_CMD_ABANDON_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: abandon successful");
         ++CF_AppData.counters.cmd;
@@ -653,31 +1043,36 @@ CFE_Status_t CF_AbandonCmd(const CF_AbandonCmd_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Sets the boolean to the configured value in this channel
  *
  *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t CF_DoEnableDisableDequeue(CF_Channel_t *chan, void *arg)
+static CFE_Status_t CF_EnaDisaDequeue_ChanActionImpl(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    const CF_ChanAction_BoolArg_t *context = arg;
-
-    /* no need to bounds check chan_num, done in caller */
-    chan->config.dequeue_enabled = context->barg;
-    return CF_ChanAction_Status_SUCCESS;
+    CF_GenericAction_DoSetBoolArg((CF_GenericAction_BoolArg_t *)ga, &chan->config.dequeue_enabled);
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_EnableDequeueCmd(const CF_EnableDequeueCmd_t *msg)
 {
-    CF_ChanAction_BoolArg_t barg = { 1 };
+    CF_GenericAction_BoolArg_t barg;
 
-    if (CF_ChanAction_Status_IS_SUCCESS(
-            CF_DoChanAction(msg->Payload.ChannelSelect, "enable_dequeue", CF_DoEnableDisableDequeue, &barg)))
+    memset(&barg, 0, sizeof(barg));
+    barg.barg = true;
+
+    CF_GenericAction_CheckAndDispatchChannel("enable_dequeue",
+                                             CF_EnaDisaDequeue_ChanActionImpl,
+                                             &barg.ga,
+                                             msg->Payload.ChannelSelect);
+
+    if (barg.ga.TotalCount > 0)
     {
         CFE_EVS_SendEvent(CF_CMD_ENABLE_DEQUEUE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: dequeue enabled");
         ++CF_AppData.counters.cmd;
@@ -695,14 +1090,22 @@ CFE_Status_t CF_EnableDequeueCmd(const CF_EnableDequeueCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_DisableDequeueCmd(const CF_DisableDequeueCmd_t *msg)
 {
-    CF_ChanAction_BoolArg_t barg = { 0 };
+    CF_GenericAction_BoolArg_t barg;
 
-    if (CF_ChanAction_Status_IS_SUCCESS(
-            CF_DoChanAction(msg->Payload.ChannelSelect, "disable_dequeue", CF_DoEnableDisableDequeue, &barg)))
+    memset(&barg, 0, sizeof(barg));
+    barg.barg = false;
+
+    CF_GenericAction_CheckAndDispatchChannel("disable_dequeue",
+                                             CF_EnaDisaDequeue_ChanActionImpl,
+                                             &barg.ga,
+                                             msg->Payload.ChannelSelect);
+
+    if (barg.ga.TotalCount > 0)
     {
         CFE_EVS_SendEvent(CF_CMD_DISABLE_DEQUEUE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: dequeue disabled");
         ++CF_AppData.counters.cmd;
@@ -718,40 +1121,40 @@ CFE_Status_t CF_DisableDequeueCmd(const CF_DisableDequeueCmd_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Configures polling directory enable flag
  *
  *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t CF_DoEnableDisablePolldir(CF_Channel_t *chan, void *arg)
+static CFE_Status_t CF_EnaDisaPollDir_ChanActionImpl(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    int                               i;
-    const CF_ChanAction_BoolMsgArg_t *context;
-    const CF_PollDirSelect_Payload_t *payload;
-    CF_ChanAction_Status_t            ret;
+    CF_LocalPdConfig_t                *PdConfPtr;
+    uint32                             num_pd;
+    CF_EnableDisablePollDir_Context_t *ctxt = (CF_EnableDisablePollDir_Context_t *)ga;
+    CFE_Status_t                       ret;
 
-    context = arg;
-    payload = context->opaque_data;
-    ret     = CF_ChanAction_Status_SUCCESS;
+    PdConfPtr = chan->config.polldir;
+    ret       = CFE_SUCCESS;
 
-    /* no need to bounds check chan_num, done in caller */
-    if (payload->PollDirIndx == CF_ALL_POLLDIRS)
+    if (ctxt->user_pollidx == CF_ALL_POLLDIRS)
     {
-        /* all polldirs in channel */
-        for (i = 0; i < CF_MAX_POLLING_DIR_PER_CHAN; ++i)
-            chan->config.polldir[i].enabled = context->barg;
+        num_pd = CF_MAX_POLLING_DIR_PER_CHAN;
     }
-    else if (payload->PollDirIndx < CF_MAX_POLLING_DIR_PER_CHAN)
+    else if (ctxt->user_pollidx <= CF_MAX_POLLING_DIR_PER_CHAN)
     {
-        chan->config.polldir[payload->PollDirIndx].enabled = context->barg;
+        PdConfPtr += (ctxt->user_pollidx - 1); /* this index is 1-based */
+        num_pd     = 1;
     }
     else
     {
-        CFE_EVS_SendEvent(CF_CMD_POLLDIR_INVALID_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "CF: enable/disable polldir: invalid polldir %d on channel %d",
-                          (int)payload->PollDirIndx,
-                          CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(chan)));
-        ret = CF_ChanAction_Status_ERROR;
+        ret    = CFE_STATUS_VALIDATION_FAILURE;
+        num_pd = 0;
+    }
+
+    while (num_pd > 0)
+    {
+        CF_GenericAction_DoSetBoolArg(&ctxt->barg, &PdConfPtr->enabled);
+        ++PdConfPtr;
+        --num_pd;
     }
 
     return ret;
@@ -759,16 +1162,62 @@ CF_ChanAction_Status_t CF_DoEnableDisablePolldir(CF_Channel_t *chan, void *arg)
 
 /*----------------------------------------------------------------
  *
+ * Local Helper function
+ * Common implementation for enable/disable polling dir command
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t
+CF_EnaDisaPollDir_CommonHandler(const char *action_str, const CF_PollDirSelect_Payload_t *payload, bool is_enable)
+{
+    CF_EnableDisablePollDir_Context_t ctxt;
+    CFE_Status_t                      status;
+    int32                             count;
+
+    memset(&ctxt, 0, sizeof(ctxt));
+    ctxt.user_pollidx = payload->PollDirIndx;
+    ctxt.barg.barg    = is_enable;
+
+    count = CF_GenericAction_CheckAndDispatchChannel(action_str,
+                                                     CF_EnaDisaPollDir_ChanActionImpl,
+                                                     &ctxt.barg.ga,
+                                                     payload->ChannelSelect);
+
+    if (ctxt.barg.ga.TotalCount != 0)
+    {
+        status = CFE_SUCCESS;
+    }
+    else
+    {
+        status = CFE_STATUS_VALIDATION_FAILURE;
+
+        /* should only be sent if the channel was valid, as an event was already sent if the channel was bad */
+        if (count != 0)
+        {
+            CFE_EVS_SendEvent(CF_CMD_POLLDIR_INVALID_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "CF: enable/disable polldir: invalid polldir %d on channel %d",
+                              (int)payload->PollDirIndx,
+                              CF_ChannelSelect_AsInt(payload->ChannelSelect));
+        }
+    }
+
+    return status;
+}
+
+/*----------------------------------------------------------------
+ *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_EnableDirPollingCmd(const CF_EnableDirPollingCmd_t *msg)
 {
-    CF_ChanAction_BoolMsgArg_t barg = { &msg->Payload, 1 };
+    CFE_Status_t ret;
 
-    if (CF_ChanAction_Status_IS_SUCCESS(
-            CF_DoChanAction(msg->Payload.ChannelSelect, "enable_polldir", CF_DoEnableDisablePolldir, &barg)))
+    ret = CF_EnaDisaPollDir_CommonHandler("enable_polldir", &msg->Payload, true);
+
+    if (ret == CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_CMD_ENABLE_POLLDIR_INF_EID,
                           CFE_EVS_EventType_INFORMATION,
@@ -790,14 +1239,16 @@ CFE_Status_t CF_EnableDirPollingCmd(const CF_EnableDirPollingCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_DisableDirPollingCmd(const CF_DisableDirPollingCmd_t *msg)
 {
-    CF_ChanAction_BoolMsgArg_t barg = { &msg->Payload, 0 };
+    CFE_Status_t ret;
 
-    if (CF_ChanAction_Status_IS_SUCCESS(
-            CF_DoChanAction(msg->Payload.ChannelSelect, "disable_polldir", CF_DoEnableDisablePolldir, &barg)))
+    ret = CF_EnaDisaPollDir_CommonHandler("disable_polldir", &msg->Payload, false);
+
+    if (ret == CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CF_CMD_DISABLE_POLLDIR_INF_EID,
                           CFE_EVS_EventType_INFORMATION,
@@ -817,11 +1268,11 @@ CFE_Status_t CF_DisableDirPollingCmd(const CF_DisableDirPollingCmd_t *msg)
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_CList_Traverse()
+ * Resets the history for every node
  *
  *-----------------------------------------------------------------*/
-CF_CListTraverse_Status_t CF_PurgeHistory(CF_CListNode_t *node, void *arg)
+static CF_CListTraverse_Status_t CF_PurgeQueue_ResetHistoryImpl(CF_CListNode_t *node, void *arg)
 {
     CF_Channel_t *chan    = arg;
     CF_History_t *history = container_of(node, CF_History_t, cl_node);
@@ -831,11 +1282,11 @@ CF_CListTraverse_Status_t CF_PurgeHistory(CF_CListNode_t *node, void *arg)
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_CList_Traverse()
+ * Resets the history for every node
  *
  *-----------------------------------------------------------------*/
-CF_CListTraverse_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignored)
+static CF_CListTraverse_Status_t CF_PurgeQueue_FinishTransactionImpl(CF_CListNode_t *node, void *ignored)
 {
     CF_Transaction_t *txn = container_of(node, CF_Transaction_t, cl_node);
     CF_CFDP_FinishTransaction(txn, false);
@@ -844,76 +1295,98 @@ CF_CListTraverse_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignore
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Purges the history queue for this channel
  *
  *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t CF_DoPurgeQueue(CF_Channel_t *chan, void *arg)
+static CFE_Status_t CF_PurgeQueue_DoHistoryQ(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    CF_ChanAction_Status_t          ret;
-    const CF_ChanAction_MsgArg_t   *context;
-    const CF_QueueSelect_Payload_t *payload;
+    CF_CList_Traverse(chan->qs[CF_QueueIdx_HIST], CF_PurgeQueue_ResetHistoryImpl, chan);
+    return CFE_SUCCESS;
+}
 
-    bool pend = false;
-    bool hist = false;
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Purges the pending queue for this channel
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_PurgeQueue_DoPendingQ(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_CList_Traverse(chan->qs[CF_QueueIdx_PEND], CF_PurgeQueue_FinishTransactionImpl, NULL);
+    return CFE_SUCCESS;
+}
 
-    context = arg;
-    payload = context->opaque_data;
-    ret     = CF_ChanAction_Status_SUCCESS;
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, dispatch table for Purge Queue command
+ * Calls the appropriate routine(s) based on specified queue
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_PurgeQueue_Dispatcher(CF_DoPurgeQueue_Context_t  *ctxt,
+                                             CF_GenericAction_HelperFn_t act_helper,
 
-    switch (payload->QueueSelect)
-    {
-        case CF_QueueSelect_Pending:
-            pend = true;
-            break;
+                                             CF_Channel_t *chan)
+{
+    static const CF_GenericAction_TableEntry_t CF_PURGEQ_HANDLER_MAP[CF_QueueSelect_MAX] = {
+        [CF_QueueSelect_Pending] = { CF_PurgeQueue_DoPendingQ },
+        [CF_QueueSelect_History] = { CF_PurgeQueue_DoHistoryQ },
+    };
 
-        case CF_QueueSelect_History:
-            hist = true;
-            break;
+    return CF_GenericAction_DoDispatch(&ctxt->ga,
+                                       act_helper,
+                                       CF_PURGEQ_HANDLER_MAP,
+                                       sizeof(CF_PURGEQ_HANDLER_MAP),
+                                       ctxt->user_qsel,
+                                       chan);
+}
 
-        case CF_QueueSelect_All:
-            pend = true;
-            hist = true;
-            break;
-
-        default:
-            CFE_EVS_SendEvent(CF_CMD_PURGE_ARG_ERR_EID,
-                              CFE_EVS_EventType_ERROR,
-                              "CF: purge queue invalid arg %d",
-                              (int)payload->QueueSelect);
-            ret = CF_ChanAction_Status_ERROR;
-            break;
-    }
-
-    if (pend)
-    {
-        CF_CList_Traverse(chan->qs[CF_QueueIdx_PEND], CF_PurgeTransaction, NULL);
-    }
-
-    if (hist)
-    {
-        CF_CList_Traverse(chan->qs[CF_QueueIdx_HIST], CF_PurgeHistory, chan);
-    }
-
-    return ret;
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Calls the appropriate routine(s) based on specified queue(s)
+ *
+ *-----------------------------------------------------------------*/
+CFE_Status_t CF_PurgeQueue_ChanActionImpl(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    return CF_PurgeQueue_Dispatcher((CF_DoPurgeQueue_Context_t *)ga, CF_GenericAction_DoInvokeAction, chan);
 }
 
 /*----------------------------------------------------------------
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg)
 {
-    CF_ChanAction_MsgArg_t arg = { &msg->Payload };
-    CF_ChanAction_Status_t status;
+    CF_DoPurgeQueue_Context_t ctxt;
+    int32                     count;
 
-    status = CF_DoChanAction(msg->Payload.ChannelSelect, "purge_queue", CF_DoPurgeQueue, &arg);
+    memset(&ctxt, 0, sizeof(ctxt));
+    ctxt.user_qsel = msg->Payload.QueueSelect;
 
-    if (CF_ChanAction_Status_IS_SUCCESS(status))
+    count = CF_GenericAction_CheckAndDispatchChannel("purge_queue",
+                                                     CF_PurgeQueue_ChanActionImpl,
+                                                     &ctxt.ga,
+                                                     msg->Payload.ChannelSelect);
+
+    /* If this matched channels but NOT any queues, send the arg err event */
+    if (count != 0 && ctxt.ga.TotalCount == 0)
     {
-        CFE_EVS_SendEvent(CF_CMD_PURGE_QUEUE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: queue purged");
+        CFE_EVS_SendEvent(CF_CMD_PURGE_ARG_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: purge queue invalid arg %d",
+                          (int)msg->Payload.QueueSelect);
+    }
+
+    if (ctxt.ga.TotalCount != 0)
+    {
+        CFE_EVS_SendEvent(CF_CMD_PURGE_QUEUE_INF_EID,
+                          CFE_EVS_EventType_INFORMATION,
+                          "CF: %u queue(s) purged",
+                          (unsigned int)ctxt.ga.TotalCount);
         ++CF_AppData.counters.cmd;
     }
     else
@@ -927,345 +1400,649 @@ CFE_Status_t CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg)
 
 /*----------------------------------------------------------------
  *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Writes Rx Active Queue data
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueue_DoRxActive(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_WriteQueue_FullContext_t *ctxt = (CF_WriteQueue_FullContext_t *)ga;
+    CFE_Status_t                 ret;
+
+    ret = CF_WriteTxnQueueDataToFile(ctxt->fd, chan, CF_QueueIdx_RX);
+    if (ret != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_RX_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: write queue failed on CF_QueueIdx_RX data");
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Writes Rx History Queue data
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueue_DoRxHistory(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_WriteQueue_FullContext_t *ctxt = (CF_WriteQueue_FullContext_t *)ga;
+    CFE_Status_t                 ret;
+
+    ret = CF_WriteHistoryQueueDataToFile(ctxt->fd, chan, CF_Direction_RX);
+    if (ret != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEvent(CF_CMD_WQ_WRITEHIST_RX_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: write queue failed on history RX data");
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Writes Tx Active Queue data
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueue_DoTxActive(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_WriteQueue_FullContext_t *ctxt = (CF_WriteQueue_FullContext_t *)ga;
+    CFE_Status_t                 ret;
+
+    ret = CF_WriteTxnQueueDataToFile(ctxt->fd, chan, CF_QueueIdx_TX);
+    if (ret != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_TX_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: write queue failed on CF_QueueIdx_TX data");
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Writes Tx Pending Queue data
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueue_DoTxPending(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_WriteQueue_FullContext_t *ctxt = (CF_WriteQueue_FullContext_t *)ga;
+    CFE_Status_t                 ret;
+
+    ret = CF_WriteTxnQueueDataToFile(ctxt->fd, chan, CF_QueueIdx_PEND);
+    if (ret != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_PEND_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: write queue failed on CF_QueueIdx_PEND data");
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Writes Tx History Queue data
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueue_DoTxHistory(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_WriteQueue_FullContext_t *ctxt = (CF_WriteQueue_FullContext_t *)ga;
+    CFE_Status_t                 ret;
+
+    ret = CF_WriteHistoryQueueDataToFile(ctxt->fd, chan, CF_Direction_TX);
+    if (ret != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEvent(CF_CMD_WQ_WRITEHIST_TX_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "CF: write queue failed on CF_QueueIdx_TX data");
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Dispatches write queue actions for the Rx direction (uploads)
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueueCmd_DoProcessRxQ(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_WriteQueue_DirContext_t  *dir_ctxt = (CF_WriteQueue_DirContext_t *)ga;
+    CF_WriteQueue_FullContext_t *ctxt     = dir_ctxt->ctxt; /* this is the original */
+
+    static const CF_GenericAction_TableEntry_t CF_WRITEQ_RX_HANDLER_MAP[CF_QueueSelect_MAX] = {
+        [CF_QueueSelect_Active]  = { CF_WriteQueue_DoRxActive },
+        [CF_QueueSelect_History] = { CF_WriteQueue_DoRxHistory },
+    };
+
+    return CF_GenericAction_DoDispatch(&ctxt->ga,
+                                       dir_ctxt->q_action,
+                                       CF_WRITEQ_RX_HANDLER_MAP,
+                                       sizeof(CF_WRITEQ_RX_HANDLER_MAP),
+                                       ctxt->user_qsel,
+                                       chan);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Dispatches write queue actions for the Tx direction (downloads)
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueueCmd_DoProcessTxQ(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_WriteQueue_DirContext_t  *dir_ctxt = (CF_WriteQueue_DirContext_t *)ga;
+    CF_WriteQueue_FullContext_t *ctxt     = dir_ctxt->ctxt; /* this is the original */
+
+    static const CF_GenericAction_TableEntry_t CF_WRITEQ_TX_HANDLER_MAP[CF_QueueSelect_MAX] = {
+        [CF_QueueSelect_Active]  = { CF_WriteQueue_DoTxActive },
+        [CF_QueueSelect_Pending] = { CF_WriteQueue_DoTxPending },
+        [CF_QueueSelect_History] = { CF_WriteQueue_DoTxHistory },
+    };
+
+    return CF_GenericAction_DoDispatch(&ctxt->ga,
+                                       dir_ctxt->q_action,
+                                       CF_WRITEQ_TX_HANDLER_MAP,
+                                       sizeof(CF_WRITEQ_TX_HANDLER_MAP),
+                                       ctxt->user_qsel,
+                                       chan);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, dispatches write queue command based on direction
+ * Calls the appropriate routine(s) based on specified direction(s)
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueueCmd_DirectionDispatch(CF_WriteQueue_FullContext_t *ctxt,
+                                                       CF_GenericAction_HelperFn_t  act_helper,
+                                                       CF_Channel_t                *chan)
+{
+    CF_WriteQueue_DirContext_t dir_ctxt;
+
+    static const CF_GenericAction_TableEntry_t CF_WRITEQ_DIR_HANDLER_MAP[CF_DirectionType_MAX] = {
+        [CF_DirectionType_up]   = { CF_WriteQueueCmd_DoProcessRxQ },
+        [CF_DirectionType_down] = { CF_WriteQueueCmd_DoProcessTxQ },
+    };
+
+    /* save the params to pass thru to the next level (queue) */
+    memset(&dir_ctxt, 0, sizeof(dir_ctxt));
+    dir_ctxt.q_action = act_helper;
+    dir_ctxt.ctxt     = ctxt;
+
+    return CF_GenericAction_DoDispatch(&dir_ctxt.ga,
+                                       CF_GenericAction_DoInvokeAction,
+                                       CF_WRITEQ_DIR_HANDLER_MAP,
+                                       sizeof(CF_WRITEQ_DIR_HANDLER_MAP),
+                                       ctxt->user_dirsel,
+                                       chan);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Invokes the write queue action for matched directions on this channel
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueueCmd_ChanActionImpl(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    return CF_WriteQueueCmd_DirectionDispatch((CF_WriteQueue_FullContext_t *)ga, CF_GenericAction_DoInvokeAction, chan);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * Invokes the check action for matched directions on this channel
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_WriteQueueCmd_CheckChannelAction(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    return CF_WriteQueueCmd_DirectionDispatch((CF_WriteQueue_FullContext_t *)ga, CF_GenericAction_DoCheck, chan);
+}
+
+/*----------------------------------------------------------------
+ *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg)
 {
     const CF_WriteQueue_Payload_t *wq = &msg->Payload;
 
-    CF_Channel_t *chan    = CF_GetChannelPtr(wq->chan);
-    osal_id_t     fd      = OS_OBJECT_ID_UNDEFINED;
-    bool          success = true;
-    int32         ret;
+    CF_WriteQueue_FullContext_t write_context;
+    CFE_Status_t                status;
+    int32                       count;
 
-    /* check the commands for validity */
-    if (chan == NULL)
+    memset(&write_context, 0, sizeof(write_context));
+
+    write_context.user_dirsel = wq->dir_type;
+    write_context.user_qsel   = wq->queue;
+
+    status = CFE_STATUS_VALIDATION_FAILURE;
+
+    /*
+     * Do a pre-check of the arguments.  This is done on this command because it opens a file.
+     * We should not open the file unless the basic command args are OK, because it would leave
+     * a zero-byte file in the filesystem if it fails.  It also has a non-insignificant cost.
+     */
+    count = CF_GenericAction_CheckAndDispatchChannel("write queue",
+                                                     CF_WriteQueueCmd_CheckChannelAction,
+                                                     &write_context.ga,
+                                                     wq->chan_num);
+
+    if (count != 0)
     {
-        CFE_EVS_SendEvent(CF_CMD_WQ_CHAN_ERR_EID, CFE_EVS_EventType_ERROR, "CF: write queue invalid channel arg");
-        ++CF_AppData.counters.err;
-        success = false;
+        /* start by checking the request -- it should match at least one valid q-write impl */
+        if (write_context.ga.ValidCount == 0)
+        {
+            /* the dir/queue combo did not map to any valid combo */
+            CFE_EVS_SendEvent(CF_CMD_WQ_ARGS_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "CF: write queue invalid command parameters");
+        }
+        else
+        {
+            /* so far so good, now do the actual work */
+            /* PTFO: queues can be large. may want to split this work up across the state machine and take several
+             * wakeups to complete */
+            status = CF_WrappedOpenCreate(&write_context.fd,
+                                          wq->filename,
+                                          OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE,
+                                          OS_WRITE_ONLY);
+            if (status != OS_SUCCESS)
+            {
+                CFE_EVS_SendEvent(CF_CMD_WQ_OPEN_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "CF: write queue failed to open file %s",
+                                  wq->filename);
+            }
+            else
+            {
+                /* now repeat the loop and actually do the write */
+                /* zero out the counts again so we can check for failures */
+                count = write_context.ga.ValidCount;
+                memset(&write_context.ga, 0, sizeof(write_context.ga));
+
+                CF_GenericAction_DispatchChannel(CF_WriteQueueCmd_ChanActionImpl, &write_context.ga, wq->chan_num);
+                CF_WrappedClose(write_context.fd);
+
+                if (write_context.ga.SuccessCount != count)
+                {
+                    /* the number of successful writes did not match what it should have been */
+                    /* this is just so we increment the error count, not the command count */
+                    status = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
+                }
+            }
+        }
     }
-    /* only invalid combination is up direction, pending queue */
-    else if ((wq->type == CF_Type_up) && (wq->queue == CF_QueueSelect_Pending))
+
+    if (status == CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(CF_CMD_WQ_ARGS_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "CF: write queue invalid command parameters");
-        ++CF_AppData.counters.err;
-        success = false;
+        ++CF_AppData.counters.cmd;
+        CFE_EVS_SendEvent(CF_CMD_WQ_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: write queue successful");
     }
     else
     {
-        /* PTFO: queues can be large. may want to split this work up across the state machine and take several wakeups
-         * to complete */
-        ret = CF_WrappedOpenCreate(&fd, wq->filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
-        if (ret < 0)
-        {
-            CFE_EVS_SendEvent(CF_CMD_WQ_OPEN_ERR_EID,
-                              CFE_EVS_EventType_ERROR,
-                              "CF: write queue failed to open file %s",
-                              wq->filename);
-            ++CF_AppData.counters.err;
-            success = false;
-        }
+        ++CF_AppData.counters.err;
+        /* all pertinent event(s) should have already been sent */
     }
 
-    /* if type is type_up, or all types */
-    if (success && ((wq->type == CF_Type_all) || (wq->type == CF_Type_up)))
+    /* all relevant events have been sent and status has been logged, so work is done - return SUCCESS */
+    return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function for all get/set parameter operations
+ * This performs the actual get/set and issues the corresponding event
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_DoParam(CF_GetSetParam_Context_t *ctxt,
+                                      CF_Channel_t             *chan,
+                                      const char               *printable_name,
+                                      void                     *param_ptr,
+                                      size_t                    param_sz)
+{
+    uint32             saved_value;
+    CF_ChannelSelect_t chan_num;
+    uint16             event_id;
+    char               msg_buffer[32];
+
+    saved_value = 0;
+    chan_num    = CF_GetChannelFromPtr(chan);
+
+    switch (param_sz)
     {
-        /* process uplink queue data */
-        if ((wq->queue == CF_QueueSelect_All) || (wq->queue == CF_QueueSelect_Active))
-        {
-            ret = CF_WriteTxnQueueDataToFile(fd, chan, CF_QueueIdx_RX);
-            if (ret)
-            {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_RX_ERR_EID,
-                                  CFE_EVS_EventType_ERROR,
-                                  "CF: write queue failed to write CF_QueueIdx_RX data");
-                CF_WrappedClose(fd);
-                ++CF_AppData.counters.err;
-                success = false;
-            }
-        }
-
-        if (success && ((wq->queue == CF_QueueSelect_All) || (wq->queue == CF_QueueSelect_History)))
-        {
-            ret = CF_WriteHistoryQueueDataToFile(fd, chan, CF_Direction_RX);
-            if (ret)
-            {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEHIST_RX_ERR_EID,
-                                  CFE_EVS_EventType_ERROR,
-                                  "CF: write queue failed to write history RX data");
-                CF_WrappedClose(fd);
-                ++CF_AppData.counters.err;
-                success = false;
-            }
-        }
+        case sizeof(uint32):
+            saved_value = *((uint32 *)param_ptr);
+            break;
+        case sizeof(uint16):
+            saved_value = *((uint16 *)param_ptr);
+            break;
+        default: /* uint8 is the only other possibility */
+            saved_value = *((uint8 *)param_ptr);
+            break;
     }
 
-    /* if type is type_down, or all types */
-    if (success && ((wq->type == CF_Type_all) || (wq->type == CF_Type_down)))
+    if (ctxt->is_set)
     {
-        /* process downlink queue data */
-        if ((wq->queue == CF_QueueSelect_All) || (wq->queue == CF_QueueSelect_Active))
+        switch (param_sz)
         {
-            ret = CF_WriteTxnQueueDataToFile(fd, chan, CF_QueueIdx_TX);
-            if (ret)
-            {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_TX_ERR_EID,
-                                  CFE_EVS_EventType_ERROR,
-                                  "CF: write queue failed to write CF_QueueIdx_TX data");
-                CF_WrappedClose(fd);
-                ++CF_AppData.counters.err;
-                success = false;
-            }
+            case sizeof(uint32):
+                *((uint32 *)param_ptr) = ctxt->value;
+                break;
+            case sizeof(uint16):
+                *((uint16 *)param_ptr) = ctxt->value;
+                break;
+            default: /* uint8 is the only other possibility */
+                *((uint8 *)param_ptr) = ctxt->value;
+                break;
         }
 
-        if (success && ((wq->queue == CF_QueueSelect_All) || (wq->queue == CF_QueueSelect_Pending)))
-        {
-            /* write pending queue */
-            ret = CF_WriteTxnQueueDataToFile(fd, chan, CF_QueueIdx_PEND);
-            if (ret)
-            {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEQ_PEND_ERR_EID,
-                                  CFE_EVS_EventType_ERROR,
-                                  "CF: write queue failed to write pending queue");
-                CF_WrappedClose(fd);
-                ++CF_AppData.counters.err;
-                success = false;
-            }
-        }
-
-        if (success && ((wq->queue == CF_QueueSelect_All) || (wq->queue == CF_QueueSelect_History)))
-        {
-            /* write history queue */
-            ret = CF_WriteHistoryQueueDataToFile(fd, chan, CF_Direction_TX);
-            if (ret)
-            {
-                CFE_EVS_SendEvent(CF_CMD_WQ_WRITEHIST_TX_ERR_EID,
-                                  CFE_EVS_EventType_ERROR,
-                                  "CF: write queue failed to write CF_QueueIdx_TX data");
-                CF_WrappedClose(fd);
-                ++CF_AppData.counters.err;
-                success = false;
-            }
-        }
+        event_id = CF_CMD_GETSET1_INF_EID;
+        snprintf(msg_buffer,
+                 sizeof(msg_buffer),
+                 "changed %u -> %u",
+                 (unsigned int)saved_value,
+                 (unsigned int)ctxt->value);
     }
-
-    if (success)
+    else
     {
-        CFE_EVS_SendEvent(CF_CMD_WQ_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: write queue successful");
-        ++CF_AppData.counters.cmd;
+        event_id = CF_CMD_GETSET2_INF_EID;
+        snprintf(msg_buffer, sizeof(msg_buffer), "value = %u", (unsigned int)saved_value);
     }
+
+    CFE_EVS_SendEvent(event_id,
+                      CFE_EVS_EventType_INFORMATION,
+                      "CF: channel %d parameter id %s %s",
+                      CF_ChannelSelect_AsInt(chan_num),
+                      printable_name,
+                      msg_buffer);
 
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ * For invalid parameters
  *
  *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t CF_ValidateChunkSizeCmd(CF_ChunkSize_t val, CF_Channel_t *chan /* ignored */)
+static CFE_Status_t CF_GetSet_Do_Invalid(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    CF_ChanAction_Status_t ret = CF_ChanAction_Status_SUCCESS;
-    if (val > sizeof(CF_CFDP_PduFileDataContent_t))
-    {
-        ret = CF_ChanAction_Status_ERROR; /* failed */
-    }
-    return ret;
+    return CFE_STATUS_NOT_IMPLEMENTED;
 }
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
  *
  *-----------------------------------------------------------------*/
-CF_ChanAction_Status_t CF_ValidateMaxOutgoingCmd(uint32 val, CF_Channel_t *chan)
+static CFE_Status_t CF_GetSet_Do_ticks_per_second(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
 {
-    CF_ChanAction_Status_t ret = CF_ChanAction_Status_SUCCESS;
+    CF_GetSetParam_Context_t *ctxt   = (CF_GetSetParam_Context_t *)ga;
+    CF_Engine_t              *engine = ga->engine;
 
-    if (!val && !chan->config.sem_name[0])
-    {
-        /* can't have unlimited messages and no semaphore */
-        ret = CF_ChanAction_Status_ERROR; /* failed */
-    }
-
-    return ret;
+    return CF_GetSet_DoParam(ctxt,
+                             chan,
+                             "ticks_per_second",
+                             &engine->config.ticks_per_second,
+                             sizeof(engine->config.ticks_per_second));
 }
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in cf_cmd.h for argument/return detail
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
  *
  *-----------------------------------------------------------------*/
-void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, CF_ChannelSelect_t chan_num)
+static CFE_Status_t CF_GetSet_Do_rx_crc_calc_bytes_per_wakeup(CF_GenericAction_Context_t *ga,
+
+                                                              CF_Channel_t *chan)
 {
-    CFE_Status_t status = CF_ERROR;
-    bool         valid_set;
-    struct
+    CF_GetSetParam_Context_t *ctxt   = (CF_GetSetParam_Context_t *)ga;
+    CF_Engine_t              *engine = ga->engine;
+
+    return CF_GetSet_DoParam(ctxt,
+                             chan,
+                             "rx_crc_calc_bytes_per_wakeup",
+                             &engine->config.rx_crc_calc_bytes_per_wakeup,
+                             sizeof(engine->config.rx_crc_calc_bytes_per_wakeup));
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_ack_timer_s(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt = (CF_GetSetParam_Context_t *)ga;
+
+    return CF_GetSet_DoParam(ctxt, chan, "ack_timer_s", &chan->config.ack_timer_s, sizeof(chan->config.ack_timer_s));
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_nak_timer_s(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt = (CF_GetSetParam_Context_t *)ga;
+
+    return CF_GetSet_DoParam(ctxt, chan, "nak_timer_s", &chan->config.nak_timer_s, sizeof(chan->config.nak_timer_s));
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_inactivity_timer_s(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt = (CF_GetSetParam_Context_t *)ga;
+
+    return CF_GetSet_DoParam(ctxt,
+                             chan,
+                             "inactivity_timer_s",
+                             &chan->config.inactivity_timer_s,
+                             sizeof(chan->config.inactivity_timer_s));
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_outgoing_file_chunk_size(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt   = (CF_GetSetParam_Context_t *)ga;
+    CF_Engine_t              *engine = ga->engine;
+    CFE_Status_t              ret;
+
+    if (ctxt->is_set && (ctxt->value == 0 || ctxt->value > sizeof(CF_CFDP_PduFileDataContent_t)))
     {
-        void  *ptr;
-        size_t size;
-        CF_ChanAction_Status_t (*fn)(uint32, CF_Channel_t *);
-    } item;
-
-    CF_Engine_t  *engine_ptr = CF_GetEngine();
-    CF_Channel_t *chan       = CF_GetChannelPtr(chan_num);
-
-    if (chan == NULL)
-    {
-        CFE_EVS_SendEvent(CF_CMD_GETSET_CHAN_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "CF: invalid configuration channel id %d received",
-                          CF_ChannelSelect_AsInt(chan_num));
-        ++CF_AppData.counters.err;
-        return;
-    }
-
-    valid_set = false;
-    memset(&item, 0, sizeof(item));
-
-    switch (param_id)
-    {
-        case CF_GetSet_ValueID_ticks_per_second:
-            item.ptr  = &engine_ptr->config.ticks_per_second;
-            item.size = sizeof(engine_ptr->config.ticks_per_second);
-            break;
-        case CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup:
-            item.ptr  = &engine_ptr->config.rx_crc_calc_bytes_per_wakeup;
-            item.size = sizeof(engine_ptr->config.rx_crc_calc_bytes_per_wakeup);
-            break;
-        case CF_GetSet_ValueID_ack_timer_s:
-            item.ptr  = &chan->config.ack_timer_s;
-            item.size = sizeof(chan->config.ack_timer_s);
-            break;
-        case CF_GetSet_ValueID_nak_timer_s:
-            item.ptr  = &chan->config.nak_timer_s;
-            item.size = sizeof(chan->config.nak_timer_s);
-            break;
-        case CF_GetSet_ValueID_inactivity_timer_s:
-            item.ptr  = &chan->config.inactivity_timer_s;
-            item.size = sizeof(chan->config.inactivity_timer_s);
-            break;
-        case CF_GetSet_ValueID_outgoing_file_chunk_size:
-            item.ptr  = &engine_ptr->config.outgoing_file_chunk_size;
-            item.size = sizeof(engine_ptr->config.outgoing_file_chunk_size);
-            item.fn   = CF_ValidateChunkSizeCmd;
-            break;
-        case CF_GetSet_ValueID_ack_limit:
-            item.ptr  = &chan->config.ack_limit;
-            item.size = sizeof(chan->config.ack_limit);
-            break;
-        case CF_GetSet_ValueID_nak_limit:
-            item.ptr  = &chan->config.nak_limit;
-            item.size = sizeof(chan->config.nak_limit);
-            break;
-        case CF_GetSet_ValueID_local_eid:
-            item.ptr  = &engine_ptr->config.local_eid;
-            item.size = sizeof(engine_ptr->config.local_eid);
-            break;
-        case CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup:
-            item.ptr  = &chan->config.max_outgoing_messages_per_wakeup;
-            item.size = sizeof(chan->config.max_outgoing_messages_per_wakeup);
-            item.fn   = CF_ValidateMaxOutgoingCmd;
-            break;
-        default:
-            break;
-    };
-
-    if (item.size == 0)
-    {
-        CFE_EVS_SendEvent(CF_CMD_GETSET_PARAM_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "CF: invalid configuration parameter id %d received",
-                          param_id);
-    }
-    else if (is_set)
-    {
-        if (item.fn)
-        {
-            if (CF_ChanAction_Status_IS_SUCCESS(item.fn(value, chan)))
-            {
-                valid_set = true;
-            }
-            else
-            {
-                CFE_EVS_SendEvent(CF_CMD_GETSET_VALIDATE_ERR_EID,
-                                  CFE_EVS_EventType_ERROR,
-                                  "CF: validation for parameter id %d failed",
-                                  param_id);
-            }
-        }
-        else
-        {
-            valid_set = true;
-        }
-
-        if (valid_set)
-        {
-            status = CFE_SUCCESS;
-
-            CFE_EVS_SendEvent(CF_CMD_GETSET1_INF_EID,
-                              CFE_EVS_EventType_INFORMATION,
-                              "CF: setting parameter id %d to %lu",
-                              param_id,
-                              (unsigned long)value);
-
-            /* Store value based on its size */
-            if (item.size == sizeof(uint32))
-            {
-                *((uint32 *)item.ptr) = value;
-            }
-            else if (item.size == sizeof(uint16))
-            {
-                *((uint16 *)item.ptr) = value;
-            }
-            else
-            {
-                /* uint8 is the only other option */
-                *((uint8 *)item.ptr) = value;
-            }
-        }
+        ret = CFE_STATUS_VALIDATION_FAILURE;
     }
     else
     {
-        status = CFE_SUCCESS;
-
-        /* Read value depending on its size */
-        if (item.size == sizeof(uint32))
-        {
-            value = *((const uint32 *)item.ptr);
-        }
-        else if (item.size == sizeof(uint16))
-        {
-            value = *((const uint16 *)item.ptr);
-        }
-        else
-        {
-            /* uint8 is the only other option */
-            value = *((const uint8 *)item.ptr);
-        }
-
-        CFE_EVS_SendEvent(CF_CMD_GETSET2_INF_EID,
-                          CFE_EVS_EventType_INFORMATION,
-                          "CF: parameter id %d = %lu",
-                          param_id,
-                          (unsigned long)value);
+        ret = CF_GetSet_DoParam(ctxt,
+                                chan,
+                                "outgoing_file_chunk_size",
+                                &engine->config.outgoing_file_chunk_size,
+                                sizeof(engine->config.outgoing_file_chunk_size));
     }
 
-    if (status == CFE_SUCCESS)
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_ack_limit(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt = (CF_GetSetParam_Context_t *)ga;
+
+    return CF_GetSet_DoParam(ctxt, chan, "ack_limit", &chan->config.ack_limit, sizeof(chan->config.ack_limit));
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_nak_limit(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt = (CF_GetSetParam_Context_t *)ga;
+
+    return CF_GetSet_DoParam(ctxt, chan, "nak_limit", &chan->config.nak_limit, sizeof(chan->config.nak_limit));
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_local_eid(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt   = (CF_GetSetParam_Context_t *)ga;
+    CF_Engine_t              *engine = ga->engine;
+
+    return CF_GetSet_DoParam(ctxt, chan, "local_eid", &engine->config.local_eid, sizeof(engine->config.local_eid));
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function, compatible with CF_GenericAction_DispatchChannel()
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSet_Do_chan_max_outgoing_messages_per_wakeup(CF_GenericAction_Context_t *ga,
+
+                                                                       CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt = (CF_GetSetParam_Context_t *)ga;
+    CFE_Status_t              ret;
+
+    /* must have a nonzero limit or a synch semaphore */
+    if (ctxt->is_set && ctxt->value == 0 && chan->config.sem_name[0] == 0)
+    {
+        ret = CFE_STATUS_VALIDATION_FAILURE;
+    }
+    else
+    {
+        ret = CF_GetSet_DoParam(ctxt,
+                                chan,
+                                "max_outgoing_messages_per_wakeup",
+                                &chan->config.max_outgoing_messages_per_wakeup,
+                                sizeof(chan->config.max_outgoing_messages_per_wakeup));
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function
+ *
+ *-----------------------------------------------------------------*/
+static CFE_Status_t CF_GetSetParam_ChanActionImpl(CF_GenericAction_Context_t *ga, CF_Channel_t *chan)
+{
+    CF_GetSetParam_Context_t *ctxt = (CF_GetSetParam_Context_t *)ga;
+    CFE_Status_t              ret;
+
+    static const CF_GenericAction_TableEntry_t CF_GETSETPARAM_HANDLER_MAP[CF_GetSet_ValueID_MAX] = {
+        [0]                                              = { CF_GetSet_Do_Invalid },
+        [CF_GetSet_ValueID_ticks_per_second]             = { CF_GetSet_Do_ticks_per_second },
+        [CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup] = { CF_GetSet_Do_rx_crc_calc_bytes_per_wakeup },
+        [CF_GetSet_ValueID_ack_timer_s]                  = { CF_GetSet_Do_ack_timer_s },
+        [CF_GetSet_ValueID_nak_timer_s]                  = { CF_GetSet_Do_nak_timer_s },
+        [CF_GetSet_ValueID_inactivity_timer_s]           = { CF_GetSet_Do_inactivity_timer_s },
+        [CF_GetSet_ValueID_outgoing_file_chunk_size]     = { CF_GetSet_Do_outgoing_file_chunk_size },
+        [CF_GetSet_ValueID_ack_limit]                    = { CF_GetSet_Do_ack_limit },
+        [CF_GetSet_ValueID_nak_limit]                    = { CF_GetSet_Do_nak_limit },
+        [CF_GetSet_ValueID_local_eid]                    = { CF_GetSet_Do_local_eid },
+        [CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup] = { CF_GetSet_Do_chan_max_outgoing_messages_per_wakeup },
+    };
+
+    ret = CF_GenericAction_DoDispatch(&ctxt->ga,
+                                      CF_GenericAction_DoInvokeAction,
+                                      CF_GETSETPARAM_HANDLER_MAP,
+                                      sizeof(CF_GETSETPARAM_HANDLER_MAP),
+                                      ctxt->param_id,
+                                      chan);
+
+    if (ret == CFE_STATUS_VALIDATION_FAILURE)
+    {
+        ++ctxt->ga.ErrorCount;
+    }
+
+    return ret;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper Function
+ * Common implementation for Get Param and Set Param commands
+ *
+ *-----------------------------------------------------------------*/
+static void
+CF_GetSetParam_CommonHandler(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, CF_ChannelSelect_t chan_num)
+{
+    int32                    count;
+    CF_GetSetParam_Context_t ctxt;
+
+    memset(&ctxt, 0, sizeof(ctxt));
+    ctxt.is_set   = is_set;
+    ctxt.param_id = param_id;
+    ctxt.value    = value;
+
+    count = CF_GenericAction_CheckAndDispatchChannel("param", CF_GetSetParam_ChanActionImpl, &ctxt.ga, chan_num);
+
+    /* if anything happened, the overall command was successful
+     * (note this is unlikely to have some channels work and some not) */
+    if (ctxt.ga.SuccessCount != 0)
     {
         ++CF_AppData.counters.cmd;
     }
     else
     {
         ++CF_AppData.counters.err;
+
+        /* check if the failure was due to key, NOT channel ID */
+        if (count != 0)
+        {
+            /* this counter is incremented for CFE_STATUS_VALIDATION_FAILURE specifically */
+            if (ctxt.ga.ErrorCount != 0)
+            {
+                /* the failure is due to a validation error */
+                CFE_EVS_SendEvent(CF_CMD_GETSET_VALIDATE_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "CF: bad value %u for parameter id %d",
+                                  (unsigned int)value,
+                                  (int)param_id);
+            }
+            else
+            {
+                /* the failure must be due to a bad parameter key */
+                CFE_EVS_SendEvent(CF_CMD_GETSET_PARAM_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "CF: invalid configuration parameter id %d received",
+                                  (int)param_id);
+            }
+        }
     }
 }
 
@@ -1273,13 +2050,14 @@ void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, 
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_SetParamCmd(const CF_SetParamCmd_t *msg)
 {
     const CF_SetParam_Payload_t *cmd = &msg->Payload;
 
-    CF_GetSetParamCmd(true, cmd->key, cmd->value, cmd->chan_num);
+    CF_GetSetParam_CommonHandler(true, cmd->key, cmd->value, cmd->chan_num);
 
     return CFE_SUCCESS;
 }
@@ -1288,13 +2066,14 @@ CFE_Status_t CF_SetParamCmd(const CF_SetParamCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_GetParamCmd(const CF_GetParamCmd_t *msg)
 {
     const CF_GetParam_Payload_t *cmd = &msg->Payload;
 
-    CF_GetSetParamCmd(false, cmd->key, 0, cmd->chan_num);
+    CF_GetSetParam_CommonHandler(false, cmd->key, 0, cmd->chan_num);
 
     return CFE_SUCCESS;
 }
@@ -1303,15 +2082,16 @@ CFE_Status_t CF_GetParamCmd(const CF_GetParamCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_EnableEngineCmd(const CF_EnableEngineCmd_t *msg)
 {
-    CF_Engine_t *engine_ptr = CF_GetEngine();
+    CF_Engine_t *engine = CF_GetEngine();
 
-    if (!engine_ptr->enabled)
+    if (!engine->enabled)
     {
-        if (CF_CFDP_InitEngine(engine_ptr) == CFE_SUCCESS)
+        if (CF_CFDP_InitEngine(engine) == CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CF_CMD_ENABLE_ENGINE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: enabled CFDP engine");
             ++CF_AppData.counters.cmd;
@@ -1339,13 +2119,14 @@ CFE_Status_t CF_EnableEngineCmd(const CF_EnableEngineCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_cmd.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_DisableEngineCmd(const CF_DisableEngineCmd_t *msg)
 {
-    CF_Engine_t *engine_ptr = CF_GetEngine();
+    CF_Engine_t *engine = CF_GetEngine();
 
-    if (engine_ptr->enabled)
+    if (engine->enabled)
     {
         CF_CFDP_DisableEngine();
         CFE_EVS_SendEvent(CF_CMD_DISABLE_ENGINE_INF_EID, CFE_EVS_EventType_INFORMATION, "CF: disabled CFDP engine");
@@ -1369,11 +2150,11 @@ CFE_Status_t CF_DisableEngineCmd(const CF_DisableEngineCmd_t *msg)
  * Compatible with CF_ForEachChannel()
  *
  *-----------------------------------------------------------------*/
-static int32 CF_DoHkStats(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg)
+static int32 CF_SendHk_DoChannelStats(CF_Engine_t *engine, CF_Channel_t *chan, void *arg)
 {
     CF_HkChannel_Data_t *out_chan_hk;
     CF_HkPacket_t       *hk       = arg;
-    const int            chan_num = CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(chan));
+    const int            chan_num = CF_ChannelSelect_AsInt(CF_GetChannelFromPtr(chan)) - 1;
     int                  q_idx;
 
     out_chan_hk = &hk->Payload.channel_hk[chan_num];
@@ -1394,11 +2175,12 @@ static int32 CF_DoHkStats(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg
  *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_SendHkCmd(const CF_SendHkCmd_t *msg)
 {
-    CF_Engine_t     *engine_ptr = CF_GetEngine();
+    CF_Engine_t     *engine = CF_GetEngine();
     CFE_SB_Buffer_t *sb_buf;
     CF_HkPacket_t   *hk;
 
@@ -1410,7 +2192,7 @@ CFE_Status_t CF_SendHkCmd(const CF_SendHkCmd_t *msg)
         hk                   = (void *)&sb_buf->Msg;
         hk->Payload.counters = CF_AppData.counters;
 
-        CF_ForEachChannel(engine_ptr, CF_DoHkStats, hk);
+        CF_ForEachChannel(engine, CF_SendHk_DoChannelStats, hk);
 
         /* return value ignored */
         CFE_SB_TransmitBuffer(sb_buf, true);
@@ -1423,6 +2205,7 @@ CFE_Status_t CF_SendHkCmd(const CF_SendHkCmd_t *msg)
  *
  * Application-scope internal function
  * See description in cf_app.h for argument/return detail
+ * This is the entry point function invoked from the SB command handler
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CF_WakeupCmd(const CF_WakeupCmd_t *msg)

--- a/fsw/src/cf_cmd.h
+++ b/fsw/src/cf_cmd.h
@@ -30,75 +30,32 @@
 #include "cf_app.h"
 #include "cf_utils.h"
 
-typedef enum
-{
-    CF_ChanAction_Status_SUCCESS = 0,
-    CF_ChanAction_Status_ERROR   = -1
-} CF_ChanAction_Status_t;
-
 /**
- * Checks if the channel action was successful
- */
-static inline bool CF_ChanAction_Status_IS_SUCCESS(CF_ChanAction_Status_t stat)
-{
-    return (stat == CF_ChanAction_Status_SUCCESS);
-}
-
-/**
- * @brief A callback function for use with CF_DoChanAction()
+ * @brief Generic action base struct
  *
- * @param chan     The CF channel pointer
- * @param context  Opaque object passed through from initial call
+ * A common context struct that is used when looping through
+ * many channels/transactions/queues/directions etc.  This
+ * is just basic counters.  The struct should be extended
+ * for additional context info (this should appear first in extensions)
  */
-typedef CF_ChanAction_Status_t (*CF_ChanActionFn_t)(CF_Channel_t *chan, void *context);
-
-/**
- * @brief An object to use with channel-scope actions requiring only a boolean argument
- */
-typedef struct CF_ChanAction_BoolArg
+typedef struct
 {
-    bool barg;
-} CF_ChanAction_BoolArg_t;
+    CF_Engine_t *engine;       /* The engine being operated on (currently always the same singleton) */
+    int32        TotalCount;   /* total number of callbacks, including no-ops */
+    int32        SuccessCount; /* count of callbacks where return status is CFE_SUCCESS */
+    int32        ValidCount;   /* General purpose counter - Incremented in the callback based on selected conditions */
+    int32        ErrorCount;   /* General purpose counter - Incremented in the callback based on selected conditions */
+} CF_GenericAction_Context_t;
 
 /**
- * @brief A callback to use with transaction actions
+ * @brief Callback function for generic actions
  *
- * For now this is the same as CF_TraverseAllTransactions_fn_t
- */
-typedef CF_TraverseAllTransactions_fn_t CF_TsnChanAction_fn_t;
-
-/**
- * @brief An object to use with channel-scope actions for suspend/resume
+ * This will be invoked for every channel match
  *
- * This combines a boolean action arg with an output that indicates if it
- * was a change or not.
+ * @param ga      pointer to the (base) context struct
+ * @param chan    CFDP channel - passed through to function
  */
-typedef struct CF_ChanAction_SuspResArg
-{
-    int  same; /**< out param -- indicates at least one action was set to its current value */
-    bool action;
-} CF_ChanAction_SuspResArg_t;
-
-/**
- * @brief An object to use with channel-scope actions that require the message value
- *
- * This combines a boolean action arg with the command message value
- */
-typedef struct CF_ChanAction_BoolMsgArg
-{
-    const void *opaque_data;
-    bool        barg;
-} CF_ChanAction_BoolMsgArg_t;
-
-/**
- * @brief An object to use with channel-scope actions that require the message value
- *
- * This combines a boolean action arg with the command message value
- */
-typedef struct CF_ChanAction_MsgArg
-{
-    const void *opaque_data;
-} CF_ChanAction_MsgArg_t;
+typedef CFE_Status_t (*CF_GenericAction_Func_t)(CF_GenericAction_Context_t *ga, CF_Channel_t *chan);
 
 /************************************************************************/
 /** @brief Send CF housekeeping packet
@@ -188,42 +145,6 @@ CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg);
 CFE_Status_t CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg);
 
 /************************************************************************/
-/** @brief Common logic for all channel-based commands.
- *
- * @par Description
- *       All the commands that act on channels or have the special
- *       "all channels" parameter come through this function. This puts
- *       all common logic in one place. It does not handle the command
- *       accept or reject counters.
- *
- * @par Assumptions, External Events, and Notes:
- *       cmd must not be NULL, errstr must not be NULL, fn must be a valid function, context may be NULL.
- *
- * @param chan_select Channel selector value from command (validated within this function)
- * @param errstr    String to be included in the EVS event if command should fail
- * @param fn        Callback action function to invoke for each affected channel
- * @param context   Opaque pointer to pass through to callback (not used in this function)
- *
- * @returns The return value from the given action function.
- * @retval CF_ChanAction_Status_ERROR on error
- */
-CF_ChanAction_Status_t
-CF_DoChanAction(CF_ChannelSelect_t chan_select, const char *errstr, CF_ChanActionFn_t fn, void *context);
-
-/************************************************************************/
-/** @brief Channel action to set the frozen bit for a channel.
- *
- * @par Assumptions, External Events, and Notes:
- *       context must not be NULL.
- *
- * @param chan      channel pointer (must not be NULL)
- * @param arg       context pointer to object, must be CF_ChanAction_BoolArg_t*
- *
- * @returns Always succeeds, so returns CF_ChanAction_Status_SUCCESS.
- */
-CF_ChanAction_Status_t CF_DoFreezeThaw(CF_Channel_t *chan, void *arg);
-
-/************************************************************************/
 /** @brief Freeze a channel.
  *
  * @par Assumptions, External Events, and Notes:
@@ -242,71 +163,6 @@ CFE_Status_t CF_FreezeCmd(const CF_FreezeCmd_t *msg);
  * @param msg   Pointer to command message
  */
 CFE_Status_t CF_ThawCmd(const CF_ThawCmd_t *msg);
-
-/************************************************************************/
-/** @brief Search for a transaction across all channels.
- *
- * @par Assumptions, External Events, and Notes:
- *       None
- *
- * @param ts  Transaction sequence number to find
- * @param eid Entity ID of the transaction
- *
- * @returns Pointer to the transaction, if found
- * @retval  NULL if transaction not found
- *
- */
-CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSeq_t ts, CF_EntityId_t eid);
-
-/************************************************************************/
-/** @brief Common logic for all transaction sequence number and channel commands.
- *
- * @par Description
- *       All the commands that on a transaction on a particular channel come
- *       through this function. This puts all common logic in one place. It
- *       does handle the command accept or reject counters.
- *
- * @par Assumptions, External Events, and Notes:
- *       cmd must not be NULL, fn must be a valid function, context may be NULL.
- *
- * @param data      Pointer to payload being processed
- * @param cmdstr    String to include in any generated EVS events
- * @param fn        Callback function to invoke for each matched transaction
- * @param context   Opaque object to pass through to the callback
- *
- * @returns returns the number of transactions acted upon
- *
- */
-int32 CF_TsnChanAction(const CF_Transaction_Payload_t *data,
-                       const char                     *cmdstr,
-                       CF_TsnChanAction_fn_t           fn,
-                       void                           *context);
-
-/************************************************************************/
-/** @brief Set the suspended bit in a transaction.
- *
- * @par Assumptions, External Events, and Notes:
- *       txn must not be NULL. context must not be NULL.
- *
- * @param txn         Pointer to the transaction object
- * @param context   Pointer to CF_ChanAction_SuspResArg_t structure from initial call
- */
-void CF_DoSuspRes_Txn(CF_Transaction_t *txn, CF_ChanAction_SuspResArg_t *context);
-
-/************************************************************************/
-/** @brief Handle transaction suspend and resume commands.
- *
- * @par Description
- *       This is called for both suspend and resume ground commands.
- *       It uses the CF_TsnChanAction() function to perform the command.
- *
- * @par Assumptions, External Events, and Notes:
- *       payload must not be NULL.
- *
- * @param payload   Pointer to the command message
- * @param action    Action to take (suspend or resume)
- */
-void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action);
 
 /************************************************************************/
 /** @brief Handle transaction suspend command.
@@ -329,19 +185,6 @@ CFE_Status_t CF_SuspendCmd(const CF_SuspendCmd_t *msg);
 CFE_Status_t CF_ResumeCmd(const CF_ResumeCmd_t *msg);
 
 /************************************************************************/
-/** @brief tsn chan action to cancel a transaction.
- *
- * This helper function is used with CF_TsnChanAction() to cancel matched transactions
- *
- * @par Assumptions, External Events, and Notes:
- *       txn must not be NULL.
- *
- * @param txn        Pointer to transaction object
- * @param ignored  Not used by this function
- */
-void CF_Cancel_TxnCmd(CF_Transaction_t *txn, void *ignored);
-
-/************************************************************************/
 /** @brief Handle a cancel ground command.
  *
  * @par Assumptions, External Events, and Notes:
@@ -352,19 +195,6 @@ void CF_Cancel_TxnCmd(CF_Transaction_t *txn, void *ignored);
 CFE_Status_t CF_CancelCmd(const CF_CancelCmd_t *msg);
 
 /************************************************************************/
-/** @brief tsn chan action to abandon a transaction.
- *
- * This helper function is used with CF_TsnChanAction() to abandon matched transactions
- *
- * @par Assumptions, External Events, and Notes:
- *       txn must not be NULL.
- *
- * @param txn        Pointer to transaction object
- * @param ignored  Not used by this function
- */
-void CF_Abandon_TxnCmd(CF_Transaction_t *txn, void *ignored);
-
-/************************************************************************/
 /** @brief Handle an abandon ground command.
  *
  * @par Assumptions, External Events, and Notes:
@@ -373,20 +203,6 @@ void CF_Abandon_TxnCmd(CF_Transaction_t *txn, void *ignored);
  * @param msg   Pointer to command message
  */
 CFE_Status_t CF_AbandonCmd(const CF_AbandonCmd_t *msg);
-
-/************************************************************************/
-/** @brief Sets the dequeue enable/disable flag for a channel.
- *
- * @par Assumptions, External Events, and Notes:
- *       context must not be NULL.
- *
- * @param chan      channel pointer (must not be NULL)
- * @param arg       context pointer to object, must be CF_ChanAction_BoolArg_t*
- *
- * @returns Always succeeds, so returns CF_ChanAction_Status_SUCCESS.
- *
- */
-CF_ChanAction_Status_t CF_DoEnableDisableDequeue(CF_Channel_t *chan, void *arg);
 
 /************************************************************************/
 /** @brief Handle an enable dequeue ground command.
@@ -409,21 +225,6 @@ CFE_Status_t CF_EnableDequeueCmd(const CF_EnableDequeueCmd_t *msg);
 CFE_Status_t CF_DisableDequeueCmd(const CF_DisableDequeueCmd_t *msg);
 
 /************************************************************************/
-/** @brief Sets the enable/disable flag for the specified polling directory.
- *
- * @par Assumptions, External Events, and Notes:
- *       context must not be NULL.
- *
- * @param chan      channel pointer (must not be NULL)
- * @param arg       context pointer to object, must be CF_ChanAction_BoolMsgArg_t*
- *
- * @returns success/fail status code
- * @retval  CF_ChanAction_Status_SUCCESS if successful
- * @retval  CF_ChanAction_Status_ERROR if failed
- */
-CF_ChanAction_Status_t CF_DoEnableDisablePolldir(CF_Channel_t *chan, void *arg);
-
-/************************************************************************/
 /** @brief Enable a polling dir ground command.
  *
  * @par Assumptions, External Events, and Notes:
@@ -444,55 +245,6 @@ CFE_Status_t CF_EnableDirPollingCmd(const CF_EnableDirPollingCmd_t *msg);
 CFE_Status_t CF_DisableDirPollingCmd(const CF_DisableDirPollingCmd_t *msg);
 
 /************************************************************************/
-/** @brief Purge the history queue for the given channel.
- *
- * This helper function is used in conjunction with CF_CList_Traverse()
- *
- * @par Assumptions, External Events, and Notes:
- *       node must not be NULL. chan must not be NULL.
- *
- * @param node  Current list node being traversed
- * @param arg   Channel pointer passed through as opaque object, must be CF_Channel_t*
- *
- * @returns Always #CF_CLIST_CONT to process all entries
- */
-CF_CListTraverse_Status_t CF_PurgeHistory(CF_CListNode_t *node, void *arg);
-
-/************************************************************************/
-/** @brief Purge the pending transaction queue.
- *
- * This helper function is used in conjunction with CF_CList_Traverse()
- *
- * @par Assumptions, External Events, and Notes:
- *       node must not be NULL.
- *
- * @param node  Current list node being traversed
- * @param ignored  Not used by this implementation
- *
- * @returns Always #CF_CLIST_CONT to process all entries
- */
-CF_CListTraverse_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignored);
-
-/************************************************************************/
-/** @brief Channel action command to perform purge queue operations.
- *
- * @par Description
- *       Determines from the command parameters which queues to traverse
- *       and purge state.
- *
- * @par Assumptions, External Events, and Notes:
- *       None
- *
- * @param chan      CF channel pointer (must not be NULL)
- * @param arg       Pointer to purge queue command
- *
- * @returns integer status code indicating success or failure
- * @retval  CF_ChanAction_Status_SUCCESS if successful
- * @retval  CF_ChanAction_Status_ERROR on error
- */
-CF_ChanAction_Status_t CF_DoPurgeQueue(CF_Channel_t *chan, void *arg);
-
-/************************************************************************/
 /** @brief Ground command to purge either the history or pending queues.
  *
  * @par Assumptions, External Events, and Notes:
@@ -511,58 +263,6 @@ CFE_Status_t CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg);
  * @param msg   Pointer to command message
  */
 CFE_Status_t CF_WriteQueueCmd(const CF_WriteQueueCmd_t *msg);
-
-/************************************************************************/
-/** @brief Checks if the value is less than or equal to the max PDU size.
- *
- * @par Assumptions, External Events, and Notes:
- *       None
- *
- * @param val       Size of chunk to test
- * @param chan      Ignored by this implementation
- *
- * @returns status code indicating if check passed
- * @retval CF_ChanAction_Status_SUCCESS if successful (val is less than or equal to max PDU)
- * @retval CF_ChanAction_Status_ERROR if failed (val is greater than max PDU)
- *
- */
-CF_ChanAction_Status_t CF_ValidateChunkSizeCmd(CF_ChunkSize_t val, CF_Channel_t *chan);
-
-/************************************************************************/
-/** @brief Checks if the value is within allowable range as outgoing packets per wakeup
- *
- * @par Assumptions, External Events, and Notes:
- *       None
- *
- * @param val       Number to test
- * @param chan      CF channel pointer
- *
- * @returns status code indicating if check passed
- * @retval CF_ChanAction_Status_SUCCESS if successful (val is allowable as max packets per wakeup)
- * @retval CF_ChanAction_Status_ERROR if failed (val is not allowed)
- *
- */
-CF_ChanAction_Status_t CF_ValidateMaxOutgoingCmd(uint32 val, CF_Channel_t *chan);
-
-/************************************************************************/
-/** @brief Perform a configuration get/set operation.
- *
- * For a set, this sets the value within the CF configuration
- * For a get, this generates an EVS event with the requested information
- *
- * @par Description
- *       Combine get and set in one function with common logic.
- *
- * @par Assumptions, External Events, and Notes:
- *       None
- *
- * @param is_set    Whether to get (false) or set (true)
- * @param param_id  Parameter ID
- * @param value     Value to get/set
- * @param chan_num  Channel selector from original command (Validated within this function)
- *
- */
-void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, CF_ChannelSelect_t chan_num);
 
 /************************************************************************/
 /** @brief Ground command to set a configuration parameter.

--- a/fsw/src/cf_utils.c
+++ b/fsw/src/cf_utils.c
@@ -480,42 +480,6 @@ int32 CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransactions_
 
 /*----------------------------------------------------------------
  *
- * Local helper function
- * Invokes CF_TraverseAllTransactions() for a single channel within the CFDP engine
- * Compatible with CF_ForEachChannel()
- *
- *-----------------------------------------------------------------*/
-static int32 CF_DoTraverseAllTransactions(CF_Engine_t *engine_ptr, CF_Channel_t *chan, void *arg)
-{
-    CF_TraverseAllTransactions_State_t *state = arg;
-
-    state->ret += CF_TraverseAllTransactions(chan, state->fn, state->context);
-
-    return CFE_SUCCESS;
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in cf_utils.h for argument/return detail
- *
- *-----------------------------------------------------------------*/
-int32 CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
-{
-    CF_TraverseAllTransactions_State_t state;
-
-    memset(&state, 0, sizeof(state));
-
-    state.fn      = fn;
-    state.context = context;
-
-    CF_ForEachChannel(CF_GetEngine(), CF_DoTraverseAllTransactions, &state);
-
-    return state.ret;
-}
-
-/*----------------------------------------------------------------
- *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
  *
@@ -607,6 +571,12 @@ CFE_Status_t CF_WrappedLseek(osal_id_t fd, off_t offset, int mode)
  *
  * Application-scope internal function
  * See description in cf_utils.h for argument/return detail
+ *
+ * NOTE: this function ranks high on the cyclic complexity scale
+ * simply due to its use of a switch/case statement with a fairly
+ * high number of cases. But there are only 3 distinct actions
+ * in the switch, but the scoring is based on the number of cases,
+ * not the number of different actions.
  *
  *-----------------------------------------------------------------*/
 CF_CFDP_ConditionCode_t CF_TxnStatus_To_ConditionCode(CF_TxnStatus_t txn_stat)

--- a/fsw/src/cf_utils.h
+++ b/fsw/src/cf_utils.h
@@ -343,19 +343,6 @@ void CF_InsertSortPrio(CF_Transaction_t *txn, CF_QueueIdx_t queue);
 int32 CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransactions_fn_t fn, void *context);
 
 /************************************************************************/
-/** @brief Traverses all transactions on all channels and performs an operation on them.
- *
- * @par Assumptions, External Events, and Notes:
- *       fn must be a valid function. context must not be NULL.
- *
- * @param fn      Callback to invoke for all traversed transactions
- * @param context Opaque object to pass to all callbacks
- *
- * @returns Number of transactions traversed
- */
-int32 CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context);
-
-/************************************************************************/
 /** @brief List traversal function performs operation on every active transaction.
  *
  * @par Description

--- a/unit-test/cf_cfdp_dispatch_tests.c
+++ b/unit-test/cf_cfdp_dispatch_tests.c
@@ -44,7 +44,7 @@ static void UT_CFDP_Dispatch_SetupBasicTestState(UT_CF_Setup_t            setup,
     static CF_Transaction_t       ut_transaction;
 
     CF_Engine_t  *engine_ptr      = CF_GetEngine();
-    CF_Channel_t *local_channel_p = &engine_ptr->channels[UT_CFDP_CHANNEL_IDX];
+    CF_Channel_t *local_channel_p = UT_CFDP_CHANNEL_PTR;
 
     /*
      * always clear all objects, regardless of what was asked for.

--- a/unit-test/cf_cfdp_r_tests.c
+++ b/unit-test/cf_cfdp_r_tests.c
@@ -54,7 +54,7 @@ static void UT_CFDP_R_SetupBasicTestState(UT_CF_Setup_t            setup,
     static CF_Transaction_t       ut_transaction;
 
     CF_Engine_t  *engine_ptr      = CF_GetEngine();
-    CF_Channel_t *local_channel_p = &engine_ptr->channels[UT_CFDP_CHANNEL_IDX];
+    CF_Channel_t *local_channel_p = UT_CFDP_CHANNEL_PTR;
 
     /*
      * always clear all objects, regardless of what was asked for.

--- a/unit-test/cf_cfdp_s_tests.c
+++ b/unit-test/cf_cfdp_s_tests.c
@@ -77,7 +77,7 @@ static void UT_CFDP_S_SetupBasicTestState(UT_CF_Setup_t            setup,
     static CF_Transaction_t       ut_transaction;
 
     CF_Engine_t  *engine_ptr      = CF_GetEngine();
-    CF_Channel_t *local_channel_p = &engine_ptr->channels[UT_CFDP_CHANNEL_IDX];
+    CF_Channel_t *local_channel_p = UT_CFDP_CHANNEL_PTR;
 
     /*
      * always clear all objects, regardless of what was asked for.

--- a/unit-test/cf_cfdp_sbintf_tests.c
+++ b/unit-test/cf_cfdp_sbintf_tests.c
@@ -111,7 +111,7 @@ static void UT_CFDP_SetupBasicTestState(UT_CF_Setup_t            setup,
     static CF_Transaction_t ut_transaction;
 
     CF_Engine_t  *engine_ptr      = CF_GetEngine();
-    CF_Channel_t *local_channel_p = &engine_ptr->channels[UT_CFDP_CHANNEL_IDX];
+    CF_Channel_t *local_channel_p = UT_CFDP_CHANNEL_PTR;
 
     /*
      * always clear all objects, regardless of what was asked for.

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -80,7 +80,7 @@ static void UT_CFDP_SetupBasicTestState(UT_CF_Setup_t            setup,
     static CF_Transaction_t       ut_transaction;
 
     CF_Engine_t  *engine_ptr      = CF_GetEngine();
-    CF_Channel_t *local_channel_p = &engine_ptr->channels[UT_CFDP_CHANNEL_IDX];
+    CF_Channel_t *local_channel_p = UT_CFDP_CHANNEL_PTR;
 
     /*
      * always clear all objects, regardless of what was asked for.

--- a/unit-test/cf_cmd_tests.c
+++ b/unit-test/cf_cmd_tests.c
@@ -53,7 +53,7 @@ CF_EntityId_t Any_CF_EntityId_t(void)
 /* uint8 used for Any_cf_polldir likely there will never be that many polldirs */
 CF_PollIdxSelect_t Any_cf_polldir(void)
 {
-    return Any_uint8_LessThan(CF_MAX_POLLING_DIR_PER_CHAN);
+    return 1 + Any_uint8_LessThan(CF_MAX_POLLING_DIR_PER_CHAN);
 }
 
 /* bool_arg_t_barg should only be 0 or 1 (Boolean) */
@@ -85,7 +85,7 @@ typedef struct
     void             *context;
 } CF_TsnChanAction_fn_t_context_t;
 
-CF_ChanAction_Status_t Chan_action_fn_t(CF_Channel_t *chan_ptr, void *context)
+CFE_Status_t Chan_action_fn_t(CF_Channel_t *chan_ptr, void *context)
 {
     /* This one does not need to save its context, just call default so count works */
     return UT_DEFAULT_IMPL(Chan_action_fn_t);
@@ -392,7 +392,7 @@ void Test_CF_ResetCountersCmd_tests_WhenCommandByteIs_all_AndResetAllMemValuesSe
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_STUB_COUNT(CF_ForEachChannel, 3);
+    UtAssert_STUB_COUNT(CF_ForEachChannel, 1);
     UT_CF_AssertEventID(CF_RESET_INF_EID);
 
     UtAssert_ZERO(CF_AppData.counters.cmd);
@@ -429,6 +429,7 @@ void Test_CF_TxFileCmd(void)
 
     /* nominal, all zero should pass checks, just calls CF_CFDP_TxFile */
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = CF_CFDP_Class_1;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
@@ -437,6 +438,7 @@ void Test_CF_TxFileCmd(void)
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = CF_CFDP_Class_2;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 2);
@@ -446,6 +448,7 @@ void Test_CF_TxFileCmd(void)
     /* out of range arguments: bad class */
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
@@ -453,34 +456,48 @@ void Test_CF_TxFileCmd(void)
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.counters.err, 2);
 
-    /* out of range arguments: bad channel */
+    /* out of range arguments: bad channel (nonzero) */
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
-    msg->chan_num = CF_NUM_CHANNELS;
+    msg->chan_num = CF_ChannelSelect_FromInt(CF_NUM_CHANNELS + 1);
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.counters.err, 3);
+
+    /* out of range arguments: bad channel (0) */
+    UT_CF_ResetEventCapture();
+    memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = CF_ChannelSelect_FromInt(0);
+    msg->cfdp_class = CF_CFDP_Class_1;
+    UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 4);
 
     /* out of range arguments: bad keep */
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
-    msg->keep = 15;
+    msg->chan_num = UT_CFDP_CHANNEL;
+    msg->keep     = 15;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.err, 4);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 5);
 
     /* CF_CFDP_TxFile fails*/
     UT_CF_ResetEventCapture();
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_TxFile), -1);
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num = UT_CFDP_CHANNEL;
     UtAssert_VOIDCALL(CF_TxFileCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_TX_FILE_ERR_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.err, 5);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 6);
 }
 
 /*******************************************************************************
@@ -501,17 +518,20 @@ void Test_CF_PlaybackDirCmd(void)
 
     /* nominal, all zero should pass checks, just calls CF_CFDP_PlaybackDir */
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = CF_CFDP_Class_1;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
 
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = CF_CFDP_Class_2;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 2);
 
     /* out of range arguments: bad class */
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = 10;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
@@ -519,6 +539,7 @@ void Test_CF_PlaybackDirCmd(void)
 
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num   = UT_CFDP_CHANNEL;
     msg->cfdp_class = -10;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
@@ -527,7 +548,7 @@ void Test_CF_PlaybackDirCmd(void)
     /* out of range arguments: bad channel */
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
-    msg->chan_num = CF_NUM_CHANNELS;
+    msg->chan_num = CF_ChannelSelect_FromInt(CF_NUM_CHANNELS + 1);
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.counters.err, 3);
@@ -535,7 +556,8 @@ void Test_CF_PlaybackDirCmd(void)
     /* out of range arguments: bad keep */
     UT_CF_ResetEventCapture();
     memset(msg, 0, sizeof(*msg));
-    msg->keep = 15;
+    msg->chan_num = UT_CFDP_CHANNEL;
+    msg->keep     = 15;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_BAD_PARAM_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.counters.err, 4);
@@ -544,207 +566,10 @@ void Test_CF_PlaybackDirCmd(void)
     UT_CF_ResetEventCapture();
     UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_PlaybackDir), -1);
     memset(msg, 0, sizeof(*msg));
+    msg->chan_num = UT_CFDP_CHANNEL;
     UtAssert_VOIDCALL(CF_PlaybackDirCmd(&utbuf));
     UT_CF_AssertEventID(CF_CMD_PLAYBACK_DIR_ERR_EID);
     UtAssert_UINT32_EQ(CF_AppData.counters.err, 5);
-}
-
-/*******************************************************************************
-**
-**  CF_DoChanAction tests
-**
-*******************************************************************************/
-
-void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t     data;
-    const char            *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t      arg_fn     = &Chan_action_fn_t;
-    int                    context;
-    void                  *arg_context = &context;
-    CF_ChanAction_Status_t local_result;
-
-    data = CF_ALL_CHANNELS;
-
-    UT_SetDeferredRetcode(UT_KEY(Chan_action_fn_t), 1, 1);
-
-    /* Act */
-    local_result = CF_DoChanAction(data, arg_errstr, arg_fn, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS | 1);
-}
-
-void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t     data;
-    const char            *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t      arg_fn     = &Chan_action_fn_t;
-    int                    context;
-    void                  *arg_context = &context;
-    CF_ChanAction_Status_t local_result;
-
-    data = CF_ALL_CHANNELS;
-
-    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 1);
-
-    /* Act */
-    local_result = CF_DoChanAction(data, arg_errstr, arg_fn, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS | 1);
-}
-
-void Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t     data;
-    const char            *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t      arg_fn     = &Chan_action_fn_t;
-    int                    context;
-    void                  *arg_context = &context;
-    CF_ChanAction_Status_t local_result;
-
-    data = CF_ALL_CHANNELS;
-
-    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 0);
-
-    /* Act */
-    local_result = CF_DoChanAction(data, arg_errstr, arg_fn, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t     data;
-    const char            *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t      arg_fn     = &Chan_action_fn_t;
-    int                    context;
-    void                  *arg_context = &context;
-    CF_ChanAction_Status_t local_result;
-
-    data = Any_cf_chan_num();
-
-    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 1);
-
-    /* Act */
-    local_result = CF_DoChanAction(data, arg_errstr, arg_fn, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(local_result, 1);
-}
-
-void Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t     data;
-    const char            *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t      arg_fn     = &Chan_action_fn_t;
-    int                    context;
-    void                  *arg_context = &context;
-    CF_ChanAction_Status_t local_result;
-
-    data = Any_cf_chan_num();
-
-    UT_SetDefaultReturnValue(UT_KEY(Chan_action_fn_t), 0);
-
-    /* Act */
-    local_result = CF_DoChanAction(data, arg_errstr, arg_fn, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(Chan_action_fn_t, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(local_result, 0);
-}
-
-void Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendEvent_(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t     data;
-    const char            *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t      arg_fn     = &Chan_action_fn_t;
-    int                    context;
-    void                  *arg_context = &context;
-    CF_ChanAction_Status_t local_result;
-
-    data = CF_NUM_CHANNELS;
-
-    /* Act */
-    local_result = CF_DoChanAction(data, arg_errstr, arg_fn, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(Chan_action_fn_t, 0);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
-
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-}
-
-void Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t     data;
-    const char            *arg_errstr = "CANNOT TEST SENT TO SEND EVENT";
-    CF_ChanActionFn_t      arg_fn     = &Chan_action_fn_t;
-    int                    context;
-    void                  *arg_context = &context;
-    CF_ChanAction_Status_t local_result;
-
-    /* force CF_ALL_CHANNELS to not be a selection possibility */
-    data = CF_ALL_CHANNELS - 2;
-
-    /* Act */
-    local_result = CF_DoChanAction(data, arg_errstr, arg_fn, arg_context);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(Chan_action_fn_t, 0);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
-
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-}
-
-/*******************************************************************************
-**
-**  CF_DoFreezeThaw tests
-**
-*******************************************************************************/
-
-void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
-{
-    /* Arrange */
-    CF_Channel_t           *chan = UT_CFDP_CHANNEL_PTR;
-    CF_ChanAction_BoolArg_t context;
-    CF_ChanAction_Status_t  local_result;
-
-    context.barg = Any_bool_arg_t_barg();
-
-    /* set frozen to opposite to ensure change was done - not required for test,
-     * but it is helpful for verification that the function did the change */
-    chan->stat.frozen = !context.barg;
-
-    /* Act */
-    local_result = CF_DoFreezeThaw(chan, &context);
-
-    /* Assert */
-    UtAssert_True(chan->stat.frozen == context.barg,
-                  "CF_DoFreezeThaw set frozen to %d and should be %d (context->barg))",
-                  chan->stat.frozen,
-                  context.barg);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
 }
 
 /**************************************************************************
@@ -756,17 +581,15 @@ void Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0(void)
 void Test_CF_FreezeCmd_Set_frozen_To_1_AndAcceptCommand(void)
 {
     /* Arrange */
-    CF_FreezeCmd_t              utbuf;
-    CF_ChannelSelect_Payload_t *data                   = &utbuf.Payload;
-    uint16                      initial_hk_cmd_counter = Any_uint16();
-    CF_Channel_t               *chan;
+    CF_FreezeCmd_t utbuf;
+    uint16         initial_hk_cmd_counter = Any_uint16();
+    CF_Channel_t  *chan;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    data->ChannelSelect = Any_cf_chan_num();
-    chan                = CF_GetChannelPtr(data->ChannelSelect);
-    chan->stat.frozen   = false;
+    chan              = UT_CFDP_CHANNEL_PTR;
+    chan->stat.frozen = false;
 
     CF_AppData.counters.cmd = initial_hk_cmd_counter;
 
@@ -796,7 +619,7 @@ void Test_CF_FreezeCmd_Set_frozen_To_1_AndRejectCommand(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    data->ChannelSelect = CF_NUM_CHANNELS + 1;
+    data->ChannelSelect = UT_CFDP_INVALID_CHANNEL;
 
     CF_AppData.counters.cmd = 0;
 
@@ -859,7 +682,7 @@ void Test_CF_ThawCmd_Set_frozen_To_0_AndRejectCommand(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    data->ChannelSelect = CF_NUM_CHANNELS + 1;
+    data->ChannelSelect = UT_CFDP_INVALID_CHANNEL;
 
     CF_AppData.counters.cmd = 0;
 
@@ -874,382 +697,11 @@ void Test_CF_ThawCmd_Set_frozen_To_0_AndRejectCommand(void)
 
 /*******************************************************************************
 **
-**  CF_FindTransactionBySequenceNumberAllChannels tests
-**
-*******************************************************************************/
-
-void Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundReturn_NULL(void)
-{
-    /* Arrange */
-    CF_TransactionSeq_t arg_ts  = Any_CF_TransactionSeq_t();
-    CF_EntityId_t       arg_eid = Any_CF_EntityId_t();
-    CF_Transaction_t   *local_result;
-    CF_Transaction_t   *expected_result = NULL;
-    CF_Engine_t        *engine_ptr      = CF_GetEngine();
-
-    CF_FindTransactionBySequenceNumber_context_t context_CF_CFDP_FTBSN;
-
-    context_CF_CFDP_FTBSN.forced_return = NULL;
-
-    UT_SetDataBuffer(UT_KEY(CF_FindTransactionBySequenceNumber),
-                     &context_CF_CFDP_FTBSN,
-                     sizeof(context_CF_CFDP_FTBSN),
-                     false);
-
-    /* Act */
-    local_result = CF_FindTransactionBySequenceNumberAllChannels(arg_ts, arg_eid);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CF_FindTransactionBySequenceNumber, CF_NUM_CHANNELS);
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_FTBSN.chan, engine_ptr->channels);
-    UtAssert_UINT32_EQ(context_CF_CFDP_FTBSN.transaction_sequence_number, arg_ts);
-    UtAssert_UINT32_EQ(context_CF_CFDP_FTBSN.src_eid, arg_eid);
-    UtAssert_ADDRESS_EQ(local_result, expected_result);
-}
-
-void Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound(void)
-{
-    /* Arrange */
-    CF_TransactionSeq_t arg_ts                   = Any_CF_TransactionSeq_t();
-    CF_EntityId_t       arg_eid                  = Any_CF_EntityId_t();
-    uint8               number_transaction_match = Any_uint8_LessThan(CF_NUM_CHANNELS);
-    CF_Transaction_t    return_value;
-    CF_Transaction_t   *local_result;
-    CF_Transaction_t   *expected_result = &return_value;
-    int                 i               = 0;
-
-    CF_FindTransactionBySequenceNumber_context_t contexts_CF_CFDP_FTBSN[CF_NUM_CHANNELS];
-
-    /* set non-matching transactions */
-    for (i = 0; i < number_transaction_match; ++i)
-    {
-        contexts_CF_CFDP_FTBSN[i].forced_return = NULL;
-    }
-    /* set matching transaction */
-    contexts_CF_CFDP_FTBSN[i].forced_return = &return_value;
-
-    UT_SetDataBuffer(UT_KEY(CF_FindTransactionBySequenceNumber),
-                     &contexts_CF_CFDP_FTBSN,
-                     sizeof(contexts_CF_CFDP_FTBSN),
-                     false);
-
-    /* Act */
-    local_result = CF_FindTransactionBySequenceNumberAllChannels(arg_ts, arg_eid);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CF_FindTransactionBySequenceNumber, number_transaction_match + 1);
-    for (i = 0; i < number_transaction_match; ++i)
-    {
-        UtAssert_ADDRESS_EQ(contexts_CF_CFDP_FTBSN[i].chan, CF_GetChannelPtr(CF_ChannelSelect_FromInt(i)));
-        UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].transaction_sequence_number, arg_ts);
-        UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].src_eid, arg_eid);
-    }
-    UtAssert_ADDRESS_EQ(contexts_CF_CFDP_FTBSN[i].chan, CF_GetChannelPtr(CF_ChannelSelect_FromInt(i)));
-    UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].transaction_sequence_number, arg_ts);
-    UtAssert_UINT32_EQ(contexts_CF_CFDP_FTBSN[i].src_eid, arg_eid);
-    UtAssert_ADDRESS_EQ(local_result, expected_result);
-}
-
-/*******************************************************************************
-**
-**  CF_TsnChanAction tests
-**
-*******************************************************************************/
-
-void Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotFoundAndReturn_neg1_Fail(void)
-{
-    /* Arrange */
-    CF_Transaction_Payload_t  utbuf;
-    CF_Transaction_Payload_t *arg_cmd = &utbuf;
-    char                      cmdstr[10];     /* 10 is arbitrary */
-    const char                arg_cmdstr[10]; /* 10 is arbitrary */
-    CF_TsnChanAction_fn_t     arg_fn = &Dummy_CF_TsnChanAction_fn_t;
-    int                       context;
-    void                     *arg_context = &context;
-    int                       i           = 0;
-
-    CF_FindTransactionBySequenceNumber_context_t contexts_CF_CFDP_FTBSN[CF_NUM_CHANNELS];
-
-    memset(&utbuf, 0, sizeof(utbuf));
-    AnyRandomStringOfLettersOfLengthCopy(cmdstr, 10);
-    memcpy((char *)arg_cmdstr, &cmdstr, 10);
-
-    arg_cmd->chan_num = CF_COMPOUND_KEY;
-
-    /* Arrange unstubbable: CF_FindTransactionBySequenceNumberAllChannels */
-    /* set non-matching transactions */
-    for (i = 0; i < CF_NUM_CHANNELS; ++i)
-    {
-        contexts_CF_CFDP_FTBSN[i].forced_return = NULL;
-    }
-
-    UT_SetDataBuffer(UT_KEY(CF_FindTransactionBySequenceNumber),
-                     &contexts_CF_CFDP_FTBSN,
-                     sizeof(contexts_CF_CFDP_FTBSN),
-                     false);
-
-    /* Act */
-    UtAssert_INT32_EQ(CF_TsnChanAction(arg_cmd, arg_cmdstr, arg_fn, arg_context), -1);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_TRANS_NOT_FOUND_ERR_EID);
-
-    UtAssert_STUB_COUNT(Dummy_CF_TsnChanAction_fn_t, 0);
-}
-
-void Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_AndReturn_CFE_SUCCESS(void)
-{
-    /* Arrange */
-    CF_Transaction_Payload_t        utbuf;
-    CF_Transaction_Payload_t       *arg_cmd = &utbuf;
-    char                            cmdstr[10];     /* 10 is arbitrary */
-    const char                      arg_cmdstr[10]; /* 10 is arbitrary */
-    CF_TsnChanAction_fn_t           arg_fn = &Dummy_CF_TsnChanAction_fn_t;
-    int                             context;
-    void                           *arg_context = &context;
-    CF_Transaction_t                txn;
-    CF_TsnChanAction_fn_t_context_t context_CF_TsnChanAction_fn_t;
-
-    memset(&utbuf, 0, sizeof(utbuf));
-    AnyRandomStringOfLettersOfLengthCopy(cmdstr, 10);
-    memcpy((char *)arg_cmdstr, &cmdstr, 10);
-
-    arg_cmd->chan_num = CF_COMPOUND_KEY;
-
-    UT_SetDataBuffer(UT_KEY(Dummy_CF_TsnChanAction_fn_t),
-                     &context_CF_TsnChanAction_fn_t,
-                     sizeof(context_CF_TsnChanAction_fn_t),
-                     false);
-
-    /* Arrange unstubbable: CF_FindTransactionBySequenceNumberAllChannels */
-    CF_FindTransactionBySequenceNumber_context_t context_CF_CFDP_FTBSN;
-
-    /* set matching transaction */
-    context_CF_CFDP_FTBSN.forced_return = &txn;
-
-    UT_SetDataBuffer(UT_KEY(CF_FindTransactionBySequenceNumber),
-                     &context_CF_CFDP_FTBSN,
-                     sizeof(context_CF_CFDP_FTBSN),
-                     false);
-
-    /* Act */
-    UtAssert_INT32_EQ(CF_TsnChanAction(arg_cmd, arg_cmdstr, arg_fn, arg_context), 1);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_STUB_COUNT(Dummy_CF_TsnChanAction_fn_t, 1);
-    UtAssert_ADDRESS_EQ(context_CF_TsnChanAction_fn_t.txn, &txn);
-    UtAssert_ADDRESS_EQ(context_CF_TsnChanAction_fn_t.context, arg_context);
-}
-
-void Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels(void)
-{
-    /* Arrange */
-    CF_Transaction_Payload_t                          utbuf;
-    CF_Transaction_Payload_t                         *arg_cmd = &utbuf;
-    char                                              cmdstr[10];     /* 10 is arbitrary */
-    const char                                        arg_cmdstr[10]; /* 10 is arbitrary */
-    CF_TsnChanAction_fn_t                             arg_fn = &Dummy_CF_TsnChanAction_fn_t;
-    int                                               context;
-    void                                             *arg_context     = &context;
-    int                                               expected_result = Any_int();
-    CF_TraverseAllTransactions_All_Channels_context_t context_CF_TATAC;
-
-    memset(&utbuf, 0, sizeof(utbuf));
-    AnyRandomStringOfLettersOfLengthCopy(cmdstr, 10);
-    memcpy((char *)arg_cmdstr, &cmdstr, 10);
-
-    context_CF_TATAC.forced_return = expected_result;
-
-    arg_cmd->chan_num = CF_ALL_CHANNELS;
-
-    UT_SetDataBuffer(UT_KEY(CF_TraverseAllTransactions_All_Channels),
-                     &context_CF_TATAC,
-                     sizeof(context_CF_TATAC),
-                     false);
-
-    /* Act */
-    UtAssert_INT32_EQ(CF_TsnChanAction(arg_cmd, arg_cmdstr, arg_fn, arg_context), expected_result);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-}
-
-void Test_CF_TsnChanAction_cmd_chan_IsASingleChannel(void)
-{
-    /* Arrange */
-    CF_Transaction_Payload_t cmd;
-    int                      result = 1;
-
-    memset(&cmd, 0, sizeof(cmd));
-
-    UT_SetDefaultReturnValue(UT_KEY(CF_TraverseAllTransactions), result);
-
-    /* Act */
-    UtAssert_INT32_EQ(CF_TsnChanAction(&cmd, NULL, NULL, NULL), result);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
-}
-
-void Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid(void)
-{
-    /* Arrange */
-    CF_Transaction_Payload_t  utbuf;
-    CF_Transaction_Payload_t *arg_cmd       = &utbuf;
-    const char                arg_cmdstr[1] = "";
-    CF_TsnChanAction_fn_t     arg_fn        = &Dummy_CF_TsnChanAction_fn_t;
-    int                       context;
-    void                     *arg_context = &context;
-
-    memset(&utbuf, 0, sizeof(utbuf));
-    arg_cmd->chan_num = CF_NUM_CHANNELS + 1;
-
-    /* Act */
-    UtAssert_INT32_EQ(CF_TsnChanAction(arg_cmd, arg_cmdstr, arg_fn, arg_context), -1);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_TSN_CHAN_INVALID_ERR_EID);
-}
-
-/*******************************************************************************
-**
-**  CF_DoSuspRes_Txn tests
-**
-*******************************************************************************/
-
-void Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action(void)
-{
-    /* Arrange */
-    CF_Transaction_t            txn;
-    CF_Transaction_t           *arg_t = &txn;
-    CF_ChanAction_SuspResArg_t  context;
-    CF_ChanAction_SuspResArg_t *arg_context = &context;
-
-    /* set same to 0 to ensure change was done - not required for test,
-     * but it is helpful for verification that the function did the change */
-    arg_context->same   = 0;
-    arg_context->action = AnyCoinFlip();
-
-    arg_t->flags.com.suspended = arg_context->action;
-
-    /* Act */
-    CF_DoSuspRes_Txn(arg_t, arg_context);
-
-    /* Assert */
-    UtAssert_True(arg_context->same == 1,
-                  "CF_DoSuspRes_Txn set context->same to %d and should be 1 (direct set)",
-                  arg_context->same);
-}
-
-void Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action(void)
-{
-    /* Arrange */
-    CF_Transaction_t            txn;
-    CF_Transaction_t           *arg_t = &txn;
-    CF_ChanAction_SuspResArg_t  context;
-    CF_ChanAction_SuspResArg_t *arg_context = &context;
-
-    /* set same to 0 to ensure change was done - not required for test,
-     * but it is helpful for verification that the function did the change */
-    arg_context->same   = 0;
-    arg_context->action = AnyCoinFlip();
-
-    arg_t->flags.com.suspended = !arg_context->action;
-
-    /* Act */
-    CF_DoSuspRes_Txn(arg_t, arg_context);
-
-    /* Assert */
-    UtAssert_True(arg_t->flags.com.suspended == arg_context->action,
-                  "CF_DoSuspRes_Txn set arg_t->flags.com.suspended to %d and should be %d (context->action)",
-                  arg_t->flags.com.suspended,
-                  arg_context->action);
-}
-
-/*******************************************************************************
-**
-**  CF_DoSuspRes tests
-**
-*******************************************************************************/
-
-static void UT_AltHandler_CF_TraverseAllTransactions_SetSuspResArg(void                   *UserObj,
-                                                                   UT_EntryKey_t           FuncKey,
-                                                                   const UT_StubContext_t *Context)
-{
-    CF_ChanAction_SuspResArg_t *context = UT_Hook_GetArgValueByName(Context, "context", CF_ChanAction_SuspResArg_t *);
-    CF_ChanAction_SuspResArg_t *utargs  = UserObj;
-
-    if (context != NULL && utargs != NULL)
-    {
-        /* Update the caller-supplied context with the UT-supplied value */
-        /* only "same" flag is an output, action is an input */
-        context->same = utargs->same;
-    }
-}
-
-void Test_CF_DoSuspRes(void)
-{
-    /* Test case for:
-     * void CF_DoSuspRes(CF_Transaction_Payload_t *cmd, uint8 action)
-     */
-
-    CF_Transaction_Payload_t   utbuf;
-    CF_Transaction_Payload_t  *cmd = &utbuf;
-    CF_ChanAction_SuspResArg_t utargs;
-
-    memset(&CF_AppData.counters, 0, sizeof(CF_AppData.counters));
-    memset(&utargs, 0, sizeof(utargs));
-    memset(cmd, 0, sizeof(*cmd));
-
-    /* nominal */
-    /* With no setup, CF_TsnChanAction() invokes CF_TraverseAllTransactions stub, which returns 0 */
-    /* this should increment the reject counter because it did not match any transactions */
-    UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 0));
-    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
-
-    /* set up to match 1 transaction, should be accepted, but should not generate an event */
-    UT_CF_ResetEventCapture();
-    UT_SetDeferredRetcode(UT_KEY(CF_TraverseAllTransactions), 1, 1);
-    UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_SUSPRES_INF_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
-
-    /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
-    /* this gets the case where it attempts to set to the same value, and is rejected due to that */
-    UT_CF_ResetEventCapture();
-    UT_SetDeferredRetcode(UT_KEY(CF_TraverseAllTransactions), 1, 1);
-    utargs.same = 1;
-    UT_SetHandlerFunction(UT_KEY(CF_TraverseAllTransactions),
-                          UT_AltHandler_CF_TraverseAllTransactions_SetSuspResArg,
-                          &utargs);
-    UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 0));
-    UT_CF_AssertEventID(CF_CMD_SUSPRES_SAME_INF_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 2);
-
-    /* Output the CF_ChanAction_SuspResArg_t back to the caller, to set the "same" flag to 1 */
-    /* however this time CF_TraverseAllTransactions reports it matched multiple transactions, so it should NOT reject it
-     */
-    UT_CF_ResetEventCapture();
-    UT_SetDeferredRetcode(UT_KEY(CF_TraverseAllTransactions), 1, 10);
-    UtAssert_VOIDCALL(CF_DoSuspRes(cmd, 1));
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_SUSPRES_INF_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 3);
-}
-
-/*******************************************************************************
-**
 **  CF_SuspendCmd tests
 **
 *******************************************************************************/
 
-/* Test_CF_SuspendCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_1 */
-void Test_CF_SuspendCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_1(void)
+void Test_CF_SuspendCmd_InvalidChannel(void)
 {
     /* Arrange */
     CF_SuspendCmd_t utbuf;
@@ -1257,18 +709,40 @@ void Test_CF_SuspendCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_1(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Set to invalid channel */
-    utbuf.Payload.chan_num = CF_NUM_CHANNELS;
+    utbuf.Payload.chan_num = UT_CFDP_INVALID_CHANNEL;
 
     /* Act */
     CF_SuspendCmd(&utbuf);
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_TSN_CHAN_INVALID_ERR_EID);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_CMD_SUSPRES_CHAN_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_SUSPRES_CHAN_ERR_EID);
 
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+}
+
+void Test_CF_SuspendCmd_Success(void)
+{
+    CF_SuspendCmd_t  utbuf;
+    CF_Transaction_t txn;
+
+    memset(&txn, 0, sizeof(txn));
+    memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+
+    /* This needs to invoke the callback thru CF_TraverseAllTransactions */
+    UT_SetHandlerFunction(UT_KEY(CF_TraverseAllTransactions), UT_AltHandler_CF_TraverseAllTransactions_InvokeCb, &txn);
+
+    /* Act */
+    CF_SuspendCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_SUSPRES_INF_EID);
 }
 
 /*******************************************************************************
@@ -1277,52 +751,47 @@ void Test_CF_SuspendCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_1(void)
 **
 *******************************************************************************/
 
-/* Test_CF_ResumeCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_0 */
-void Test_CF_ResumeCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_0(void)
+void Test_CF_ResumeCmd_InvalidChannel(void)
 {
     CF_ResumeCmd_t utbuf;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Invalid channel */
-    utbuf.Payload.chan_num = CF_NUM_CHANNELS;
+    utbuf.Payload.chan_num = UT_CFDP_INVALID_CHANNEL;
 
     /* Act */
     CF_ResumeCmd(&utbuf);
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_TSN_CHAN_INVALID_ERR_EID);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[1], CF_CMD_SUSPRES_CHAN_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_SUSPRES_CHAN_ERR_EID);
 
     /* Assert incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
 }
 
-/*******************************************************************************
-**
-**  CF_Cancel_TxnCmd tests
-**
-*******************************************************************************/
-
-void Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t(void)
+void Test_CF_ResumeCmd_SuccessSame(void)
 {
-    /* Arrange */
-    CF_Transaction_t  txn;
-    CF_Transaction_t *arg_t       = &txn;
-    void             *arg_ignored = NULL;
-    CF_Transaction_t *context_CF_CFDP_CancelTransaction;
+    CF_ResumeCmd_t   utbuf;
+    CF_Transaction_t txn;
 
-    UT_SetDataBuffer(UT_KEY(CF_CFDP_CancelTransaction),
-                     &context_CF_CFDP_CancelTransaction,
-                     sizeof(context_CF_CFDP_CancelTransaction),
-                     false);
+    memset(&txn, 0, sizeof(txn));
+    memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+
+    /* This needs to invoke the callback thru CF_TraverseAllTransactions */
+    UT_SetHandlerFunction(UT_KEY(CF_TraverseAllTransactions), UT_AltHandler_CF_TraverseAllTransactions_InvokeCb, &txn);
 
     /* Act */
-    CF_Cancel_TxnCmd(arg_t, arg_ignored);
+    CF_ResumeCmd(&utbuf);
 
     /* Assert */
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_CancelTransaction, arg_t);
+    UtAssert_STUB_COUNT(CF_TraverseAllTransactions, 1);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_SUSPRES_SAME_INF_EID);
 }
 
 /*******************************************************************************
@@ -1333,12 +802,15 @@ void Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t(void)
 
 void Test_CF_CancelCmd_Success(void)
 {
-    CF_CancelCmd_t utbuf;
+    CF_CancelCmd_t   utbuf;
+    CF_Transaction_t txn;
 
+    memset(&txn, 0, sizeof(txn));
     memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
 
-    /* Nominally returns number of transactions affected, cause failure */
-    UT_SetDefaultReturnValue(UT_KEY(CF_TraverseAllTransactions), 1);
+    /* This needs to invoke the callback thru CF_TraverseAllTransactions */
+    UT_SetHandlerFunction(UT_KEY(CF_TraverseAllTransactions), UT_AltHandler_CF_TraverseAllTransactions_InvokeCb, &txn);
 
     /* Act */
     CF_CancelCmd(&utbuf);
@@ -1350,14 +822,37 @@ void Test_CF_CancelCmd_Success(void)
     UT_CF_AssertEventID(CF_CMD_CANCEL_INF_EID);
 }
 
+void Test_CF_CancelCmd_SuccessSingleTxn(void)
+{
+    CF_CancelCmd_t   utbuf;
+    CF_Transaction_t txn;
+
+    memset(&txn, 0, sizeof(txn));
+    memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num   = UT_CFDP_CHANNEL;
+    utbuf.Payload.use_ts_eid = true;
+
+    /* This needs to return a valid pointer from CF_FindTransactionBySequenceNumber */
+    UT_SetHandlerFunction(UT_KEY(CF_FindTransactionBySequenceNumber),
+                          UT_AltHandler_CF_FindTransactionBySequenceNumber,
+                          &txn);
+
+    /* Act */
+    CF_CancelCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CF_FindTransactionBySequenceNumber, 1);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_CANCEL_INF_EID);
+}
+
 void Test_CF_CancelCmd_Failure(void)
 {
     CF_CancelCmd_t utbuf;
 
     memset(&utbuf, 0, sizeof(utbuf));
-
-    /* Nominally returns number of transactions affected, cause failure */
-    UT_SetDefaultReturnValue(UT_KEY(CF_TraverseAllTransactions), 0);
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
 
     /* Act */
     CF_CancelCmd(&utbuf);
@@ -1368,24 +863,27 @@ void Test_CF_CancelCmd_Failure(void)
     UT_CF_AssertEventID(CF_CMD_CANCEL_CHAN_ERR_EID);
 }
 
-/*******************************************************************************
-**
-**  CF_Abandon_TxnCmd tests
-**
-*******************************************************************************/
-
-void Test_CF_Abandon_TxnCmd_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void)
+void Test_CF_CancelCmd_FailSingleTxn(void)
 {
-    /* Arrange */
-    CF_Transaction_t  txn;
-    CF_Transaction_t *arg_t       = &txn;
-    void             *arg_ignored = NULL;
+    CF_CancelCmd_t   utbuf;
+    CF_Transaction_t txn;
+
+    memset(&txn, 0, sizeof(txn));
+    memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num   = UT_CFDP_CHANNEL;
+    utbuf.Payload.use_ts_eid = true;
+
+    /* Note: default behavior of CF_FindTransactionBySequenceNumber() is to return NULL */
 
     /* Act */
-    CF_Abandon_TxnCmd(arg_t, arg_ignored);
+    CF_CancelCmd(&utbuf);
 
     /* Assert */
-    UtAssert_STUB_COUNT(CF_CFDP_FinishTransaction, 1);
+    UtAssert_STUB_COUNT(CF_FindTransactionBySequenceNumber, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+    UT_CF_AssertEventID(CF_CMD_TRANS_NOT_FOUND_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_CANCEL_CHAN_ERR_EID);
 }
 
 /*******************************************************************************
@@ -1396,12 +894,15 @@ void Test_CF_Abandon_TxnCmd_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0(void
 
 void Test_CF_AbandonCmd_Success(void)
 {
-    CF_AbandonCmd_t utbuf;
+    CF_AbandonCmd_t  utbuf;
+    CF_Transaction_t txn;
 
+    memset(&txn, 0, sizeof(txn));
     memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
 
-    /* Nominally returns number of transactions affected, cause failure */
-    UT_SetDefaultReturnValue(UT_KEY(CF_TraverseAllTransactions), 1);
+    /* This needs to invoke the callback thru CF_TraverseAllTransactions */
+    UT_SetHandlerFunction(UT_KEY(CF_TraverseAllTransactions), UT_AltHandler_CF_TraverseAllTransactions_InvokeCb, &txn);
 
     /* Act */
     CF_AbandonCmd(&utbuf);
@@ -1413,11 +914,37 @@ void Test_CF_AbandonCmd_Success(void)
     UT_CF_AssertEventID(CF_CMD_ABANDON_INF_EID);
 }
 
+void Test_CF_AbandonCmd_SuccessSingleTxn(void)
+{
+    CF_AbandonCmd_t  utbuf;
+    CF_Transaction_t txn;
+
+    memset(&txn, 0, sizeof(txn));
+    memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num   = UT_CFDP_CHANNEL;
+    utbuf.Payload.use_ts_eid = true;
+
+    /* This needs to return a valid pointer from CF_FindTransactionBySequenceNumber */
+    UT_SetHandlerFunction(UT_KEY(CF_FindTransactionBySequenceNumber),
+                          UT_AltHandler_CF_FindTransactionBySequenceNumber,
+                          &txn);
+
+    /* Act */
+    CF_AbandonCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CF_FindTransactionBySequenceNumber, 1);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_ABANDON_INF_EID);
+}
+
 void Test_CF_AbandonCmd_Failure(void)
 {
     CF_AbandonCmd_t utbuf;
 
     memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
 
     /* Nominally returns number of transactions acted on, force failure */
     UT_SetDefaultReturnValue(UT_KEY(CF_TraverseAllTransactions), 0);
@@ -1431,31 +958,27 @@ void Test_CF_AbandonCmd_Failure(void)
     UT_CF_AssertEventID(CF_CMD_ABANDON_CHAN_ERR_EID);
 }
 
-/*******************************************************************************
-**
-**  CF_DoEnableDisableDequeue tests
-**
-*******************************************************************************/
-
-void Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg(void)
+void Test_CF_AbandonCmd_FailSingleTxn(void)
 {
-    /* Arrange */
-    CF_ChannelSelect_t       chan_num = Any_cf_chan_num();
-    CF_ChanAction_BoolArg_t  context;
-    CF_ChanAction_BoolArg_t *arg_context = &context;
-    CF_Channel_t            *chan        = CF_GetChannelPtr(chan_num);
+    CF_AbandonCmd_t  utbuf;
+    CF_Transaction_t txn;
 
-    context.barg = Any_bool_arg_t_barg();
+    memset(&txn, 0, sizeof(txn));
+    memset(&utbuf, 0, sizeof(utbuf));
+    utbuf.Payload.chan_num   = UT_CFDP_CHANNEL;
+    utbuf.Payload.use_ts_eid = true;
+
+    /* Note: default behavior of CF_FindTransactionBySequenceNumber() is to return NULL */
 
     /* Act */
-    CF_DoEnableDisableDequeue(chan, arg_context);
+    CF_AbandonCmd(&utbuf);
 
     /* Assert */
-    UtAssert_True(chan->config.dequeue_enabled == context.barg,
-                  "Channel %u dequeue_enabled is %u and should be %u (context->barg)",
-                  CF_ChannelSelect_AsInt(chan_num),
-                  chan->config.dequeue_enabled,
-                  context.barg);
+    UtAssert_STUB_COUNT(CF_FindTransactionBySequenceNumber, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+    UT_CF_AssertEventID(CF_CMD_TRANS_NOT_FOUND_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_ABANDON_CHAN_ERR_EID);
 }
 
 /*******************************************************************************
@@ -1511,7 +1034,7 @@ void Test_CF_EnableDequeueCmd_Failure(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    data->ChannelSelect = CF_NUM_CHANNELS + 1;
+    data->ChannelSelect = UT_CFDP_INVALID_CHANNEL;
 
     CF_AppData.counters.err = 0;
 
@@ -1574,7 +1097,7 @@ void Test_CF_DisableDequeueCmd_Failure(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* Arrange unstubbable: CF_DoChanAction */
-    data->ChannelSelect = CF_NUM_CHANNELS + 1;
+    data->ChannelSelect = UT_CFDP_INVALID_CHANNEL;
 
     CF_AppData.counters.err = 0;
 
@@ -1589,149 +1112,47 @@ void Test_CF_DisableDequeueCmd_Failure(void)
 
 /*******************************************************************************
 **
-**  CF_DoEnableDisablePolldir tests
-**
-*******************************************************************************/
-
-void Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannelEnabledTo_context_barg(void)
-{
-    /* Arrange */
-    CF_PollDirSelect_Payload_t  utbuf;
-    CF_PollDirSelect_Payload_t *data = &utbuf;
-    CF_ChanAction_BoolMsgArg_t  context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
-    CF_ChannelSelect_t          chan_num    = Any_cf_chan_num();
-    uint8                       expected_enabled;
-    uint8                       current_polldir = 0;
-    CF_ChanAction_Status_t      local_result;
-    CF_Channel_t               *chan = CF_GetChannelPtr(chan_num);
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->PollDirIndx = CF_ALL_POLLDIRS;
-
-    context.opaque_data = data;
-    context.barg        = Any_bool_arg_t_barg();
-    expected_enabled    = context.barg;
-
-    /* Act */
-    local_result = CF_DoEnableDisablePolldir(chan, arg_context);
-
-    /* Assert */
-    for (current_polldir = 0; current_polldir < CF_MAX_POLLING_DIR_PER_CHAN; ++current_polldir)
-    {
-        UtAssert_True(chan->config.polldir[current_polldir].enabled == expected_enabled,
-                      "Channel %u Polldir %u set to %u and should be %u (context->barg)",
-                      CF_ChannelSelect_AsInt(chan_num),
-                      current_polldir,
-                      chan->config.polldir[current_polldir].enabled,
-                      expected_enabled);
-    }
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t          chan_num = Any_cf_chan_num();
-    uint8                       polldir  = Any_cf_polldir();
-    CF_PollDirSelect_Payload_t  utbuf;
-    CF_PollDirSelect_Payload_t *data = &utbuf;
-    CF_ChanAction_BoolMsgArg_t  context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
-    uint8                       expected_enabled;
-    CF_ChanAction_Status_t      local_result;
-    CF_Channel_t               *chan = CF_GetChannelPtr(chan_num);
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->PollDirIndx = polldir;
-
-    context.opaque_data = data;
-    context.barg        = Any_bool_arg_t_barg();
-    expected_enabled    = context.barg;
-
-    /* Act */
-    local_result = CF_DoEnableDisablePolldir(chan, arg_context);
-
-    /* Assert */
-    UtAssert_True(chan->config.polldir[polldir].enabled == expected_enabled,
-                  "Channel %u Polldir %u set to %u and should be %u (context->barg)",
-                  CF_ChannelSelect_AsInt(chan_num),
-                  polldir,
-                  chan->config.polldir[polldir].enabled,
-                  expected_enabled);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t          chan_num = Any_cf_chan_num();
-    CF_PollDirSelect_Payload_t  utbuf;
-    CF_PollDirSelect_Payload_t *data = &utbuf;
-    CF_ChanAction_BoolMsgArg_t  context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
-    CF_ChanAction_Status_t      local_result;
-    CF_Channel_t               *chan = CF_GetChannelPtr(chan_num);
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->PollDirIndx = CF_MAX_POLLING_DIR_PER_CHAN;
-
-    context.opaque_data = data;
-    context.barg        = Any_bool_arg_t_barg();
-
-    /* Act */
-    local_result = CF_DoEnableDisablePolldir(chan, arg_context);
-
-    /* Assert */
-    UT_CF_AssertEventID(CF_CMD_POLLDIR_INVALID_ERR_EID);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-}
-
-void Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t          chan_num = Any_cf_chan_num();
-    CF_PollDirSelect_Payload_t  utbuf;
-    CF_PollDirSelect_Payload_t *data = &utbuf;
-    CF_ChanAction_BoolMsgArg_t  context;
-    CF_ChanAction_BoolMsgArg_t *arg_context = &context;
-    CF_ChanAction_Status_t      local_result;
-    CF_Channel_t               *chan = CF_GetChannelPtr(chan_num);
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->PollDirIndx = CF_MAX_POLLING_DIR_PER_CHAN;
-
-    context.opaque_data = data;
-    context.barg        = Any_bool_arg_t_barg();
-
-    /* Act */
-    local_result = CF_DoEnableDisablePolldir(chan, arg_context);
-
-    /* Assert */
-    UT_CF_AssertEventID(CF_CMD_POLLDIR_INVALID_ERR_EID);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-}
-
-/*******************************************************************************
-**
 **  CF_EnablePolldirCmd tests
 **
 *******************************************************************************/
 
-void Test_CF_EnablePolldirCmd_SuccessWhenActionSuccess(void)
+void Test_CF_EnablePolldirCmd_InvalidChannel(void)
 {
     /* Arrange */
-    CF_ChannelSelect_t chan_num = Any_cf_chan_num();
-    uint8              polldir  = Any_cf_polldir();
-    CF_Channel_t      *chan     = CF_GetChannelPtr(chan_num);
+    CF_Channel_t       *chan = UT_CFDP_CHANNEL_PTR;
+    CF_LocalPdConfig_t *PdConfig;
+
+    CF_EnableDirPollingCmd_t utbuf;
+
+    CF_PollDirSelect_Payload_t *data                   = &utbuf.Payload;
+    uint16                      initial_hk_err_counter = Any_uint16();
+
+    memset(&utbuf, 0, sizeof(utbuf));
+    PdConfig = &chan->config.polldir[CF_MAX_POLLING_DIR_PER_CHAN - 1];
+
+    PdConfig->enabled   = false;
+    data->ChannelSelect = UT_CFDP_INVALID_CHANNEL;
+    data->PollDirIndx   = CF_ALL_POLLDIRS;
+
+    CF_AppData.counters.err = initial_hk_err_counter;
+
+    /* Act */
+    CF_EnableDirPollingCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_BOOL_FALSE(PdConfig->enabled);
+    UtAssert_UINT16_EQ(CF_AppData.counters.err, initial_hk_err_counter + 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_ENABLE_POLLDIR_ERR_EID);
+}
+
+void Test_CF_EnablePolldirCmd_AllPollDirs(void)
+{
+    /* Arrange */
+    CF_Channel_t       *chan = UT_CFDP_CHANNEL_PTR;
+    CF_LocalPdConfig_t *PdConfig;
 
     CF_EnableDirPollingCmd_t utbuf;
 
@@ -1739,6 +1160,40 @@ void Test_CF_EnablePolldirCmd_SuccessWhenActionSuccess(void)
     uint16                      initial_hk_cmd_counter = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
+    PdConfig = &chan->config.polldir[CF_MAX_POLLING_DIR_PER_CHAN - 1];
+
+    PdConfig->enabled   = false;
+    data->ChannelSelect = UT_CFDP_CHANNEL;
+    data->PollDirIndx   = CF_ALL_POLLDIRS;
+
+    CF_AppData.counters.cmd = initial_hk_cmd_counter;
+
+    /* Act */
+    CF_EnableDirPollingCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_BOOL_TRUE(PdConfig->enabled);
+    UtAssert_UINT16_EQ(CF_AppData.counters.cmd, initial_hk_cmd_counter + 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_ENABLE_POLLDIR_INF_EID);
+}
+
+void Test_CF_EnablePolldirCmd_SuccessWhenActionSuccess(void)
+{
+    /* Arrange */
+    CF_ChannelSelect_t  chan_num = Any_cf_chan_num();
+    uint8               polldir  = Any_cf_polldir();
+    CF_Channel_t       *chan     = CF_GetChannelPtr(chan_num);
+    CF_LocalPdConfig_t *PdConfig;
+
+    CF_EnableDirPollingCmd_t utbuf;
+
+    CF_PollDirSelect_Payload_t *data                   = &utbuf.Payload;
+    uint16                      initial_hk_cmd_counter = Any_uint16();
+
+    memset(&utbuf, 0, sizeof(utbuf));
+    PdConfig = &chan->config.polldir[polldir - 1];
 
     /* Arrange unstubbable: CF_DoChanAction */
     data->ChannelSelect = chan_num;
@@ -1753,11 +1208,11 @@ void Test_CF_EnablePolldirCmd_SuccessWhenActionSuccess(void)
 
     /* Assert */
     /* Assert for CF_DoEnableDisablePolldir */
-    UtAssert_True(chan->config.polldir[polldir].enabled == 1,
+    UtAssert_True(PdConfig->enabled == 1,
                   "Channel %u Polldir %u set to %u and should be 1 (context->barg)",
                   CF_ChannelSelect_AsInt(chan_num),
                   polldir,
-                  chan->config.polldir[polldir].enabled);
+                  PdConfig->enabled);
     /* Assert for incremented counter */
     UtAssert_True(CF_AppData.counters.cmd == (uint16)(initial_hk_cmd_counter + 1),
                   "CF_AppData.counters.cmd is %d and should be 1 more than %d",
@@ -1770,7 +1225,7 @@ void Test_CF_EnablePolldirCmd_FailWhenActionFail(void)
 {
     /* Arrange */
     CF_ChannelSelect_t chan_num      = Any_cf_chan_num();
-    uint8              error_polldir = Any_uint8_BetweenInclusive(CF_MAX_POLLING_DIR_PER_CHAN, CF_ALL_CHANNELS - 1);
+    uint8              error_polldir = 1 + CF_MAX_POLLING_DIR_PER_CHAN;
 
     CF_EnableDirPollingCmd_t    utbuf;
     CF_PollDirSelect_Payload_t *data                   = &utbuf.Payload;
@@ -1804,6 +1259,68 @@ void Test_CF_EnablePolldirCmd_FailWhenActionFail(void)
 **  CF_DisablePolldirCmd tests
 **
 *******************************************************************************/
+
+void Test_CF_DisablePolldirCmd_InvalidChannel(void)
+{
+    /* Arrange */
+    CF_Channel_t       *chan = UT_CFDP_CHANNEL_PTR;
+    CF_LocalPdConfig_t *PdConfig;
+
+    CF_DisableDirPollingCmd_t utbuf;
+
+    CF_PollDirSelect_Payload_t *data                   = &utbuf.Payload;
+    uint16                      initial_hk_err_counter = Any_uint16();
+
+    memset(&utbuf, 0, sizeof(utbuf));
+    PdConfig = &chan->config.polldir[CF_MAX_POLLING_DIR_PER_CHAN - 1];
+
+    PdConfig->enabled   = true;
+    data->ChannelSelect = UT_CFDP_INVALID_CHANNEL;
+    data->PollDirIndx   = CF_ALL_POLLDIRS;
+
+    CF_AppData.counters.err = initial_hk_err_counter;
+
+    /* Act */
+    CF_DisableDirPollingCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_BOOL_TRUE(PdConfig->enabled);
+    UtAssert_UINT16_EQ(CF_AppData.counters.err, initial_hk_err_counter + 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_DISABLE_POLLDIR_ERR_EID);
+}
+
+void Test_CF_DisablePolldirCmd_AllPollDirs(void)
+{
+    /* Arrange */
+    CF_Channel_t       *chan = UT_CFDP_CHANNEL_PTR;
+    CF_LocalPdConfig_t *PdConfig;
+
+    CF_DisableDirPollingCmd_t utbuf;
+
+    CF_PollDirSelect_Payload_t *data                   = &utbuf.Payload;
+    uint16                      initial_hk_cmd_counter = Any_uint16();
+
+    memset(&utbuf, 0, sizeof(utbuf));
+    PdConfig = &chan->config.polldir[CF_MAX_POLLING_DIR_PER_CHAN - 1];
+
+    PdConfig->enabled   = true;
+    data->ChannelSelect = UT_CFDP_CHANNEL;
+    data->PollDirIndx   = CF_ALL_POLLDIRS;
+
+    CF_AppData.counters.cmd = initial_hk_cmd_counter;
+
+    /* Act */
+    CF_DisableDirPollingCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_BOOL_FALSE(PdConfig->enabled);
+    UtAssert_UINT16_EQ(CF_AppData.counters.cmd, initial_hk_cmd_counter + 1);
+
+    UT_CF_AssertEventID(CF_CMD_DISABLE_POLLDIR_INF_EID);
+}
 
 void Test_CF_DisablePolldirCmd_SuccessWhenActionSuccess(void)
 {
@@ -1848,7 +1365,7 @@ void Test_CF_DisablePolldirCmd_FailWhenActionFail(void)
 {
     /* Arrange */
     CF_ChannelSelect_t chan_num      = Any_cf_chan_num();
-    uint8              error_polldir = Any_uint8_BetweenInclusive(CF_MAX_POLLING_DIR_PER_CHAN, CF_ALL_CHANNELS - 1);
+    uint8              error_polldir = 1 + CF_MAX_POLLING_DIR_PER_CHAN;
 
     CF_DisableDirPollingCmd_t   utbuf;
     CF_PollDirSelect_Payload_t *data                   = &utbuf.Payload;
@@ -1879,241 +1396,39 @@ void Test_CF_DisablePolldirCmd_FailWhenActionFail(void)
 
 /*******************************************************************************
 **
-**  CF_PurgeHistory tests
-**
-*******************************************************************************/
-
-void Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT(void)
-{
-    /* Arrange */
-    CF_History_t                   history;
-    CF_CListNode_t                *arg_n = &history.cl_node;
-    CF_Channel_t                   chan;
-    CF_Channel_t                  *arg_c = &chan;
-    CF_CListTraverse_Status_t      local_result;
-    CF_CFDP_ResetHistory_context_t context_CF_CFDP_ResetHistory;
-
-    UT_SetDataBuffer(UT_KEY(CF_ResetHistory),
-                     &context_CF_CFDP_ResetHistory,
-                     sizeof(context_CF_CFDP_ResetHistory),
-                     false);
-
-    /* Act */
-    local_result = CF_PurgeHistory(arg_n, arg_c);
-
-    /* Assert */
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetHistory.chan, arg_c);
-    UtAssert_ADDRESS_EQ(context_CF_CFDP_ResetHistory.history, &history);
-    UtAssert_True(local_result == CF_CLIST_CONT,
-                  "CF_PurgeHistory returned %d and should be %d (CF_CLIST_CONT)",
-                  local_result,
-                  CF_CLIST_CONT);
-}
-
-/*******************************************************************************
-**
-**  CF_PurgeTransaction tests
-**
-*******************************************************************************/
-
-void Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT(void)
-{
-    /* Arrange */
-    CF_Transaction_t txn;
-    CF_CListNode_t  *arg_n = &txn.cl_node;
-    int              ignored;
-    void            *arg_ignored = &ignored;
-
-    /* Act */
-    UtAssert_INT32_EQ(CF_PurgeTransaction(arg_n, arg_ignored), CF_CLIST_CONT);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CF_CFDP_FinishTransaction, 1);
-}
-
-/*******************************************************************************
-**
-**  CF_DoPurgeQueue tests
-**
-*******************************************************************************/
-
-void Test_CF_DoPurgeQueue_PendOnly(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t                  chan_num = Any_cf_chan_num();
-    CF_QueueSelect_Payload_t            utbuf;
-    CF_QueueSelect_Payload_t           *data   = &utbuf;
-    CF_ChanAction_MsgArg_t              msgarg = { data };
-    CF_Channel_t                       *chan   = CF_GetChannelPtr(chan_num);
-    CF_CListNode_t                      start;
-    CF_CListNode_t                     *expected_start = &start;
-    CF_ChanAction_Status_t              local_result;
-    CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse;
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->ChannelSelect = chan_num;
-    data->QueueSelect   = CF_QueueSelect_Pending; /* pend */
-    UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse),
-                          UT_AltHandler_CF_CList_Traverse_POINTER,
-                          &context_CF_CList_Traverse);
-
-    chan->qs[CF_QueueIdx_PEND] = expected_start;
-
-    /* Act */
-    local_result = CF_DoPurgeQueue(chan, &msgarg);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CF_CList_Traverse, 1);
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.start, expected_start);
-    UtAssert_True(context_CF_CList_Traverse.fn == CF_PurgeTransaction,
-                  "context_CF_CList_Traverse.fn ==  CF_PurgeTransaction");
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, NULL);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_DoPurgeQueue_HistoryOnly(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t                  chan_num = Any_cf_chan_num();
-    CF_QueueSelect_Payload_t            utbuf;
-    CF_QueueSelect_Payload_t           *data   = &utbuf;
-    CF_ChanAction_MsgArg_t              msgarg = { data };
-    CF_Channel_t                       *chan   = CF_GetChannelPtr(chan_num);
-    CF_CListNode_t                      start;
-    CF_CListNode_t                     *expected_start = &start;
-    CF_ChanAction_Status_t              local_result;
-    CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse;
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->ChannelSelect = chan_num;
-    data->QueueSelect   = CF_QueueSelect_History; /* history */
-
-    /* set correct context type for CF_CList_Traverse stub */
-    UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse),
-                          UT_AltHandler_CF_CList_Traverse_POINTER,
-                          &context_CF_CList_Traverse);
-
-    chan->qs[CF_QueueIdx_HIST] = expected_start;
-
-    /* Act */
-    local_result = CF_DoPurgeQueue(chan, &msgarg);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CF_CList_Traverse, 1);
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.start, expected_start);
-    UtAssert_True(context_CF_CList_Traverse.fn == (CF_CListFn_t)CF_PurgeHistory,
-                  "context_CF_CList_Traverse.fn ==  (CF_CListFn_t )CF_PurgeHistory");
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse.context, chan);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_DoPurgeQueue_Both(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t                  chan_num = Any_cf_chan_num();
-    CF_QueueSelect_Payload_t            utbuf;
-    CF_QueueSelect_Payload_t           *data   = &utbuf;
-    CF_ChanAction_MsgArg_t              msgarg = { data };
-    CF_Channel_t                       *chan   = CF_GetChannelPtr(chan_num);
-    CF_CListNode_t                      pend_start;
-    CF_CListNode_t                     *expected_pend_start = &pend_start;
-    CF_CListNode_t                      history_start;
-    CF_CListNode_t                     *expected_history_start = &history_start;
-    CF_ChanAction_Status_t              local_result;
-    CF_CList_Traverse_POINTER_context_t context_CF_CList_Traverse[2];
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->ChannelSelect = chan_num;
-    data->QueueSelect   = CF_QueueSelect_All; /* both */
-
-    /* set correct context type for CF_CList_Traverse stub */
-    /* this must use data buffer hack to pass multiple contexts */
-    UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_POINTER, NULL);
-    UT_SetDataBuffer(UT_KEY(CF_CList_Traverse), context_CF_CList_Traverse, sizeof(context_CF_CList_Traverse), false);
-
-    chan->qs[CF_QueueIdx_PEND] = expected_pend_start;
-    chan->qs[CF_QueueIdx_HIST] = expected_history_start;
-
-    /* Act */
-    local_result = CF_DoPurgeQueue(chan, &msgarg);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CF_CList_Traverse, 2);
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[0].start, expected_pend_start);
-    UtAssert_True(context_CF_CList_Traverse[0].fn == CF_PurgeTransaction,
-                  "context_CF_CList_Traverse[0].fn ==  CF_PurgeTransaction");
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[0].context, NULL);
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[1].start, expected_history_start);
-    UtAssert_True(context_CF_CList_Traverse[1].fn == (CF_CListFn_t)CF_PurgeHistory,
-                  "context_CF_CList_Traverse[1].fn ==  (CF_CListFn_t )CF_PurgeHistory");
-    UtAssert_ADDRESS_EQ(context_CF_CList_Traverse[1].context, chan);
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t        chan_num = Any_cf_chan_num();
-    CF_QueueSelect_Payload_t  utbuf;
-    CF_QueueSelect_Payload_t *data   = &utbuf;
-    CF_ChanAction_MsgArg_t    msgarg = { data };
-    CF_ChanAction_Status_t    local_result;
-    CF_Channel_t             *chan = CF_GetChannelPtr(chan_num);
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->ChannelSelect = chan_num;
-    data->QueueSelect   = 10; /* Invalid */
-
-    /* Act */
-    local_result = CF_DoPurgeQueue(chan, &msgarg);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_PURGE_ARG_ERR_EID);
-    UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
-}
-
-void Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1(void)
-{
-    /* Arrange */
-    CF_ChannelSelect_t        chan_num = Any_cf_chan_num();
-    CF_QueueSelect_Payload_t  utbuf;
-    CF_QueueSelect_Payload_t *data   = &utbuf;
-    CF_ChanAction_MsgArg_t    msgarg = { data };
-    CF_ChanAction_Status_t    local_result;
-    CF_Channel_t             *chan = CF_GetChannelPtr(chan_num);
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    data->ChannelSelect = chan_num;
-    data->QueueSelect   = Any_uint8_GreaterThan(CF_QueueSelect_All);
-
-    /* Act */
-    local_result = CF_DoPurgeQueue(chan, &msgarg);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_PURGE_ARG_ERR_EID);
-    UtAssert_STUB_COUNT(CF_CList_Traverse, 0);
-}
-
-/*******************************************************************************
-**
 **  CF_PurgeQueueCmd tests
 **
 *******************************************************************************/
+
+void Test_CF_PurgeQueueCmd_InvalidChannel(void)
+{
+    /* Arrange */
+    CF_PurgeQueueCmd_t        utbuf;
+    CF_QueueSelect_Payload_t *data                   = &utbuf.Payload;
+    uint16                    initial_hk_err_counter = Any_uint16();
+
+    memset(&utbuf, 0, sizeof(utbuf));
+
+    data->ChannelSelect = UT_CFDP_INVALID_CHANNEL;
+
+    CF_AppData.counters.err = initial_hk_err_counter;
+
+    /* Act */
+    CF_PurgeQueueCmd(&utbuf);
+
+    /* Assert */
+    UtAssert_UINT16_EQ(CF_AppData.counters.err, initial_hk_err_counter + 1);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UT_CF_AssertEventID(CF_CMD_PURGE_QUEUE_ERR_EID);
+}
 
 void Test_CF_PurgeQueueCmd_FailWhenActionFail(void)
 {
     /* Arrange */
     CF_ChannelSelect_t        chan_num    = Any_cf_chan_num();
-    uint8                     error_purge = CF_QueueSelect_All + 1; /* Shortest return from CF_DoPurgeQueue */
+    uint8                     error_purge = 0xAA; /* Shortest return from CF_DoPurgeQueue */
     CF_PurgeQueueCmd_t        utbuf;
     CF_QueueSelect_Payload_t *data                   = &utbuf.Payload;
     uint16                    initial_hk_err_counter = Any_uint16();
@@ -2138,6 +1453,7 @@ void Test_CF_PurgeQueueCmd_FailWhenActionFail(void)
                   "CF_AppData.counters.err is %d and should be 1 more than %d",
                   CF_AppData.counters.err,
                   initial_hk_err_counter);
+    UT_CF_AssertEventID(CF_CMD_PURGE_ARG_ERR_EID);
     UT_CF_AssertEventID(CF_CMD_PURGE_QUEUE_ERR_EID);
 }
 
@@ -2154,6 +1470,9 @@ void Test_CF_PurgeQueueCmd_SuccessWhenActionSuccess(void)
     data->ChannelSelect = chan_num;
 
     CF_AppData.counters.cmd = 0;
+
+    /* this causes the callback to be invoked */
+    UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_InvokeCb, NULL);
 
     /* Act */
     CF_PurgeQueueCmd(&utbuf);
@@ -2182,7 +1501,7 @@ void Test_CF_WriteQueueCmd_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* invalid channel */
-    wq->chan = CF_NUM_CHANNELS;
+    wq->chan_num = UT_CFDP_INVALID_CHANNEL;
 
     CF_AppData.counters.err = initial_hk_err_counter;
 
@@ -2191,32 +1510,7 @@ void Test_CF_WriteQueueCmd_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectComman
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_CHAN_ERR_EID);
-    /* Assert for incremented counter */
-    UtAssert_UINT32_EQ(CF_AppData.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
-}
-
-void Test_CF_WriteQueueCmd_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand(void)
-{
-    /* Arrange */
-    CF_WriteQueueCmd_t       utbuf;
-    CF_WriteQueue_Payload_t *wq                     = &utbuf.Payload;
-    uint16                   initial_hk_err_counter = Any_uint16();
-
-    memset(&utbuf, 0, sizeof(utbuf));
-
-    /* invalid channel */
-    wq->chan = CF_NUM_CHANNELS + 1;
-
-    CF_AppData.counters.err = initial_hk_err_counter;
-
-    /* Act */
-    CF_WriteQueueCmd(&utbuf);
-
-    /* Assert */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UT_CF_AssertEventID(CF_CMD_WQ_CHAN_ERR_EID);
-
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.err, (initial_hk_err_counter + 1) & 0xFFFF);
 }
@@ -2231,11 +1525,11 @@ void Test_CF_WriteQueueCmd_WhenUpAndPendingQueueSendEventAndRejectCommand(void)
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* invalid combination up direction, pending queue */
-    wq->type  = CF_Type_up;
-    wq->queue = CF_QueueSelect_Pending;
+    wq->dir_type = CF_DirectionType_up;
+    wq->queue    = CF_QueueSelect_Pending;
 
     CF_AppData.counters.err = initial_hk_err_counter;
 
@@ -2262,11 +1556,11 @@ void Test_CF_WriteQueueCmd_When_CF_WrappedCreat_Fails_type_Is_type_up_And_queue_
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination up direction, NOT pending queue */
-    wq->type  = CF_Type_up;
-    wq->queue = Any_queue_Except_q_pend(); /* 0 is q_pend */
+    wq->dir_type = CF_DirectionType_up;
+    wq->queue    = CF_QueueSelect_Active;
 
     /* invalid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
@@ -2305,11 +1599,11 @@ void Test_CF_WriteQueueCmd_When_CF_WrappedCreat_Fails_type_IsNot_type_up_And_que
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination down direction, pending queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_Pending;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_Pending;
 
     /* invalid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
@@ -2343,7 +1637,6 @@ void Test_CF_WriteQueueCmd_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     uint16                               initial_hk_err_counter                   = Any_uint16();
@@ -2351,21 +1644,14 @@ void Test_CF_WriteQueueCmd_When_wq_IsAllAnd_queue_IsAll_fd_Is_0_Call_CF_WrappedC
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_all;
-    wq->queue = CF_QueueSelect_All;
+    wq->dir_type = CF_DirectionType_all;
+    wq->queue    = CF_QueueSelect_All;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = 0;
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile),
@@ -2395,7 +1681,6 @@ void Test_CF_WriteQueueCmd_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
@@ -2404,21 +1689,14 @@ void Test_CF_WriteQueueCmd_When_CF_WriteTxnQueueDataToFile_FailsAnd_wq_IsUpAnd_q
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_up;
-    wq->queue = CF_QueueSelect_Active;
+    wq->dir_type = CF_DirectionType_up;
+    wq->queue    = CF_QueueSelect_Active;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile),
@@ -2450,7 +1728,6 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t           context_CF_WrappedOpenCreate;
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
     int32                                    context_CF_WrappedClose_fd;
@@ -2459,21 +1736,14 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsUpA
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_up;
-    wq->queue = CF_QueueSelect_History;
+    wq->dir_type = CF_DirectionType_up;
+    wq->queue    = CF_QueueSelect_History;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* invalid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDataBuffer(UT_KEY(CF_WriteHistoryQueueDataToFile),
@@ -2505,7 +1775,6 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
@@ -2514,21 +1783,14 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryDataToFile_FailsOnFirstCallAnd_wq
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_Active;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_Active;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile),
@@ -2560,7 +1822,6 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t       context_CF_WrappedOpenCreate;
     CF_WriteTxnQueueDataToFile_context_t context_CF_WriteTxnQueueDataToFile;
     int32                                forced_return_CF_WriteTxnQueueDataToFile = Any_int32_Except(0);
     int32                                context_CF_WrappedClose_fd;
@@ -2569,21 +1830,14 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_Pending;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_Pending;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* invalid result from CF_WriteTxnQueueDataToFile */
     UT_SetDataBuffer(UT_KEY(CF_WriteTxnQueueDataToFile),
@@ -2615,7 +1869,6 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t           context_CF_WrappedOpenCreate;
     CF_WriteHistoryQueueDataToFile_context_t context_CF_WriteHistoryQueueDataToFile;
     int32                                    forced_return_CF_WriteHistoryQueueDataToFile = Any_int32_Except(0);
     int32                                    context_CF_WrappedClose_fd;
@@ -2624,21 +1877,14 @@ void Test_CF_WriteQueueCmd_When_CF_WriteHistoryQueueDataToFile_FailsAnd_wq_IsDow
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_History;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_History;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* invalid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDataBuffer(UT_KEY(CF_WriteHistoryQueueDataToFile),
@@ -2669,29 +1915,21 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_All(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
-    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile     = 0;
+    int32  forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_all;
-    wq->queue = CF_QueueSelect_All;
+    wq->dir_type = CF_DirectionType_all;
+    wq->queue    = CF_QueueSelect_All;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -2709,7 +1947,7 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -2720,28 +1958,20 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_History(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    int32  forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_all;
-    wq->queue = CF_QueueSelect_History;
+    wq->dir_type = CF_DirectionType_all;
+    wq->queue    = CF_QueueSelect_History;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
@@ -2756,7 +1986,7 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -2767,28 +1997,20 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_Active(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_all;
-    wq->queue = CF_QueueSelect_Active;
+    wq->dir_type = CF_DirectionType_all;
+    wq->queue    = CF_QueueSelect_Active;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -2803,7 +2025,7 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -2814,28 +2036,20 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_Pend(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_all;
-    wq->queue = CF_QueueSelect_Pending;
+    wq->dir_type = CF_DirectionType_all;
+    wq->queue    = CF_QueueSelect_Pending;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -2850,7 +2064,7 @@ void Test_CF_WriteQueueCmd_Success_type_AllAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -2861,29 +2075,21 @@ void Test_CF_WriteQueueCmd_Success_type_UpAnd_q_All(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile     = 0;
-    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile     = 0;
+    int32  forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_up;
-    wq->queue = CF_QueueSelect_All;
+    wq->dir_type = CF_DirectionType_up;
+    wq->queue    = CF_QueueSelect_All;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -2901,7 +2107,7 @@ void Test_CF_WriteQueueCmd_Success_type_UpAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -2912,28 +2118,20 @@ void Test_CF_WriteQueueCmd_Success_type_UpAnd_q_History(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteHistoryQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                       = Any_uint16();
+    int32  forced_return_CF_WriteHistoryQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                       = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_up;
-    wq->queue = CF_QueueSelect_History;
+    wq->dir_type = CF_DirectionType_up;
+    wq->queue    = CF_QueueSelect_History;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteHistoryQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteHistoryQueueDataToFile), forced_return_CF_WriteHistoryQueueDataToFile);
@@ -2948,7 +2146,7 @@ void Test_CF_WriteQueueCmd_Success_type_UpAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -2959,28 +2157,20 @@ void Test_CF_WriteQueueCmd_Success_type_UpAnd_q_Active(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_up;
-    wq->queue = CF_QueueSelect_Active;
+    wq->dir_type = CF_DirectionType_up;
+    wq->queue    = CF_QueueSelect_Active;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -2995,7 +2185,7 @@ void Test_CF_WriteQueueCmd_Success_type_UpAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -3008,28 +2198,20 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_All(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_All;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_All;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -3044,7 +2226,7 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_All(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -3055,28 +2237,20 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_History(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_History;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_History;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -3091,7 +2265,7 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_History(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -3102,28 +2276,20 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_Active(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_Active;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_Active;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -3138,7 +2304,7 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_Active(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
 }
@@ -3149,28 +2315,20 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_Pend(void)
     CF_WriteQueueCmd_t       utbuf;
     CF_WriteQueue_Payload_t *wq = &utbuf.Payload;
 
-    CF_WrappedOpenCreate_context_t context_CF_WrappedOpenCreate;
-    int32                          forced_return_CF_WriteTxnQueueDataToFile = 0;
-    uint16                         initial_hk_cmd_counter                   = Any_uint16();
+    int32  forced_return_CF_WriteTxnQueueDataToFile = 0;
+    uint16 initial_hk_cmd_counter                   = Any_uint16();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     /* valid channel */
-    wq->chan = Any_cf_chan_num();
+    wq->chan_num = Any_cf_chan_num();
 
     /* valid combination all direction, all queue */
-    wq->type  = CF_Type_down;
-    wq->queue = CF_QueueSelect_Pending;
+    wq->dir_type = CF_DirectionType_down;
+    wq->queue    = CF_QueueSelect_Pending;
 
     /* valid result from CF_WrappedCreat */
     strncpy(wq->filename, AnyRandomStringOfLettersOfLength(10), 10);
-
-    context_CF_WrappedOpenCreate.forced_return = Any_int_Positive();
-
-    UT_SetDataBuffer(UT_KEY(CF_WrappedOpenCreate),
-                     &context_CF_WrappedOpenCreate,
-                     sizeof(context_CF_WrappedOpenCreate),
-                     false);
 
     /* valid result from CF_WriteTxnQueueDataToFile */
     UT_SetDefaultReturnValue(UT_KEY(CF_WriteTxnQueueDataToFile), forced_return_CF_WriteTxnQueueDataToFile);
@@ -3185,193 +2343,9 @@ void Test_CF_WriteQueueCmd_Success_type_DownAnd_q_Pend(void)
     UtAssert_STUB_COUNT(CF_WriteHistoryQueueDataToFile, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UT_CF_AssertEventID(CF_CMD_WQ_INF_EID);
-    UtAssert_STUB_COUNT(CF_WrappedClose, 0);
+    UtAssert_STUB_COUNT(CF_WrappedClose, 1);
     /* Assert for incremented counter */
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, (initial_hk_cmd_counter + 1) & 0xFFFF);
-}
-
-/*******************************************************************************
-**
-**  CF_ValidateChunkSizeCmd tests
-**
-*******************************************************************************/
-
-void Test_CF_ValidateChunkSizeCmd_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(void)
-{
-    /* Arrange */
-    size_t                 arg_val = sizeof(CF_CFDP_PduFileDataContent_t) + 1;
-    CF_ChanAction_Status_t local_result;
-
-    /* Act */
-    local_result = CF_ValidateChunkSizeCmd(arg_val, NULL);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-}
-
-void Test_CF_ValidateChunkSizeCmd_Any_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1(void)
-{
-    /* Arrange */
-    uint32                 arg_val = Any_uint32_GreaterThan(sizeof(CF_CFDP_PduFileDataContent_t));
-    CF_ChanAction_Status_t local_result;
-
-    /* Act */
-    local_result = CF_ValidateChunkSizeCmd(arg_val, NULL);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-}
-
-void Test_CF_ValidateChunkSizeCmd_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0(void)
-{
-    /* Arrange */
-    size_t                 arg_val = sizeof(CF_CFDP_PduFileDataContent_t);
-    CF_ChanAction_Status_t local_result;
-
-    /* Act */
-    local_result = CF_ValidateChunkSizeCmd(arg_val, NULL);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_ValidateChunkSizeCmd_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0(void)
-{
-    /* Arrange */
-    uint32                 arg_val = Any_uint32_LessThan_or_EqualTo(sizeof(CF_CFDP_PduFileDataContent_t));
-    CF_ChanAction_Status_t local_result;
-
-    /* Act */
-    local_result = CF_ValidateChunkSizeCmd(arg_val, NULL);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-/*******************************************************************************
-**
-**  CF_ValidateMaxOutgoingCmd tests
-**
-*******************************************************************************/
-
-void Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_IsNot_0_Return_0_Success(void)
-{
-    /* Arrange */
-    uint32                 arg_val = Any_uint32_Except(0);
-    CF_ChanAction_Status_t local_result;
-
-    /* Act */
-    local_result = CF_ValidateMaxOutgoingCmd(arg_val, NULL);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_Return_0_Success(void)
-{
-    /* Arrange */
-    uint32             arg_val  = 0;
-    CF_ChannelSelect_t chan_num = Any_cf_chan_num(); /* Any_cf_chan_num used here because value matters to this test */
-    CF_ChanAction_Status_t local_result;
-    CF_Channel_t          *chan = CF_GetChannelPtr(chan_num);
-
-    memset(chan->config.sem_name, (char)Any_uint8_Except(0), 1);
-
-    /* Act */
-    local_result = CF_ValidateMaxOutgoingCmd(arg_val, chan);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_SUCCESS);
-}
-
-void Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail(void)
-{
-    /* Arrange */
-    uint32             arg_val  = 0;
-    CF_ChannelSelect_t chan_num = Any_cf_chan_num(); /* Any_cf_chan_num used here because value matters to this test */
-    CF_ChanAction_Status_t local_result;
-    CF_Channel_t          *chan = CF_GetChannelPtr(chan_num);
-
-    memset(chan->config.sem_name, (char)0, 1);
-
-    /* Act */
-    local_result = CF_ValidateMaxOutgoingCmd(arg_val, chan);
-
-    /* Assert */
-    UtAssert_INT32_EQ(local_result, CF_ChanAction_Status_ERROR);
-}
-
-/*******************************************************************************
-**
-**  CF_GetSetParamCmd tests
-**
-*******************************************************************************/
-
-void Test_CF_GetSetParamCmd(void)
-{
-    /* Test cases for:
-     * void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, CF_Channel_t *chan_ptr);
-     */
-
-    /* Arrange */
-    CF_GetSet_ValueID_t param_id;
-    uint16              expected_count;
-    CF_Engine_t        *engine_ptr = CF_GetEngine();
-    CF_Channel_t       *chan       = UT_CFDP_CHANNEL_PTR;
-
-    memset(&CF_AppData.counters, 0, sizeof(CF_AppData.counters));
-    expected_count = 0;
-
-    /* Nominal: "set" for each parameter */
-    for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
-    {
-        UT_CF_ResetEventCapture();
-        UtAssert_VOIDCALL(CF_GetSetParamCmd(true, param_id, 1 + param_id, UT_CFDP_CHANNEL));
-        UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
-        UtAssert_UINT32_EQ(CF_AppData.counters.cmd, ++expected_count);
-    }
-
-    /* each of the config parameters should have actually been set to a different value */
-    UtAssert_UINT32_EQ(engine_ptr->config.ticks_per_second, 1);
-    UtAssert_UINT32_EQ(engine_ptr->config.rx_crc_calc_bytes_per_wakeup, 2);
-    UtAssert_UINT32_EQ(chan->config.ack_timer_s, 3);
-    UtAssert_UINT32_EQ(chan->config.nak_timer_s, 4);
-    UtAssert_UINT32_EQ(chan->config.inactivity_timer_s, 5);
-    UtAssert_UINT32_EQ(engine_ptr->config.outgoing_file_chunk_size, 6);
-    UtAssert_UINT32_EQ(chan->config.ack_limit, 7);
-    UtAssert_UINT32_EQ(chan->config.nak_limit, 8);
-    UtAssert_UINT32_EQ(engine_ptr->config.local_eid, 9);
-    UtAssert_UINT32_EQ(chan->config.max_outgoing_messages_per_wakeup, 10);
-
-    /* Nominal: "get" for each parameter */
-    for (param_id = 0; param_id < CF_GetSet_ValueID_MAX; ++param_id)
-    {
-        UT_CF_ResetEventCapture();
-        UtAssert_VOIDCALL(CF_GetSetParamCmd(false, param_id, 1, UT_CFDP_CHANNEL));
-        UT_CF_AssertEventID(CF_CMD_GETSET2_INF_EID);
-        UtAssert_UINT32_EQ(CF_AppData.counters.cmd, ++expected_count);
-    }
-
-    /* Bad param ID */
-    UT_CF_ResetEventCapture();
-    UtAssert_VOIDCALL(CF_GetSetParamCmd(false, CF_GetSet_ValueID_MAX, 0, UT_CFDP_CHANNEL));
-    UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
-
-    /* Bad channel ID */
-    UT_CF_ResetEventCapture();
-    UtAssert_VOIDCALL(CF_GetSetParamCmd(false, 0, 0, CF_NUM_CHANNELS + 1));
-    UT_CF_AssertEventID(CF_CMD_GETSET_CHAN_ERR_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.err, 2);
-
-    /* Validation fail */
-    UT_CF_ResetEventCapture();
-    UtAssert_VOIDCALL(CF_GetSetParamCmd(true,
-                                        CF_GetSet_ValueID_outgoing_file_chunk_size,
-                                        100 + sizeof(CF_CFDP_PduFileDataContent_t),
-                                        UT_CFDP_CHANNEL));
-    UT_CF_AssertEventID(CF_CMD_GETSET_VALIDATE_ERR_EID);
-    UtAssert_UINT32_EQ(CF_AppData.counters.err, 3);
 }
 
 /*******************************************************************************
@@ -3380,27 +2354,171 @@ void Test_CF_GetSetParamCmd(void)
 **
 *******************************************************************************/
 
-void Test_CF_SetParamCmd_Call_CF_GetSetParamCmd_With_cmd_key_And_cmd_value(void)
+void Test_CF_SetParamCmd_Nominal(void)
 {
-    /* Arrange */
+    CF_SetParamCmd_t    utbuf;
+    CF_GetSet_ValueID_t param_id;
+    uint16              expected_count;
+    CF_Engine_t        *engine_ptr = CF_GetEngine();
+    CF_Channel_t       *chan       = UT_CFDP_CHANNEL_PTR;
+
+    memset(&utbuf, 0, sizeof(utbuf));
+    expected_count = 0;
+
+    /* Nominal: "set" for each parameter.  0 is reserved, valid values start at 1. */
+    for (param_id = 1; (int)param_id < CF_GetSet_ValueID_MAX; ++param_id)
+    {
+        UT_CF_ResetEventCapture();
+        utbuf.Payload.key      = param_id;
+        utbuf.Payload.value    = 1 + param_id;
+        utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+
+        /* run the function under test */
+        UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+        UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+        UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
+        UtAssert_UINT32_EQ(CF_AppData.counters.cmd, ++expected_count);
+    }
+
+    /* each of the config parameters should have actually been set to a different value */
+    UtAssert_UINT32_EQ(engine_ptr->config.ticks_per_second, 1 + CF_GetSet_ValueID_ticks_per_second);
+    UtAssert_UINT32_EQ(engine_ptr->config.rx_crc_calc_bytes_per_wakeup,
+                       1 + CF_GetSet_ValueID_rx_crc_calc_bytes_per_wakeup);
+    UtAssert_UINT32_EQ(chan->config.ack_timer_s, 1 + CF_GetSet_ValueID_ack_timer_s);
+    UtAssert_UINT32_EQ(chan->config.nak_timer_s, 1 + CF_GetSet_ValueID_nak_timer_s);
+    UtAssert_UINT32_EQ(chan->config.inactivity_timer_s, 1 + CF_GetSet_ValueID_inactivity_timer_s);
+    UtAssert_UINT32_EQ(engine_ptr->config.outgoing_file_chunk_size, 1 + CF_GetSet_ValueID_outgoing_file_chunk_size);
+    UtAssert_UINT32_EQ(chan->config.ack_limit, 1 + CF_GetSet_ValueID_ack_limit);
+    UtAssert_UINT32_EQ(chan->config.nak_limit, 1 + CF_GetSet_ValueID_nak_limit);
+    UtAssert_UINT32_EQ(engine_ptr->config.local_eid, 1 + CF_GetSet_ValueID_local_eid);
+    UtAssert_UINT32_EQ(chan->config.max_outgoing_messages_per_wakeup,
+                       1 + CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup);
+}
+
+void Test_CF_SetParamCmd_BadParam(void)
+{
     CF_SetParamCmd_t utbuf;
-    CF_Engine_t     *engine_ptr = CF_GetEngine();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    utbuf.Payload.key      = CF_GetSet_ValueID_ticks_per_second;
-    utbuf.Payload.value    = 1;
+    /* Bad param ID (0)*/
+    utbuf.Payload.key      = 0;
     utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
 
-    /* Act */
-    CF_SetParamCmd(&utbuf);
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
 
-    /* Assert */
-    UtAssert_UINT32_EQ(engine_ptr->config.ticks_per_second, utbuf.Payload.value);
+    UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+
+    /* Bad param ID (high)*/
+    UT_CF_ResetEventCapture();
+    utbuf.Payload.key      = CF_GetSet_ValueID_MAX;
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_GETSET1_INF_EID);
-    /* Assert for incremented counter() */
+    UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 2);
+
+    /* Bad channel ID */
+    UT_CF_ResetEventCapture();
+    utbuf.Payload.key      = 1;
+    utbuf.Payload.chan_num = UT_CFDP_INVALID_CHANNEL;
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 3);
+}
+
+void Test_CF_SetParamCmd_ValidateChunkSize(void)
+{
+    CF_SetParamCmd_t utbuf;
+
+    memset(&utbuf, 0, sizeof(utbuf));
+
+    /* Validation fail, chunk size 0 */
+    utbuf.Payload.key      = CF_GetSet_ValueID_outgoing_file_chunk_size;
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+    utbuf.Payload.value    = 0;
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_GETSET_VALIDATE_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 0);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+
+    /* Validation fail, chunk size too high */
+    UT_CF_ResetEventCapture();
+    utbuf.Payload.key      = CF_GetSet_ValueID_outgoing_file_chunk_size;
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+    utbuf.Payload.value    = 100 + sizeof(CF_CFDP_PduFileDataContent_t);
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_GETSET_VALIDATE_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 0);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 2);
+
+    /* Validation success, chunk size max */
+    UT_CF_ResetEventCapture();
+    utbuf.Payload.key      = CF_GetSet_ValueID_outgoing_file_chunk_size;
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+    utbuf.Payload.value    = sizeof(CF_CFDP_PduFileDataContent_t);
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
     UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 2);
+}
+
+void Test_CF_SetParamCmd_ValidateMaxMsgs(void)
+{
+    /* this test case specifically targets the additional validation for chan_max_outgoing_messages_per_wakeup */
+    CF_SetParamCmd_t utbuf;
+    CF_Channel_t    *chan = UT_CFDP_CHANNEL_PTR;
+
+    memset(&utbuf, 0, sizeof(utbuf));
+
+    utbuf.Payload.key      = CF_GetSet_ValueID_chan_max_outgoing_messages_per_wakeup;
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+
+    /* Validation fail: unlimited msgs with no sem */
+    chan->config.sem_name[0] = 0;
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+    UT_CF_AssertEventID(CF_CMD_GETSET_VALIDATE_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 0);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+
+    /* Validation success: unlimited msgs with sem */
+    UT_CF_ResetEventCapture();
+    chan->config.sem_name[0] = 'a';
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+    UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+
+    /* Validation success: limited msgs with sem */
+    UT_CF_ResetEventCapture();
+    chan->config.sem_name[0] = 'a';
+    utbuf.Payload.value      = 10;
+
+    UtAssert_VOIDCALL(CF_SetParamCmd(&utbuf));
+
+    UT_CF_AssertEventID(CF_CMD_GETSET1_INF_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 2);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
 }
 
 /*******************************************************************************
@@ -3409,25 +2527,67 @@ void Test_CF_SetParamCmd_Call_CF_GetSetParamCmd_With_cmd_key_And_cmd_value(void)
 **
 *******************************************************************************/
 
-void Test_CF_GetParamCmd_Call_CF_GetSetParamCmd_With_cmd_data_byte_0_AndConstantValue_0(void)
+void Test_CF_GetParamCmd_Nominal(void)
 {
-    /* Arrange */
+    CF_GetParamCmd_t    utbuf;
+    CF_GetSet_ValueID_t param_id;
+    uint16              expected_count;
+
+    memset(&utbuf, 0, sizeof(utbuf));
+    expected_count = 0;
+
+    /* Nominal: "get" for each parameter */
+    for (param_id = 1; (int)param_id < CF_GetSet_ValueID_MAX; ++param_id)
+    {
+        UT_CF_ResetEventCapture();
+
+        utbuf.Payload.key      = param_id;
+        utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+
+        UtAssert_VOIDCALL(CF_GetParamCmd(&utbuf));
+
+        UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+        UT_CF_AssertEventID(CF_CMD_GETSET2_INF_EID);
+        UtAssert_UINT32_EQ(CF_AppData.counters.cmd, ++expected_count);
+    }
+}
+
+void Test_CF_GetParamCmd_BadParam(void)
+{
     CF_GetParamCmd_t utbuf;
 
     memset(&utbuf, 0, sizeof(utbuf));
 
-    utbuf.Payload.key      = CF_GetSet_ValueID_ticks_per_second;
+    /* Bad param ID (0)*/
+    utbuf.Payload.key      = 0;
     utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
 
-    /* Act */
-    CF_GetParamCmd(&utbuf);
+    UtAssert_VOIDCALL(CF_GetParamCmd(&utbuf));
 
-    /* Assert */
-    /* Note actual value not tested, just flow */
+    UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 1);
+
+    /* Bad param ID (high)*/
+    UT_CF_ResetEventCapture();
+    utbuf.Payload.key      = CF_GetSet_ValueID_MAX;
+    utbuf.Payload.chan_num = UT_CFDP_CHANNEL;
+
+    UtAssert_VOIDCALL(CF_GetParamCmd(&utbuf));
+
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT32_EQ(UT_CF_CapturedEventIDs[0], CF_CMD_GETSET2_INF_EID);
-    /* Assert for incremented counter() */
-    UtAssert_UINT32_EQ(CF_AppData.counters.cmd, 1);
+    UT_CF_AssertEventID(CF_CMD_GETSET_PARAM_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 2);
+
+    /* Bad channel ID */
+    UT_CF_ResetEventCapture();
+    utbuf.Payload.key      = 1;
+    utbuf.Payload.chan_num = UT_CFDP_INVALID_CHANNEL;
+
+    UtAssert_VOIDCALL(CF_GetParamCmd(&utbuf));
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UT_CF_AssertEventID(CF_CMD_CHAN_PARAM_ERR_EID);
+    UtAssert_UINT32_EQ(CF_AppData.counters.err, 3);
 }
 
 /*******************************************************************************
@@ -3467,15 +2627,14 @@ void Test_CF_EnableEngineCmd_WithEngineNotEnableFailsInitSendEventAndIncrementEr
 {
     /* Arrange */
     CF_EnableEngineCmd_t utbuf;
-    uint32               forced_return_CF_CFDP_InitEngine = Any_uint32_Except(CF_ChanAction_Status_SUCCESS);
-    uint16               initial_hk_err_counter           = Any_uint16();
-    CF_Engine_t         *engine_ptr                       = CF_GetEngine();
+    uint16               initial_hk_err_counter = Any_uint16();
+    CF_Engine_t         *engine_ptr             = CF_GetEngine();
 
     memset(&utbuf, 0, sizeof(utbuf));
 
     engine_ptr->enabled = false;
 
-    UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), forced_return_CF_CFDP_InitEngine);
+    UT_SetDefaultReturnValue(UT_KEY(CF_CFDP_InitEngine), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
     CF_AppData.counters.err = initial_hk_err_counter;
 
@@ -3685,46 +2844,6 @@ void add_CF_PlaybackDirCmd_tests(void)
     UtTest_Add(Test_CF_PlaybackDirCmd, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "CF_PlaybackDirCmd");
 }
 
-void add_CF_DoChanAction_tests(void)
-{
-    UtTest_Add(Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAny_fn_returns_1_Return_1");
-    UtTest_Add(Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenAll_fn_return_1_Return_1");
-    UtTest_Add(Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoChanAction_CF_ALL_CHANNELS_WhenNo_fn_returns_0_Return_0");
-    UtTest_Add(Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_1_Return_1");
-    UtTest_Add(Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoChanAction_WhenChannel_fn_ActionReturns_0_Return_1");
-    UtTest_Add(Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendEvent_,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoChanAction_WhenChanNumberEq_CF_NUM_CHANNELS_Return_neg1_And_SendEvent_");
-    UtTest_Add(Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoChanAction_WhenBadChannelNumber_Return_neg1_And_SendEvent");
-}
-
-void add_CF_DoFreezeThaw_tests(void)
-{
-    UtTest_Add(Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoFreezeThaw_Set_frozen_ToGiven_context_barg_AndReturn_0");
-}
-
 void add_CF_FreezeCmd_tests(void)
 {
     UtTest_Add(Test_CF_FreezeCmd_Set_frozen_To_1_AndAcceptCommand,
@@ -3749,109 +2868,53 @@ void add_CF_ThawCmd_tests(void)
                "Test_CF_ThawCmd_Set_frozen_To_0_AndRejectCommand");
 }
 
-void add_CF_FindTransactionBySequenceNumberAllChannels_tests(void)
-{
-    UtTest_Add(Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundReturn_NULL,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_FindTransactionBySequenceNumberAllChannels_WhenNoTransactionFoundReturn_NULL");
-    UtTest_Add(Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_FindTransactionBySequenceNumberAllChannels_Return_TransactionFound");
-}
-
-void add_CF_TsnChanAction_tests(void)
-{
-    UtTest_Add(Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotFoundAndReturn_neg1_Fail,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_TsnChanAction_SendEvent_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionNotFoundAndReturn_neg1_Fail");
-    UtTest_Add(Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_AndReturn_CFE_SUCCESS,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_TsnChanAction_cmd_chan_Eq_CF_COMPOUND_KEY_TransactionFoundRun_fn_AndReturn_CFE_SUCCESS");
-    UtTest_Add(Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_TsnChanAction_cmd_chan_Eq_CF_ALL_CHANNELS_Return_CF_TraverseAllTransactions_All_Channels");
-    UtTest_Add(Test_CF_TsnChanAction_cmd_chan_IsASingleChannel,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_TsnChanAction_cmd_chan_IsASingleChannel");
-    UtTest_Add(Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_TsnChanAction_cmd_FailBecause_cmd_chan_IsInvalid");
-}
-
-void add_CF_DoSuspRes_Txn_tests(void)
-{
-    UtTest_Add(Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoSuspRes_Txn_Set_context_same_To_1_suspended_Eq_action");
-    UtTest_Add(Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoSuspRes_Txn_When_suspended_NotEqTo_action_Set_suspended_To_action");
-}
-
-void add_CF_DoSuspRes_tests(void)
-{
-    UtTest_Add(Test_CF_DoSuspRes, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "CF_DoSuspRes");
-}
-
 void add_CF_SuspendCmd_tests(void)
 {
-    UtTest_Add(Test_CF_SuspendCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_1,
+    UtTest_Add(Test_CF_SuspendCmd_InvalidChannel,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_SuspendCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_1");
+               "Test_CF_SuspendCmd_InvalidChannel");
+    UtTest_Add(Test_CF_SuspendCmd_Success, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_SuspendCmd_Success");
 }
 
 void add_CF_ResumeCmd_tests(void)
 {
-    UtTest_Add(Test_CF_ResumeCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_0,
+    UtTest_Add(Test_CF_ResumeCmd_InvalidChannel,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_ResumeCmd_Call_CF_DoSuspRes_WithGiven_msg_And_action_0");
-}
-
-void add_CF_Cancel_TxnCmd_tests(void)
-{
-    UtTest_Add(Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t,
+               "Test_CF_ResumeCmd_InvalidChannel");
+    UtTest_Add(Test_CF_ResumeCmd_SuccessSame,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_Cancel_TxnCmd_Call_CF_CFDP_CancelTransaction_WithGiven_t");
+               "Test_CF_ResumeCmd_SuccessSame");
 }
 
 void add_CF_CancelCmd_tests(void)
 {
     UtTest_Add(Test_CF_CancelCmd_Failure, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_CancelCmd_Failure");
     UtTest_Add(Test_CF_CancelCmd_Success, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_CancelCmd_Success");
-}
-
-void add_CF_Abandon_TxnCmd_tests(void)
-{
-    UtTest_Add(Test_CF_Abandon_TxnCmd_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0,
+    UtTest_Add(Test_CF_CancelCmd_SuccessSingleTxn,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_Abandon_TxnCmd_Call_CF_CFDP_ResetTransaction_WithGiven_t_And_0");
+               "Test_CF_CancelCmd_SuccessSingleTxn");
+    UtTest_Add(Test_CF_CancelCmd_FailSingleTxn,
+               cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown,
+               "Test_CF_CancelCmd_FailSingleTxn");
 }
 
 void add_CF_AbandonCmd_tests(void)
 {
     UtTest_Add(Test_CF_AbandonCmd_Failure, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_AbandonCmd_Failure");
     UtTest_Add(Test_CF_AbandonCmd_Success, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_AbandonCmd_Success");
-}
-
-void add_CF_DoEnableDisableDequeue_tests(void)
-{
-    UtTest_Add(Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg,
+    UtTest_Add(Test_CF_AbandonCmd_SuccessSingleTxn,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_DoEnableDisableDequeue_Set_chan_num_EnabledFlagTo_context_barg");
+               "Test_CF_AbandonCmd_SuccessSingleTxn");
+    UtTest_Add(Test_CF_AbandonCmd_FailSingleTxn,
+               cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown,
+               "Test_CF_AbandonCmd_FailSingleTxn");
 }
 
 void add_CF_EnableDequeueCmd_tests(void)
@@ -3878,27 +2941,6 @@ void add_CF_DisableDequeueCmd_tests(void)
                "Test_CF_DisableDequeueCmd_Failure");
 }
 
-void add_CF_DoEnableDisablePolldir_tests(void)
-{
-    UtTest_Add(Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannelEnabledTo_context_barg,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoEnableDisablePolldir_When_CF_ALL_CHANNELS_SetAllPolldirsInChannelEnabledTo_context_barg");
-    UtTest_Add(
-        Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg,
-        cf_cmd_tests_Setup,
-        cf_cmd_tests_Teardown,
-        "Test_CF_DoEnableDisablePolldir_WhenSetToSpecificPolldirSetPolldirFrom_context_ChannelEnabledTo_context_barg");
-    UtTest_Add(Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoEnableDisablePolldir_FailPolldirEq_CF_MAX_POLLING_DIR_PER_CHAN_AndSendEvent");
-    UtTest_Add(Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoEnableDisablePolldir_FailAnyBadPolldirSendEvent");
-}
-
 void add_CF_EnablePolldirCmd_tests(void)
 {
     UtTest_Add(Test_CF_EnablePolldirCmd_SuccessWhenActionSuccess,
@@ -3909,6 +2951,14 @@ void add_CF_EnablePolldirCmd_tests(void)
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_EnablePolldirCmd_FailWhenActionFail");
+    UtTest_Add(Test_CF_EnablePolldirCmd_AllPollDirs,
+               cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown,
+               "Test_CF_EnablePolldirCmd_AllPollDirs");
+    UtTest_Add(Test_CF_EnablePolldirCmd_InvalidChannel,
+               cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown,
+               "Test_CF_EnablePolldirCmd_InvalidChannel");
 }
 
 void add_CF_DisablePolldirCmd_tests(void)
@@ -3921,43 +2971,14 @@ void add_CF_DisablePolldirCmd_tests(void)
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_DisablePolldirCmd_FailWhenActionFail");
-}
-
-void add_CF_PurgeHistory_tests(void)
-{
-    UtTest_Add(Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT,
+    UtTest_Add(Test_CF_DisablePolldirCmd_AllPollDirs,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_PurgeHistory_Call_CF_CFDP_ResetHistory_AndReturn_CLIST_CONT");
-}
-
-void add_CF_PurgeTransaction_tests(void)
-{
-    UtTest_Add(Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT,
+               "Test_CF_DisablePolldirCmd_AllPollDirs");
+    UtTest_Add(Test_CF_DisablePolldirCmd_InvalidChannel,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_PurgeTransaction_Call_CF_CFDP_ResetTransaction_AndReturn_CLIST_CONT");
-}
-
-void add_CF_DoPurgeQueue_tests(void)
-{
-    UtTest_Add(Test_CF_DoPurgeQueue_PendOnly,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoPurgeQueue_PendOnly");
-    UtTest_Add(Test_CF_DoPurgeQueue_HistoryOnly,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoPurgeQueue_HistoryOnly");
-    UtTest_Add(Test_CF_DoPurgeQueue_Both, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_DoPurgeQueue_Both");
-    UtTest_Add(Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoPurgeQueue_GivenBad_data_byte_1_SendEventAndReturn_neg1");
-    UtTest_Add(Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_DoPurgeQueue_AnyGivenBad_data_byte_1_SendEventAndReturn_neg1");
+               "Test_CF_DisablePolldirCmd_InvalidChannel");
 }
 
 void add_CF_PurgeQueueCmd_tests(void)
@@ -3970,6 +2991,10 @@ void add_CF_PurgeQueueCmd_tests(void)
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_PurgeQueueCmd_SuccessWhenActionSuccess");
+    UtTest_Add(Test_CF_PurgeQueueCmd_InvalidChannel,
+               cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown,
+               "Test_CF_PurgeQueueCmd_InvalidChannel");
 }
 
 void add_CF_WriteQueueCmd_tests(void)
@@ -3978,10 +3003,6 @@ void add_CF_WriteQueueCmd_tests(void)
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
                "Test_CF_WriteQueueCmd_When_chan_Eq_CF_NUM_CAHNNELS_SendEventAndRejectCommand");
-    UtTest_Add(Test_CF_WriteQueueCmd_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_WriteQueueCmd_When_chan_GreaterThan_CF_NUM_CAHNNELS_SendEventAndRejectCommand");
     UtTest_Add(Test_CF_WriteQueueCmd_WhenUpAndPendingQueueSendEventAndRejectCommand,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
@@ -4082,61 +3103,25 @@ void add_CF_WriteQueueCmd_tests(void)
                "Test_CF_WriteQueueCmd_Success_type_DownAnd_q_Pend");
 }
 
-void add_CF_ValidateChunkSizeCmd_tests(void)
-{
-    UtTest_Add(Test_CF_ValidateChunkSizeCmd_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_ValidateChunkSizeCmd_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1");
-    UtTest_Add(Test_CF_ValidateChunkSizeCmd_Any_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_ValidateChunkSizeCmd_Any_val_GreaterThan_pdu_fd_data_t_FailAndReturn_1");
-    UtTest_Add(Test_CF_ValidateChunkSizeCmd_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_ValidateChunkSizeCmd_val_SizeOf_pdu_fd_data_t_SuccessAndReturn_0");
-    UtTest_Add(Test_CF_ValidateChunkSizeCmd_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_ValidateChunkSizeCmd_val_LessThanOrEqSizeOf_pdu_fd_data_t_SuccessAndReturn_0");
-}
-
-void add_CF_ValidateMaxOutgoingCmd_tests(void)
-{
-    UtTest_Add(Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_IsNot_0_Return_0_Success,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_IsNot_0_Return_0_Success");
-    UtTest_Add(Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_Return_0_Success,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_Is_0_But_sem_name_IsNot_NULL_Return_0_Success");
-    UtTest_Add(Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_ValidateMaxOutgoingCmd_WhenGiven_val_Is_0_And_sem_name_Is_NULL_Return_1_Fail");
-}
-
-void add_CF_GetSetParamCmd_tests(void)
-{
-    UtTest_Add(Test_CF_GetSetParamCmd, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "CF_GetSetParamCmd");
-}
-
 void add_CF_SetParamCmd_tests(void)
 {
-    UtTest_Add(Test_CF_SetParamCmd_Call_CF_GetSetParamCmd_With_cmd_key_And_cmd_value,
+    UtTest_Add(Test_CF_SetParamCmd_Nominal, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_SetParamCmd_Nominal");
+    UtTest_Add(Test_CF_SetParamCmd_BadParam, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_SetParamCmd_BadParam");
+    UtTest_Add(Test_CF_SetParamCmd_ValidateChunkSize,
                cf_cmd_tests_Setup,
                cf_cmd_tests_Teardown,
-               "Test_CF_SetParamCmd_Call_CF_GetSetParamCmd_With_cmd_key_And_cmd_value");
+               "Test_CF_SetParamCmd_ValidateChunkSize");
+    UtTest_Add(Test_CF_SetParamCmd_ValidateMaxMsgs,
+               cf_cmd_tests_Setup,
+               cf_cmd_tests_Teardown,
+               "Test_CF_SetParamCmd_ValidateMaxMsgs");
 }
 
 void add_CF_GetParamCmd_tests(void)
 {
-    UtTest_Add(Test_CF_GetParamCmd_Call_CF_GetSetParamCmd_With_cmd_data_byte_0_AndConstantValue_0,
-               cf_cmd_tests_Setup,
-               cf_cmd_tests_Teardown,
-               "Test_CF_GetParamCmd_Call_CF_GetSetParamCmd_With_cmd_data_byte_0_AndConstantValue_0");
+    UtTest_Add(Test_CF_GetParamCmd_Nominal, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_GetParamCmd_Nominal");
+
+    UtTest_Add(Test_CF_GetParamCmd_BadParam, cf_cmd_tests_Setup, cf_cmd_tests_Teardown, "Test_CF_GetParamCmd_BadParam");
 }
 
 void add_CF_EnableEngineCmd_tests(void)
@@ -4196,61 +3181,29 @@ void UtTest_Setup(void)
 
     add_CF_PlaybackDirCmd_tests();
 
-    add_CF_DoChanAction_tests();
-
-    add_CF_DoFreezeThaw_tests();
-
     add_CF_FreezeCmd_tests();
 
     add_CF_ThawCmd_tests();
-
-    add_CF_FindTransactionBySequenceNumberAllChannels_tests();
-
-    add_CF_TsnChanAction_tests();
-
-    add_CF_DoSuspRes_Txn_tests();
-
-    add_CF_DoSuspRes_tests();
 
     add_CF_SuspendCmd_tests();
 
     add_CF_ResumeCmd_tests();
 
-    add_CF_Cancel_TxnCmd_tests();
-
     add_CF_CancelCmd_tests();
 
-    add_CF_Abandon_TxnCmd_tests();
-
     add_CF_AbandonCmd_tests();
-
-    add_CF_DoEnableDisableDequeue_tests();
 
     add_CF_EnableDequeueCmd_tests();
 
     add_CF_DisableDequeueCmd_tests();
 
-    add_CF_DoEnableDisablePolldir_tests();
-
     add_CF_EnablePolldirCmd_tests();
 
     add_CF_DisablePolldirCmd_tests();
 
-    add_CF_PurgeHistory_tests();
-
-    add_CF_PurgeTransaction_tests();
-
-    add_CF_DoPurgeQueue_tests();
-
     add_CF_PurgeQueueCmd_tests();
 
     add_CF_WriteQueueCmd_tests();
-
-    add_CF_ValidateChunkSizeCmd_tests();
-
-    add_CF_ValidateMaxOutgoingCmd_tests();
-
-    add_CF_GetSetParamCmd_tests();
 
     add_CF_SetParamCmd_tests();
 

--- a/unit-test/cf_utils_tests.c
+++ b/unit-test/cf_utils_tests.c
@@ -985,27 +985,6 @@ void Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_ar
 
 /*******************************************************************************
 **
-**  CF_TraverseAllTransactions_All_Channels tests
-**
-*******************************************************************************/
-
-void Test_CF_TraverseAllTransactions_All_Channels_ReturnTotalTraversals(void)
-{
-    /* Arrange */
-    int   context;
-    void *arg_context       = &context;
-    uint8 per_channel_count = CF_QueueIdx_RX - CF_QueueIdx_PEND + 1;
-    int   expected_result   = per_channel_count * CF_NUM_CHANNELS;
-
-    CF_TraverseAllTransactions_fn_t arg_fn = NULL;
-    UT_SetHandlerFunction(UT_KEY(CF_CList_Traverse), UT_AltHandler_CF_CList_Traverse_TRAVERSE_ALL_ARGS_T, NULL);
-
-    /* Act */
-    UtAssert_INT32_EQ(CF_TraverseAllTransactions_All_Channels(arg_fn, arg_context), expected_result);
-}
-
-/*******************************************************************************
-**
 **  CF_WrappedOpen tests
 **
 *******************************************************************************/
@@ -1374,14 +1353,6 @@ void add_CF_TraverseAllTransactions_tests(void)
                "Test_CF_TraverseAllTransactions_CallOtherFunction_CF_Q_RX_TimesAndReturn_args_counter");
 }
 
-void add_CF_TraverseAllTransactions_All_Channels_tests(void)
-{
-    UtTest_Add(Test_CF_TraverseAllTransactions_All_Channels_ReturnTotalTraversals,
-               cf_utils_tests_Setup,
-               cf_utils_tests_Teardown,
-               "Test_CF_TraverseAllTransactions_All_Channels_ReturnTotalTraversals");
-}
-
 void add_CF_WrappedOpen_tests(void)
 {
     UtTest_Add(Test_CF_WrappedOpen_Call_OS_OpenCreate_WithGivenArgumentsAndReturnItsReturnValue,
@@ -1453,8 +1424,6 @@ void UtTest_Setup(void)
     add_CF_TraverseAllTransactions_Impl_tests();
 
     add_CF_TraverseAllTransactions_tests();
-
-    add_CF_TraverseAllTransactions_All_Channels_tests();
 
     add_CF_WrappedOpen_tests();
 

--- a/unit-test/stubs/cf_cfdp_sbintf_stubs.c
+++ b/unit-test/stubs/cf_cfdp_sbintf_stubs.c
@@ -62,9 +62,9 @@ void CF_CFDP_ReceiveMessage(CF_Channel_t *chan)
  * Generated stub function for CF_CFDP_Send()
  * ----------------------------------------------------
  */
-void CF_CFDP_Send(CF_Channel_t *chan_ptr, const CF_Logical_PduBuffer_t *ph)
+void CF_CFDP_Send(CF_Channel_t *chan, const CF_Logical_PduBuffer_t *ph)
 {
-    UT_GenStub_AddParam(CF_CFDP_Send, CF_Channel_t *, chan_ptr);
+    UT_GenStub_AddParam(CF_CFDP_Send, CF_Channel_t *, chan);
     UT_GenStub_AddParam(CF_CFDP_Send, const CF_Logical_PduBuffer_t *, ph);
 
     UT_GenStub_Execute(CF_CFDP_Send, Basic, NULL);

--- a/unit-test/stubs/cf_cmd_stubs.c
+++ b/unit-test/stubs/cf_cmd_stubs.c
@@ -44,19 +44,6 @@ CFE_Status_t CF_AbandonCmd(const CF_AbandonCmd_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_Abandon_TxnCmd()
- * ----------------------------------------------------
- */
-void CF_Abandon_TxnCmd(CF_Transaction_t *txn, void *ignored)
-{
-    UT_GenStub_AddParam(CF_Abandon_TxnCmd, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_Abandon_TxnCmd, void *, ignored);
-
-    UT_GenStub_Execute(CF_Abandon_TxnCmd, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_CancelCmd()
  * ----------------------------------------------------
  */
@@ -69,19 +56,6 @@ CFE_Status_t CF_CancelCmd(const CF_CancelCmd_t *msg)
     UT_GenStub_Execute(CF_CancelCmd, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_CancelCmd, CFE_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_Cancel_TxnCmd()
- * ----------------------------------------------------
- */
-void CF_Cancel_TxnCmd(CF_Transaction_t *txn, void *ignored)
-{
-    UT_GenStub_AddParam(CF_Cancel_TxnCmd, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_Cancel_TxnCmd, void *, ignored);
-
-    UT_GenStub_Execute(CF_Cancel_TxnCmd, Basic, NULL);
 }
 
 /*
@@ -134,120 +108,6 @@ CFE_Status_t CF_DisableEngineCmd(const CF_DisableEngineCmd_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_DoChanAction()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t
-CF_DoChanAction(CF_ChannelSelect_t chan_select, const char *errstr, CF_ChanActionFn_t fn, void *context)
-{
-    UT_GenStub_SetupReturnBuffer(CF_DoChanAction, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_DoChanAction, CF_ChannelSelect_t, chan_select);
-    UT_GenStub_AddParam(CF_DoChanAction, const char *, errstr);
-    UT_GenStub_AddParam(CF_DoChanAction, CF_ChanActionFn_t, fn);
-    UT_GenStub_AddParam(CF_DoChanAction, void *, context);
-
-    UT_GenStub_Execute(CF_DoChanAction, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_DoChanAction, CF_ChanAction_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_DoEnableDisableDequeue()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_DoEnableDisableDequeue(CF_Channel_t *chan, void *arg)
-{
-    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisableDequeue, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_DoEnableDisableDequeue, CF_Channel_t *, chan);
-    UT_GenStub_AddParam(CF_DoEnableDisableDequeue, void *, arg);
-
-    UT_GenStub_Execute(CF_DoEnableDisableDequeue, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_DoEnableDisableDequeue, CF_ChanAction_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_DoEnableDisablePolldir()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_DoEnableDisablePolldir(CF_Channel_t *chan, void *arg)
-{
-    UT_GenStub_SetupReturnBuffer(CF_DoEnableDisablePolldir, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_DoEnableDisablePolldir, CF_Channel_t *, chan);
-    UT_GenStub_AddParam(CF_DoEnableDisablePolldir, void *, arg);
-
-    UT_GenStub_Execute(CF_DoEnableDisablePolldir, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_DoEnableDisablePolldir, CF_ChanAction_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_DoFreezeThaw()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_DoFreezeThaw(CF_Channel_t *chan, void *arg)
-{
-    UT_GenStub_SetupReturnBuffer(CF_DoFreezeThaw, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_DoFreezeThaw, CF_Channel_t *, chan);
-    UT_GenStub_AddParam(CF_DoFreezeThaw, void *, arg);
-
-    UT_GenStub_Execute(CF_DoFreezeThaw, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_DoFreezeThaw, CF_ChanAction_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_DoPurgeQueue()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_DoPurgeQueue(CF_Channel_t *chan, void *arg)
-{
-    UT_GenStub_SetupReturnBuffer(CF_DoPurgeQueue, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_DoPurgeQueue, CF_Channel_t *, chan);
-    UT_GenStub_AddParam(CF_DoPurgeQueue, void *, arg);
-
-    UT_GenStub_Execute(CF_DoPurgeQueue, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_DoPurgeQueue, CF_ChanAction_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_DoSuspRes()
- * ----------------------------------------------------
- */
-void CF_DoSuspRes(const CF_Transaction_Payload_t *payload, uint8 action)
-{
-    UT_GenStub_AddParam(CF_DoSuspRes, const CF_Transaction_Payload_t *, payload);
-    UT_GenStub_AddParam(CF_DoSuspRes, uint8, action);
-
-    UT_GenStub_Execute(CF_DoSuspRes, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_DoSuspRes_Txn()
- * ----------------------------------------------------
- */
-void CF_DoSuspRes_Txn(CF_Transaction_t *txn, CF_ChanAction_SuspResArg_t *context)
-{
-    UT_GenStub_AddParam(CF_DoSuspRes_Txn, CF_Transaction_t *, txn);
-    UT_GenStub_AddParam(CF_DoSuspRes_Txn, CF_ChanAction_SuspResArg_t *, context);
-
-    UT_GenStub_Execute(CF_DoSuspRes_Txn, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_EnableDequeueCmd()
  * ----------------------------------------------------
  */
@@ -296,23 +156,6 @@ CFE_Status_t CF_EnableEngineCmd(const CF_EnableEngineCmd_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_FindTransactionBySequenceNumberAllChannels()
- * ----------------------------------------------------
- */
-CF_Transaction_t *CF_FindTransactionBySequenceNumberAllChannels(CF_TransactionSeq_t ts, CF_EntityId_t eid)
-{
-    UT_GenStub_SetupReturnBuffer(CF_FindTransactionBySequenceNumberAllChannels, CF_Transaction_t *);
-
-    UT_GenStub_AddParam(CF_FindTransactionBySequenceNumberAllChannels, CF_TransactionSeq_t, ts);
-    UT_GenStub_AddParam(CF_FindTransactionBySequenceNumberAllChannels, CF_EntityId_t, eid);
-
-    UT_GenStub_Execute(CF_FindTransactionBySequenceNumberAllChannels, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_FindTransactionBySequenceNumberAllChannels, CF_Transaction_t *);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_FreezeCmd()
  * ----------------------------------------------------
  */
@@ -341,21 +184,6 @@ CFE_Status_t CF_GetParamCmd(const CF_GetParamCmd_t *msg)
     UT_GenStub_Execute(CF_GetParamCmd, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_GetParamCmd, CFE_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_GetSetParamCmd()
- * ----------------------------------------------------
- */
-void CF_GetSetParamCmd(bool is_set, CF_GetSet_ValueID_t param_id, uint32 value, CF_ChannelSelect_t chan_num)
-{
-    UT_GenStub_AddParam(CF_GetSetParamCmd, bool, is_set);
-    UT_GenStub_AddParam(CF_GetSetParamCmd, CF_GetSet_ValueID_t, param_id);
-    UT_GenStub_AddParam(CF_GetSetParamCmd, uint32, value);
-    UT_GenStub_AddParam(CF_GetSetParamCmd, CF_ChannelSelect_t, chan_num);
-
-    UT_GenStub_Execute(CF_GetSetParamCmd, Basic, NULL);
 }
 
 /*
@@ -392,23 +220,6 @@ CFE_Status_t CF_PlaybackDirCmd(const CF_PlaybackDirCmd_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_PurgeHistory()
- * ----------------------------------------------------
- */
-CF_CListTraverse_Status_t CF_PurgeHistory(CF_CListNode_t *node, void *arg)
-{
-    UT_GenStub_SetupReturnBuffer(CF_PurgeHistory, CF_CListTraverse_Status_t);
-
-    UT_GenStub_AddParam(CF_PurgeHistory, CF_CListNode_t *, node);
-    UT_GenStub_AddParam(CF_PurgeHistory, void *, arg);
-
-    UT_GenStub_Execute(CF_PurgeHistory, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_PurgeHistory, CF_CListTraverse_Status_t);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_PurgeQueueCmd()
  * ----------------------------------------------------
  */
@@ -421,23 +232,6 @@ CFE_Status_t CF_PurgeQueueCmd(const CF_PurgeQueueCmd_t *msg)
     UT_GenStub_Execute(CF_PurgeQueueCmd, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_PurgeQueueCmd, CFE_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_PurgeTransaction()
- * ----------------------------------------------------
- */
-CF_CListTraverse_Status_t CF_PurgeTransaction(CF_CListNode_t *node, void *ignored)
-{
-    UT_GenStub_SetupReturnBuffer(CF_PurgeTransaction, CF_CListTraverse_Status_t);
-
-    UT_GenStub_AddParam(CF_PurgeTransaction, CF_CListNode_t *, node);
-    UT_GenStub_AddParam(CF_PurgeTransaction, void *, ignored);
-
-    UT_GenStub_Execute(CF_PurgeTransaction, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_PurgeTransaction, CF_CListTraverse_Status_t);
 }
 
 /*
@@ -538,28 +332,6 @@ CFE_Status_t CF_ThawCmd(const CF_ThawCmd_t *msg)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for CF_TsnChanAction()
- * ----------------------------------------------------
- */
-int32 CF_TsnChanAction(const CF_Transaction_Payload_t *data,
-                       const char                     *cmdstr,
-                       CF_TsnChanAction_fn_t           fn,
-                       void                           *context)
-{
-    UT_GenStub_SetupReturnBuffer(CF_TsnChanAction, int32);
-
-    UT_GenStub_AddParam(CF_TsnChanAction, const CF_Transaction_Payload_t *, data);
-    UT_GenStub_AddParam(CF_TsnChanAction, const char *, cmdstr);
-    UT_GenStub_AddParam(CF_TsnChanAction, CF_TsnChanAction_fn_t, fn);
-    UT_GenStub_AddParam(CF_TsnChanAction, void *, context);
-
-    UT_GenStub_Execute(CF_TsnChanAction, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_TsnChanAction, int32);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for CF_TxFileCmd()
  * ----------------------------------------------------
  */
@@ -572,40 +344,6 @@ CFE_Status_t CF_TxFileCmd(const CF_TxFileCmd_t *msg)
     UT_GenStub_Execute(CF_TxFileCmd, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_TxFileCmd, CFE_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_ValidateChunkSizeCmd()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_ValidateChunkSizeCmd(CF_ChunkSize_t val, CF_Channel_t *chan)
-{
-    UT_GenStub_SetupReturnBuffer(CF_ValidateChunkSizeCmd, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_ValidateChunkSizeCmd, CF_ChunkSize_t, val);
-    UT_GenStub_AddParam(CF_ValidateChunkSizeCmd, CF_Channel_t *, chan);
-
-    UT_GenStub_Execute(CF_ValidateChunkSizeCmd, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_ValidateChunkSizeCmd, CF_ChanAction_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_ValidateMaxOutgoingCmd()
- * ----------------------------------------------------
- */
-CF_ChanAction_Status_t CF_ValidateMaxOutgoingCmd(uint32 val, CF_Channel_t *chan)
-{
-    UT_GenStub_SetupReturnBuffer(CF_ValidateMaxOutgoingCmd, CF_ChanAction_Status_t);
-
-    UT_GenStub_AddParam(CF_ValidateMaxOutgoingCmd, uint32, val);
-    UT_GenStub_AddParam(CF_ValidateMaxOutgoingCmd, CF_Channel_t *, chan);
-
-    UT_GenStub_Execute(CF_ValidateMaxOutgoingCmd, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CF_ValidateMaxOutgoingCmd, CF_ChanAction_Status_t);
 }
 
 /*

--- a/unit-test/stubs/cf_utils_handlers.c
+++ b/unit-test/stubs/cf_utils_handlers.c
@@ -63,51 +63,6 @@ void UT_DefaultHandler_CF_ResetHistory(void *UserObj, UT_EntryKey_t FuncKey, con
  * arguments to a test-provided context capture buffer.
  *
  *-----------------------------------------------------------------*/
-void UT_DefaultHandler_CF_FindTransactionBySequenceNumber(void                   *UserObj,
-                                                          UT_EntryKey_t           FuncKey,
-                                                          const UT_StubContext_t *Context)
-{
-    CF_FindTransactionBySequenceNumber_context_t *ctxt =
-        UT_CF_GetContextBuffer(FuncKey, CF_FindTransactionBySequenceNumber_context_t);
-    CF_Transaction_t *forced_return;
-
-    if (ctxt)
-    {
-        ctxt->chan = UT_Hook_GetArgValueByName(Context, "chan", CF_Channel_t *);
-        ctxt->transaction_sequence_number =
-            UT_Hook_GetArgValueByName(Context, "transaction_sequence_number", CF_TransactionSeq_t);
-        ctxt->src_eid = UT_Hook_GetArgValueByName(Context, "src_eid", CF_EntityId_t);
-
-        forced_return = ctxt->forced_return;
-    }
-    else
-    {
-        forced_return = NULL;
-    }
-
-    UT_Stub_SetReturnValue(FuncKey, forced_return);
-}
-
-/*----------------------------------------------------------------
- *
- * Default always returns NULL, an alt handler can be registered for other pointer returns
- *
- *-----------------------------------------------------------------*/
-void UT_DefaultHandler_CF_FindUnusedTransaction(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
-{
-    CF_Transaction_t *forced_return;
-
-    forced_return = NULL;
-
-    UT_Stub_SetReturnValue(FuncKey, forced_return);
-}
-
-/*----------------------------------------------------------------
- *
- * For compatibility with other tests, this has a mechanism to save its
- * arguments to a test-provided context capture buffer.
- *
- *-----------------------------------------------------------------*/
 void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     CF_WriteTxnQueueDataToFile_context_t *ctxt = UT_CF_GetContextBuffer(FuncKey, CF_WriteTxnQueueDataToFile_context_t);
@@ -165,28 +120,6 @@ void UT_DefaultHandler_CF_TraverseAllTransactions(void *UserObj, UT_EntryKey_t F
  * arguments to a test-provided context capture buffer.
  *
  *-----------------------------------------------------------------*/
-void UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels(void                   *UserObj,
-                                                               UT_EntryKey_t           FuncKey,
-                                                               const UT_StubContext_t *Context)
-{
-    CF_TraverseAllTransactions_All_Channels_context_t *ctxt =
-        UT_CF_GetContextBuffer(FuncKey, CF_TraverseAllTransactions_All_Channels_context_t);
-
-    if (ctxt)
-    {
-        ctxt->fn      = UT_Hook_GetArgValueByName(Context, "fn", CF_TraverseAllTransactions_fn_t);
-        ctxt->context = UT_Hook_GetArgValueByName(Context, "context", void *);
-
-        UT_Stub_SetReturnValue(FuncKey, ctxt->forced_return);
-    }
-}
-
-/*----------------------------------------------------------------
- *
- * For compatibility with other tests, this has a mechanism to save its
- * arguments to a test-provided context capture buffer.
- *
- *-----------------------------------------------------------------*/
 void UT_DefaultHandler_CF_WrappedOpenCreate(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     CF_WrappedOpenCreate_context_t *ctxt = UT_CF_GetContextBuffer(FuncKey, CF_WrappedOpenCreate_context_t);
@@ -215,10 +148,18 @@ void UT_DefaultHandler_CF_ForEachChannel(void *UserObj, UT_EntryKey_t FuncKey, c
     CF_ChannelFunc_t fn         = UT_Hook_GetArgValueByName(Context, "fn", CF_ChannelFunc_t);
     void            *arg        = UT_Hook_GetArgValueByName(Context, "arg", void *);
     int32            ret;
+    CF_Channel_t    *chan;
+
+    /* this permits this handler to be configured for something other than UT_CFDP_CHANNEL_PTR if needed */
+    chan = UserObj;
+    if (chan == NULL)
+    {
+        chan = UT_CFDP_CHANNEL_PTR;
+    }
 
     if (fn)
     {
-        ret = fn(engine_ptr, &engine_ptr->channels[UT_CFDP_CHANNEL_IDX], arg);
+        ret = fn(engine_ptr, chan, arg);
     }
     else
     {

--- a/unit-test/stubs/cf_utils_stubs.c
+++ b/unit-test/stubs/cf_utils_stubs.c
@@ -26,12 +26,9 @@
 #include "cf_utils.h"
 #include "utgenstub.h"
 
-void UT_DefaultHandler_CF_FindTransactionBySequenceNumber(void *, UT_EntryKey_t, const UT_StubContext_t *);
-void UT_DefaultHandler_CF_FindUnusedTransaction(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_ForEachChannel(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_ResetHistory(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_TraverseAllTransactions(void *, UT_EntryKey_t, const UT_StubContext_t *);
-void UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WrappedOpenCreate(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WriteHistoryQueueDataToFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CF_WriteTxnQueueDataToFile(void *, UT_EntryKey_t, const UT_StubContext_t *);
@@ -67,7 +64,7 @@ CF_Transaction_t *CF_FindTransactionBySequenceNumber(CF_Channel_t       *chan,
     UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber, CF_TransactionSeq_t, transaction_sequence_number);
     UT_GenStub_AddParam(CF_FindTransactionBySequenceNumber, CF_EntityId_t, src_eid);
 
-    UT_GenStub_Execute(CF_FindTransactionBySequenceNumber, Basic, UT_DefaultHandler_CF_FindTransactionBySequenceNumber);
+    UT_GenStub_Execute(CF_FindTransactionBySequenceNumber, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_FindTransactionBySequenceNumber, CF_Transaction_t *);
 }
@@ -101,7 +98,7 @@ CF_Transaction_t *CF_FindUnusedTransaction(CF_Channel_t *chan, CF_Direction_t di
     UT_GenStub_AddParam(CF_FindUnusedTransaction, CF_Channel_t *, chan);
     UT_GenStub_AddParam(CF_FindUnusedTransaction, CF_Direction_t, direction);
 
-    UT_GenStub_Execute(CF_FindUnusedTransaction, Basic, UT_DefaultHandler_CF_FindUnusedTransaction);
+    UT_GenStub_Execute(CF_FindUnusedTransaction, Basic, NULL);
 
     return UT_GenStub_GetReturnValue(CF_FindUnusedTransaction, CF_Transaction_t *);
 }
@@ -212,25 +209,6 @@ int32 CF_TraverseAllTransactions(CF_Channel_t *chan, CF_TraverseAllTransactions_
     UT_GenStub_Execute(CF_TraverseAllTransactions, Basic, UT_DefaultHandler_CF_TraverseAllTransactions);
 
     return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions, int32);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CF_TraverseAllTransactions_All_Channels()
- * ----------------------------------------------------
- */
-int32 CF_TraverseAllTransactions_All_Channels(CF_TraverseAllTransactions_fn_t fn, void *context)
-{
-    UT_GenStub_SetupReturnBuffer(CF_TraverseAllTransactions_All_Channels, int32);
-
-    UT_GenStub_AddParam(CF_TraverseAllTransactions_All_Channels, CF_TraverseAllTransactions_fn_t, fn);
-    UT_GenStub_AddParam(CF_TraverseAllTransactions_All_Channels, void *, context);
-
-    UT_GenStub_Execute(CF_TraverseAllTransactions_All_Channels,
-                       Basic,
-                       UT_DefaultHandler_CF_TraverseAllTransactions_All_Channels);
-
-    return UT_GenStub_GetReturnValue(CF_TraverseAllTransactions_All_Channels, int32);
 }
 
 /*

--- a/unit-test/utilities/cf_test_alt_handler.c
+++ b/unit-test/utilities/cf_test_alt_handler.c
@@ -156,3 +156,80 @@ void UT_AltHandler_CaptureTransactionStatus(void *UserObj, UT_EntryKey_t FuncKey
 
     *p_txn_stat = in_stat;
 }
+
+/*----------------------------------------------------------------
+ *
+ * Function: UT_AltHandler_CF_TraverseAllTransactions_InvokeCb
+ *
+ * A handler for CF_TraverseAllTransactions() which invokes the callback
+ * with the given UserObj for the transaction
+ *
+ *-----------------------------------------------------------------*/
+void UT_AltHandler_CF_TraverseAllTransactions_InvokeCb(void                   *UserObj,
+                                                       UT_EntryKey_t           FuncKey,
+                                                       const UT_StubContext_t *Context)
+{
+    CF_Channel_t                   *chan    = UT_Hook_GetArgValueByName(Context, "chan", CF_Channel_t *);
+    CF_TraverseAllTransactions_fn_t fn      = UT_Hook_GetArgValueByName(Context, "fn", CF_TraverseAllTransactions_fn_t);
+    void                           *context = UT_Hook_GetArgValueByName(Context, "context", void *);
+    CF_Transaction_t               *txn     = UserObj;
+    int32                           RetVal;
+
+    if (fn == NULL || txn == NULL)
+    {
+        RetVal = 0;
+    }
+    else
+    {
+        txn->chan_ptr = chan;
+        fn(UserObj, context);
+        RetVal = 1;
+    }
+
+    UT_Stub_SetReturnValue(FuncKey, RetVal);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: UT_AltHandler_CF_FindTransactionBySequenceNumber
+ *
+ * Similar to the basic pointer return but ensures the chan_ptr
+ * in the transaction points to a valid channel
+ *
+ *-----------------------------------------------------------------*/
+void UT_AltHandler_CF_FindTransactionBySequenceNumber(void                   *UserObj,
+                                                      UT_EntryKey_t           FuncKey,
+                                                      const UT_StubContext_t *Context)
+{
+    CF_Channel_t     *chan          = UT_Hook_GetArgValueByName(Context, "chan", CF_Channel_t *);
+    CF_Transaction_t *forced_return = UserObj;
+
+    if (forced_return != NULL)
+    {
+        forced_return->chan_ptr = chan;
+    }
+
+    UT_Stub_SetReturnValue(FuncKey, forced_return);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: UT_AltHandler_CF_CList_Traverse_InvokeCb
+ *
+ * Similar to the basic pointer return but ensures the chan_ptr
+ * in the transaction points to a valid channel
+ *
+ * A handler for CF_CList_Traverse() which invokes the callback
+ *
+ *-----------------------------------------------------------------*/
+void UT_AltHandler_CF_CList_Traverse_InvokeCb(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    CF_CListNode_t *start   = UT_Hook_GetArgValueByName(Context, "start", CF_CListNode_t *);
+    CF_CListFn_t    fn      = UT_Hook_GetArgValueByName(Context, "fn", CF_CListFn_t);
+    void           *context = UT_Hook_GetArgValueByName(Context, "context", void *);
+
+    if (fn != NULL)
+    {
+        fn(start, context);
+    }
+}

--- a/unit-test/utilities/cf_test_alt_handler.h
+++ b/unit-test/utilities/cf_test_alt_handler.h
@@ -39,4 +39,14 @@ void UT_AltHandler_GenericPointerReturn(void *UserObj, UT_EntryKey_t FuncKey, co
 
 void UT_AltHandler_CaptureTransactionStatus(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context);
 
+void UT_AltHandler_CF_TraverseAllTransactions_InvokeCb(void                   *UserObj,
+                                                       UT_EntryKey_t           FuncKey,
+                                                       const UT_StubContext_t *Context);
+
+void UT_AltHandler_CF_FindTransactionBySequenceNumber(void                   *UserObj,
+                                                      UT_EntryKey_t           FuncKey,
+                                                      const UT_StubContext_t *Context);
+
+void UT_AltHandler_CF_CList_Traverse_InvokeCb(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context);
+
 #endif /* CF_TEST_ALT_HANDLER_H */

--- a/unit-test/utilities/cf_test_utils.c
+++ b/unit-test/utilities/cf_test_utils.c
@@ -391,5 +391,5 @@ void AnyRandomStringOfLettersOfLengthCopy(char *random_string, size_t length)
 /* cf specific */
 CF_ChannelSelect_t Any_cf_chan_num(void)
 {
-    return (Any_uint8_LessThan(CF_NUM_CHANNELS));
+    return CF_ChannelSelect_FromInt(1 + Any_uint8_LessThan(CF_NUM_CHANNELS));
 }

--- a/unit-test/utilities/cf_test_utils.h
+++ b/unit-test/utilities/cf_test_utils.h
@@ -45,9 +45,10 @@
 #define RANDOM_VALUES_SEED 0
 #endif /* !RANDOM_VALUES_SEED */
 
-#define UT_CFDP_CHANNEL_IDX 0
-#define UT_CFDP_CHANNEL     CF_ChannelSelect_FromInt(UT_CFDP_CHANNEL_IDX)
-#define UT_CFDP_CHANNEL_PTR CF_GetChannelPtr(UT_CFDP_CHANNEL)
+#define UT_CFDP_CHANNEL_IDX     1
+#define UT_CFDP_CHANNEL         CF_ChannelSelect_FromInt(UT_CFDP_CHANNEL_IDX)
+#define UT_CFDP_CHANNEL_PTR     CF_GetChannelPtr(UT_CFDP_CHANNEL)
+#define UT_CFDP_INVALID_CHANNEL CF_ChannelSelect_FromInt(CF_NUM_CHANNELS + 1)
 
 typedef enum
 {
@@ -86,21 +87,6 @@ typedef struct
     uint8           priority;
     CF_EntityId_t   dest_id;
 } CF_CFDP_PlaybackDir_context_t;
-
-typedef struct
-{
-    CF_Channel_t       *chan;
-    CF_TransactionSeq_t transaction_sequence_number;
-    CF_EntityId_t       src_eid;
-    CF_Transaction_t   *forced_return;
-} CF_FindTransactionBySequenceNumber_context_t;
-
-typedef struct
-{
-    CF_TraverseAllTransactions_fn_t fn;
-    void                           *context;
-    int                             forced_return;
-} CF_TraverseAllTransactions_All_Channels_context_t;
 
 typedef struct
 {


### PR DESCRIPTION
---
name: FSW Code Change
about: Flight Software code changes
labels: fsw
---

## Description of Change

Refactor the cf_cmd.c to reduce complexity of various functions

This removes multiple variations on how the loops over multiple entities are being performed in command handlers, creating standard patterns for all commands.

The index specifier value of 0 is reserved to mean "all" for any command which accepts this type of wildcard value.  All singluar item specifiers should be 1-based.

For all commands accepting a channel number, the value of "all" (0) is permitted whenever feasible.  The only exceptions are TxFile and PlaybackDir commands which are only valid for a single specific channel at a time.  All other commands will accept "all" and go through the same ForEachChannel loop to perform the same operation on all channels.  This removes a lot of inconsistencies in how this channel number had been interpreted.

For other indices such as Queue selections, direction specifiers, polling dirs, and any other index - 0 will mean "all" and will be processed consistently across all commands.

IMPORTANT: this changes some command definitions where "0" was a valid value.  Enumerations are changed so that all valid (singular) values start at 1, and 0 is reserved to mean "all" or will be rejected as invalid if the command does not permit operation on multiple channels.


## Linked Issue

Closes #515

## Requirements Impact

- Requirement ID(s):
- [ ] Requirements updated as necessary
- [x] Existing requirements are still satisfied by this change

## Testing Evidence
Verified normal operation 

### Unit Tests (UT Assert)
All tests pass

### COSMOS Test Suite
COSMOS suite not implemented yet.  Definitions will need corresponding update to CMD definition changes.


---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [x] Static analysis workflows ran and passed
- [x] Unit tests (UT Assert) updated/added to cover code changes
- [x] Unit test workflows ran and passed
- [ ] COSMOS test suite was run; tests updated/added if relevant changes were made
- [x] Requirements have been reviewed; updated or confirmed still satisfied (see above)
- [x] Testing evidence is included above
- [x] Self-review of the diff completed

---

## Reviewer Checklist

- [ ] Code logic is correct and matches the stated intent
- [ ] Code is readable, maintainable, and follows project conventions
- [ ] `.clang-format` has been applied
- [ ] Static analysis results reviewed and acceptable
- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
- [ ] Requirements impact reviewed and appropriate
- [ ] Error handling is appropriate
- [ ] Appropriate Expert areas have been reviewed

