### PR TITLE
Fix #484, reject invalid move-target buffers

### DIFF
--- a/fsw/src/cf_cfdp.c
+++ b/fsw/src/cf_cfdp.c
@@ -2459,6 +2459,12 @@ const char *CF_CFDP_GetMoveTarget(const char *dest_dir, const char *subject_file
     const char *filename;
     int         dest_path_len;
 
+    /* A returned destination must have space for its string terminator. */
+    if (dest_buf == NULL || dest_size == 0)
+    {
+        return NULL;
+    }
+
     result = NULL;
     if (dest_dir != NULL && dest_dir[0] != 0)
     {

--- a/fsw/src/cf_cfdp.h
+++ b/fsw/src/cf_cfdp.h
@@ -840,8 +840,8 @@ CF_CListTraverse_Status_t CF_CFDP_DoTick(CF_CListNode_t *node, void *context);
  * @param dest_buf     Buffer to store result
  * @param dest_size    Size of result buffer
  *
- * @retval NULL if the result is not valid (i.e. dest_dir not set)
- * @retval dest_buf if result is valid
+ * @retval NULL if dest_dir is not set, dest_buf is NULL, or dest_size is zero
+ * @retval dest_buf if result is a valid NUL-terminated string
  */
 const char *CF_CFDP_GetMoveTarget(const char *dest_dir, const char *subject_file, char *dest_buf, size_t dest_size);
 

--- a/unit-test/cf_cfdp_tests.c
+++ b/unit-test/cf_cfdp_tests.c
@@ -1920,9 +1920,33 @@ void Test_CF_CFDP_GetMoveTarget(void)
      */
     char FileNameBuf[6];
 
+    /* No destination capacity must not return an uninitialized string. */
+    memset(FileNameBuf, 'X', sizeof(FileNameBuf));
+    UtAssert_NULL(CF_CFDP_GetMoveTarget("d", "ut", FileNameBuf, 0));
+    UtAssert_True(memcmp(FileNameBuf, "XXXXXX", sizeof(FileNameBuf)) == 0, "Zero-capacity output remains untouched");
+
     /* nominal, no dest dir */
     UtAssert_NULL(CF_CFDP_GetMoveTarget(NULL, "ut", FileNameBuf, sizeof(FileNameBuf)));
     UtAssert_NULL(CF_CFDP_GetMoveTarget("", "ut", FileNameBuf, sizeof(FileNameBuf)));
+
+    /* Missing storage is invalid regardless of its reported capacity. */
+    UtAssert_NULL(CF_CFDP_GetMoveTarget("d", "ut", NULL, 0));
+    UtAssert_NULL(CF_CFDP_GetMoveTarget("d", "ut", NULL, sizeof(FileNameBuf)));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+    /* One byte holds the terminator, and must not touch the following bytes. */
+    UtAssert_True(CF_CFDP_GetMoveTarget("d", "ut", FileNameBuf, 1) == FileNameBuf,
+                  "One-byte destination returns the supplied buffer");
+    UtAssert_ZERO(FileNameBuf[0]);
+    UtAssert_True(memcmp(FileNameBuf + 1, "XXXXX", sizeof(FileNameBuf) - 1) == 0, "Only the available byte is written");
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+    /* An exact fit preserves the complete path and the following byte. */
+    UtAssert_True(CF_CFDP_GetMoveTarget("d", "ut", FileNameBuf, 5) == FileNameBuf,
+                  "Exact-fit destination returns the supplied buffer");
+    UtAssert_STRINGBUF_EQ(FileNameBuf, 5, "d/ut", -1);
+    UtAssert_INT32_EQ(FileNameBuf[5], 'X');
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
     /* nominal with dest dir */
     UtAssert_NOT_NULL(CF_CFDP_GetMoveTarget("d", "ut", FileNameBuf, sizeof(FileNameBuf)));


### PR DESCRIPTION
Fixes #484.

Reject null or zero-capacity destination buffers before formatting a move target. Document the return contract and extend the existing regression test for untouched zero-length buffers, null pointers, one-byte capacity, exact fits, and existing truncation behavior.

### Validation

Debian 12 arm64, GCC 12.2, native cFE/OSAL, EDS disabled:
- All 14 CF coverage targets passed: 318 cases and 2,349 assertions, repeated 10 times.
- The isolated move-target regression passed 23 assertions across 100 AddressSanitizer/UndefinedBehaviorSanitizer runs, with production source and test code instrumented.
- The zero-capacity regression failed against unchanged upstream code.
- Flight application build, clang-format 19 on changed lines, and `git diff --check` passed.

The broader CFDP sanitizer run stopped in unchanged `CF_CFDP_CopyStringFromLV` on a null source pointer. That separate issue is outside this patch; the sanitizer result above is limited to the move-target regression. Full mission/COSMOS, EDS-enabled and hardware testing were not run.

Valid-buffer behavior and public signatures are unchanged.

Contributor: Sylvester Kaczmarek, Personal. No third-party code added. Contributor License Agreement submission status is unverified.
