### PR TITLE
Fix #517, Ignore empty ranges in CF_ChunkListAdd

### DIFF
--- a/fsw/src/cf_chunk.c
+++ b/fsw/src/cf_chunk.c
@@ -281,8 +281,18 @@ void CF_Chunks_Insert(CF_ChunkList_t *chunks, CF_ChunkIdx_t i, const CF_Chunk_t 
  *-----------------------------------------------------------------*/
 void CF_ChunkListAdd(CF_ChunkList_t *chunks, CF_ChunkOffset_t offset, CF_ChunkSize_t size)
 {
-    const CF_Chunk_t    chunk = { offset, size };
-    const CF_ChunkIdx_t i     = CF_Chunks_FindInsertPosition(chunks, &chunk);
+    const CF_Chunk_t chunk = { offset, size };
+    CF_ChunkIdx_t    i;
+
+    /* An empty range covers no data, so there is nothing to track.  Storing it would
+     * consume a list entry and split a surrounding gap in two, and CF_Chunks_CombineNext
+     * asserts that the chunk end is past its offset. */
+    if (size == 0)
+    {
+        return;
+    }
+
+    i = CF_Chunks_FindInsertPosition(chunks, &chunk);
 
     /* PTFO: files won't be so big we need to gracefully handle overflow,
      * and in that case the user should change everything in chunks

--- a/unit-test/cf_chunk_tests.c
+++ b/unit-test/cf_chunk_tests.c
@@ -163,6 +163,30 @@ void Test_CF_Chunk_CreateAddReset(void)
     UtAssert_UINT32_EQ(clist.count, 3);
 }
 
+/* Cover add of an empty range, which covers no data and must not be stored */
+void Test_CF_Chunk_AddEmpty(void)
+{
+    CF_ChunkList_t clist;
+    CF_Chunk_t     chunks[3];
+
+    CF_ChunkListInit(&clist, sizeof(chunks) / sizeof(chunks[0]), chunks);
+
+    /* Empty range on an empty list */
+    UtAssert_VOIDCALL(CF_ChunkListAdd(&clist, 100, 0));
+    UtAssert_UINT32_EQ(clist.count, 0);
+
+    /* Empty range between two tracked chunks leaves the list and the gaps alone */
+    CF_ChunkListAdd(&clist, 0, 10);
+    CF_ChunkListAdd(&clist, 100, 10);
+    UtAssert_VOIDCALL(CF_ChunkListAdd(&clist, 50, 0));
+    UtAssert_UINT32_EQ(clist.chunks[0].offset, 0);
+    UtAssert_UINT32_EQ(clist.chunks[0].size, 10);
+    UtAssert_UINT32_EQ(clist.chunks[1].offset, 100);
+    UtAssert_UINT32_EQ(clist.chunks[1].size, 10);
+    UtAssert_UINT32_EQ(clist.count, 2);
+    UtAssert_UINT32_EQ(CF_ChunkList_ComputeGaps(&clist, TEST_CF_MAX_GAPS, 200, 0, NULL, NULL), 2);
+}
+
 /* Cover combination cases */
 void Test_CF_Chunk_Combine(void)
 {
@@ -360,6 +384,7 @@ void UtTest_Setup(void)
 {
     /* Full coverage with just this section of tests */
     TEST_CF_ADD(Test_CF_Chunk_CreateAddReset);
+    TEST_CF_ADD(Test_CF_Chunk_AddEmpty);
     TEST_CF_ADD(Test_CF_Chunk_Combine);
     TEST_CF_ADD(Test_CF_Chunk_GetRmFirst);
     TEST_CF_ADD(Test_CF_Chunk_ComputeGaps);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CF/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #517

This PR prevents zero-length ranges from entering the chunk tracking system.

The issue occurs across two execution paths:

1. Receiver path: `CF_CFDP_DecodeFileDataHeader` (`cf_codec.c:976`) sets `data_len = CF_CODEC_GET_REMAIN(state)`, so a File Data PDU carrying an offset but no data bytes decodes to zero. Nothing rejects it, and `CF_CFDP_R_ProcessFd` passes it straight to `CF_ChunkListAdd(..., fd->offset, fd->data_len)` (`cf_cfdp_r.c:173`). In `CF_Chunks_CombineNext`, `chunk_end == chunk->offset` occurs, violating `CF_Assert(chunk_end > chunk->offset)`.

2. Sender path (`cf_cfdp_s.c:295-306`, inside `CF_CFDP_S2_SubstateNak`): NAK ranges are filtered only if `offset_end < offset_start` or `offset_end > fsize`. A NAK request where `offset_start == offset_end` passes validation and reaches `CF_ChunkListAdd` with a length of zero.

Fix: Ignore empty ranges (`size == 0`) directly inside `CF_ChunkListAdd`. This single guard handles both receiver and sender entry points while preserving tracked byte coverage.

**Testing performed**
Due to assertions behaving differently across build types, `fsw/src/cf_chunk.c` was tested standalone against minimal headers in both debug and release configurations:

```
clang -std=c99 -DCF_DEBUG_BUILD -I stub -I fsw/src -o h_debug  harness.c fsw/src/cf_chunk.c
clang -std=c99                  -I stub -I fsw/src -o h_normal harness.c fsw/src/cf_chunk.c
```

Single-call validation:

- Debug build: `CF_ChunkListAdd(list, 100, 0)` caused `SIGABRT` (exit 134) on `CF_Assert` before the fix; exits 0 with the fix.
- Normal build: Empty ranges were previously added to the list (62 empty additions filled a 58-entry capacity list). With the fix, empty ranges are discarded and consume none of the 58 slots.
- Gap computation: An empty range inserted between two valid chunks created 3 gaps instead of 2. With the fix, gap count remains accurate at 2.

Fuzzing & Randomization (20,000 mixed-add rounds, ~25% zero-length):
Comparing chunk lists built with empty ranges against lists built with zero-length filtering:

- Tracked byte coverage discrepancies: 0 rounds (byte tracking stayed accurate before and after).
- Gap count discrepancies: 16,548 rounds differed before the fix (producing up to 11 extra fragmented segments); 0 rounds differed after the fix.
- `CF_Assert` violations: 67,216 before the fix; 0 after the fix.

Unit Tests:
Added `Test_CF_Chunk_AddEmpty` verifying 7 test conditions (5 fail on unpatched code, 7/7 pass on patched code).

**Expected behavior changes**

- API Change: None.
- Behavior Change: Zero-length ranges passed to `CF_ChunkListAdd` are ignored rather than stored. Zero-length File Data PDUs and NAK requests no longer consume entries in the fixed chunk list or artificially fragment gap calculations. Tracked byte coverage remains unchanged.

**System(s) tested on**

- Hardware: Apple M4
- OS: macOS (Darwin 25.3.0)
- Versions: nasa/CF dev @ 5250915 (`cf_chunk.c` tested via standalone harness)

**Additional context**

- Full cFS suite was not built locally; relying on CI for integrated application testing.
- Measurement note: Fuzzing confirmed that zero-length entries do not corrupt byte coverage tracking itself, but they inflate the gap list count and crowd out valid segments due to fixed list size limits.
- This contribution was prepared with AI assistance.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Muhammed Tekin Ertekin, Personal